### PR TITLE
Exclude test directories from CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: "CodeQL config"
+
+paths-ignore:
+  - "**/__tests__/**"
+  - "**/test/**"
+  - "**/tests/**"
+  - "**/*.test.js"
+  - "**/*.spec.js"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 5 * * 1" # Monday 05:30 UTC
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- Add explicit CodeQL workflow (`.github/workflows/codeql.yml`) replacing default setup
- Add CodeQL config (`.github/codeql/codeql-config.yml`) with `paths-ignore` for test directories
- Excludes: `__tests__/`, `test/`, `tests/`, `*.test.js`, `*.spec.js`

This prevents false positive findings on test fixture code (e.g., Express route handlers in test apps flagged as "missing rate limiting").

## Test plan
- [ ] Verify CodeQL runs on PRs after merge
- [ ] Verify test files no longer produce false positive findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)