### PR TITLE
Fix deploy script reliability: auto occ upgrade and y-provider race

### DIFF
--- a/apps/deploy-docs.sh
+++ b/apps/deploy-docs.sh
@@ -189,6 +189,8 @@ cat "$REPO_ROOT/docs/health-sidecar-configmap.yaml" | sed "s/namespace: docs/nam
 envsubst '${YPROVIDER_MIN_REPLICAS}' < "$REPO_ROOT/docs/y-provider-deployment.yaml" | sed "s/namespace: docs/namespace: $NS_DOCS/g" | kubectl apply -f -
 cat "$REPO_ROOT/docs/y-provider-service.yaml" | sed "s/namespace: docs/namespace: $NS_DOCS/g" | kubectl apply -f -
 # Restart to ensure ConfigMap changes are picked up (wait in background, check later)
+# Brief pause to avoid "restart already triggered within past second" race with backend/frontend restart
+sleep 2
 kubectl -n "$NS_DOCS" rollout restart deploy/docs-y-provider
 kubectl -n "$NS_DOCS" rollout status deploy/docs-y-provider --timeout=300s &
 YPROVIDER_PID=$!

--- a/apps/deploy-nextcloud.sh
+++ b/apps/deploy-nextcloud.sh
@@ -384,6 +384,23 @@ if ! poll_pod_ready "$NS_FILES" "app.kubernetes.io/instance=nextcloud" 600 5; th
     exit 1
 fi
 
+# Step 7a: Run occ upgrade if Nextcloud requires it (e.g. image version bump)
+# When the container image is newer than the DB schema, Nextcloud blocks all occ
+# commands until `occ upgrade` runs. Detect this and handle it automatically.
+NEXTCLOUD_POD_UPGRADE=$(kubectl get pod -n "$NS_FILES" -l app.kubernetes.io/instance=nextcloud -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [ -n "$NEXTCLOUD_POD_UPGRADE" ]; then
+    UPGRADE_CHECK=$(kubectl exec -n "$NS_FILES" "$NEXTCLOUD_POD_UPGRADE" -c nextcloud -- su -s /bin/sh www-data -c 'php occ status --output=json' 2>&1 || true)
+    if echo "$UPGRADE_CHECK" | grep -q "require upgrade"; then
+        print_status "Nextcloud requires database upgrade (image version newer than DB schema)..."
+        if kubectl exec -n "$NS_FILES" "$NEXTCLOUD_POD_UPGRADE" -c nextcloud -- su -s /bin/sh www-data -c 'php occ upgrade' 2>&1; then
+            print_success "Nextcloud database upgrade completed"
+        else
+            print_error "Nextcloud occ upgrade failed"
+            exit 1
+        fi
+    fi
+fi
+
 # Step 7b: Extract/update identity secret from running pod
 # After first install: extract instanceid, passwordsalt, secret and create the identity secret.
 # On every deploy: update the version key to match the installed version.


### PR DESCRIPTION
## Summary

- **deploy-nextcloud.sh**: Auto-detect when Nextcloud requires a database schema upgrade after a container image bump and run `occ upgrade` automatically. Previously all occ commands would fail with "Nextcloud or one of the apps require upgrade" until manually run.
- **deploy-docs.sh**: Add 2-second pause before y-provider restart to avoid "restart already triggered within past second" race condition with the backend/frontend restarts that precede it.

## Test plan

- [x] Deployed to dev with `create_env` — Nextcloud upgrade detected and applied automatically
- [x] y-provider restart completes without race condition error
- [ ] Deploy to a fresh environment to verify no regressions

## OSS Compliance Review

No findings (CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0)

## Security Review

No security-relevant findings. Both changes are operational reliability improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)