### PR TITLE
Ignore openid-client v6 and Node 24 in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+    ignore:
+      - dependency-name: "openid-client"
+        versions: [">=6"]
 
   # npm: Account Portal
   - package-ecosystem: "npm"
@@ -21,6 +24,9 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+    ignore:
+      - dependency-name: "openid-client"
+        versions: [">=6"]
 
   # Terraform: Phase 1 (cluster, VPN, TURN)
   - package-ecosystem: "terraform"
@@ -63,7 +69,7 @@ updates:
       - "docker"
     ignore:
       - dependency-name: "node"
-        versions: [">=23, <24", ">=25, <26"]
+        versions: [">=23, <24", ">=24, <25", ">=25, <26"]
 
   # Docker: Account Portal
   - package-ecosystem: "docker"
@@ -76,7 +82,7 @@ updates:
       - "docker"
     ignore:
       - dependency-name: "node"
-        versions: [">=23, <24", ">=25, <26"]
+        versions: [">=23, <24", ">=24, <25", ">=25, <26"]
 
   # Docker: Roundcube
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Summary
- Ignore `openid-client` v6+ in npm Dependabot for both portals — v6 is a complete API rewrite (no more `Issuer`/`Strategy` classes), requires significant rework
- Ignore Node 24 in Docker Dependabot for both portals — not yet LTS, CJS/ESM interop changes need testing
- Closed Dependabot PRs #61, #62, #63 with `@dependabot ignore this major version`

Tracking issues:
- #64 — Upgrade openid-client v5 → v6
- #65 — Upgrade Node 22 → 24

## OSS Compliance Review
No issues found. CI config change only — no domains, credentials, or tenant data.

## Security Review
No issues found. Pinning to LTS Node and known-working openid-client version is the safer posture.

## Test plan
- [ ] Verify Dependabot no longer opens PRs for openid-client v6 or Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)