### PR TITLE
Fix Roundcube search by upgrading Stalwart to v0.15.5

### DIFF
--- a/apps/manifests/stalwart/stalwart.yaml.tpl
+++ b/apps/manifests/stalwart/stalwart.yaml.tpl
@@ -300,7 +300,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: stalwart
-        image: stalwartlabs/stalwart:v0.15.3
+        image: stalwartlabs/stalwart:v0.15.5
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Summary

- Upgrades Stalwart mail server from v0.15.3 → v0.15.5 to fix broken search in Roundcube webmail
- Stalwart v0.15.3 doesn't map IMAP `HEADER SUBJECT/FROM/TO` search commands to proper FTS queries — Roundcube uses this exact format, so all searches return empty results
- v0.15.4 added the mapping ([changelog](https://github.com/stalwartlabs/stalwart/releases/tag/v0.15.4))
- v0.15.5 also includes a security fix for CVE-2026-26312 (OOM with cyclical MIME structures)

Closes #70

## Post-deploy: FTS reindex

After deploying, trigger a full-text search reindex so existing emails get indexed under the new engine. From within the cluster:

```bash
# Port-forward to Stalwart's HTTP API (port 8080)
kubectl -n tn-<tenant>-mail port-forward deploy/stalwart 8080:8080 &

# Trigger FTS reindex (uses the admin password from stalwart-secrets)
curl -u "admin:<STALWART_ADMIN_PASSWORD>" http://localhost:8080/api/store/reindex

# Kill the port-forward
kill %1
```

Or as a one-liner with the password pulled from the K8s secret:

```bash
STALWART_PW=$(kubectl -n tn-<tenant>-mail get secret stalwart-secrets -o jsonpath='{.data.STALWART_ADMIN_PASSWORD}' | base64 -d) && \
kubectl -n tn-<tenant>-mail port-forward deploy/stalwart 8080:8080 &
sleep 2 && \
curl -s -u "admin:${STALWART_PW}" http://localhost:8080/api/store/reindex && \
kill %1
```

## Test plan

- [ ] Deploy updated Stalwart to dev environment
- [ ] Trigger FTS reindex using the commands above
- [ ] Open Roundcube webmail and search for a known word in email subjects — verify results appear
- [ ] Search for a word in email body content — verify results appear
- [ ] Search for a sender email address — verify results appear

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0
No issues found. Single image tag change uses public Docker Hub registry.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0
No issues found. Pinned image tag confirmed to exist on Docker Hub. All secrets flow through K8s Secrets. Security context preserved (runAsNonRoot, drop ALL capabilities, seccomp RuntimeDefault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)