### PR TITLE
Ignore non-LTS Node versions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,9 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      - dependency-name: "node"
+        versions: [">=23, <24", ">=25, <26"]
 
   # Docker: Account Portal
   - package-ecosystem: "docker"
@@ -71,6 +74,9 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      - dependency-name: "node"
+        versions: [">=23, <24", ">=25, <26"]
 
   # Docker: Roundcube
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Summary
- Skip Node 23.x and 25.x (odd-numbered, non-LTS releases) for portal Docker base image updates
- Node 22 is the current LTS; Node 25 introduced CJS/ESM interop changes that could break the portals
- Dependabot will still propose Node 24 and 26 when they become available

## OSS Compliance Review
No issues found. CI config change only — no domains, credentials, or tenant data.

## Security Review
No issues found. Actually improves security posture by keeping portals on LTS Node (longer security patch support).

## Test plan
- [ ] Verify Dependabot no longer opens PRs for Node 23/25 on next weekly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)