### PR TITLE
Fix Synapse OIDC login: use internal Keycloak URL for token exchange

### DIFF
--- a/apps/environments/dev/synapse.yaml.gotmpl
+++ b/apps/environments/dev/synapse.yaml.gotmpl
@@ -66,11 +66,20 @@ extraConfig:
   password_config:
     enabled: false
   # OIDC provider configuration for Keycloak (dev environment)
+  # Uses explicit endpoints instead of discover: true to avoid PROXY protocol issues.
+  # Browser-facing endpoint (authorization) uses the external URL; server-to-server
+  # endpoints (token, userinfo, jwks) use the internal K8s service URL (HTTP).
+  # skip_verification bypasses RFC 8414 HTTPS requirement for internal endpoints.
   oidc_providers:
     - idp_id: keycloak
       idp_name: "Sign in with MotherTree"
-      discover: true
+      discover: false
+      skip_verification: true
       issuer: 'https://{{ env "AUTH_HOST" }}/realms/{{ env "TENANT_KEYCLOAK_REALM" }}'
+      authorization_endpoint: 'https://{{ env "AUTH_HOST" }}/realms/{{ env "TENANT_KEYCLOAK_REALM" }}/protocol/openid-connect/auth'
+      token_endpoint: '{{ env "KEYCLOAK_INTERNAL_URL" }}/realms/{{ env "TENANT_KEYCLOAK_REALM" }}/protocol/openid-connect/token'
+      userinfo_endpoint: '{{ env "KEYCLOAK_INTERNAL_URL" }}/realms/{{ env "TENANT_KEYCLOAK_REALM" }}/protocol/openid-connect/userinfo'
+      jwks_uri: '{{ env "KEYCLOAK_INTERNAL_URL" }}/realms/{{ env "TENANT_KEYCLOAK_REALM" }}/protocol/openid-connect/certs'
       client_id: "matrix-synapse"
       client_secret: {{ env "SYNAPSE_OIDC_CLIENT_SECRET" | quote }}
       scopes: ["openid", "profile", "email"]

--- a/apps/environments/prod/synapse.yaml.gotmpl
+++ b/apps/environments/prod/synapse.yaml.gotmpl
@@ -55,11 +55,20 @@ extraConfig:
   password_config:
     enabled: false
   # OIDC provider configuration for Keycloak (prod environment)
+  # Uses explicit endpoints instead of discover: true to avoid PROXY protocol issues.
+  # Browser-facing endpoint (authorization) uses the external URL; server-to-server
+  # endpoints (token, userinfo, jwks) use the internal K8s service URL (HTTP).
+  # skip_verification bypasses RFC 8414 HTTPS requirement for internal endpoints.
   oidc_providers:
     - idp_id: keycloak
       idp_name: "Sign in with MotherTree"
-      discover: true
+      discover: false
+      skip_verification: true
       issuer: 'https://{{ env "AUTH_HOST" }}/realms/{{ env "TENANT_KEYCLOAK_REALM" }}'
+      authorization_endpoint: 'https://{{ env "AUTH_HOST" }}/realms/{{ env "TENANT_KEYCLOAK_REALM" }}/protocol/openid-connect/auth'
+      token_endpoint: '{{ env "KEYCLOAK_INTERNAL_URL" }}/realms/{{ env "TENANT_KEYCLOAK_REALM" }}/protocol/openid-connect/token'
+      userinfo_endpoint: '{{ env "KEYCLOAK_INTERNAL_URL" }}/realms/{{ env "TENANT_KEYCLOAK_REALM" }}/protocol/openid-connect/userinfo'
+      jwks_uri: '{{ env "KEYCLOAK_INTERNAL_URL" }}/realms/{{ env "TENANT_KEYCLOAK_REALM" }}/protocol/openid-connect/certs'
       client_id: "matrix-synapse"
       client_secret: {{ env "SYNAPSE_OIDC_CLIENT_SECRET" | quote }}
       scopes: ["openid", "profile", "email"]


### PR DESCRIPTION
## Summary

- Synapse OIDC token exchange was failing with HTTP 500 due to the PROXY protocol issue — same root cause previously fixed for admin-portal, account-portal, Roundcube, and Stalwart
- Switch from `discover: true` to explicit endpoints with split URLs: external HTTPS for browser-facing `authorization_endpoint`, internal K8s service URL for server-to-server `token_endpoint`/`userinfo_endpoint`/`jwks_uri`

Closes #74

## What was wrong

Synapse used `discover: true`, which auto-discovered all OIDC endpoints from Keycloak's external URL. When Synapse tried to exchange the auth code via the external `token_endpoint`, in-cluster traffic hit the ingress pod directly (via kube-proxy), which expects PROXY protocol headers from Cloudflare/NodeBalancer. Without them: ECONNRESET → HTTP 500 on `_synapse/client/oidc/callback`.

## How it's fixed

- `discover: false` + explicit OIDC endpoints
- `authorization_endpoint`: external HTTPS URL (browser-facing)
- `token_endpoint`, `userinfo_endpoint`, `jwks_uri`: internal K8s service URL (`KEYCLOAK_INTERNAL_URL`)
- `skip_verification: true`: bypasses RFC 8414 HTTPS requirement for internal HTTP endpoints
- `issuer`: remains external HTTPS (for ID token `iss` claim validation)

Applied to both dev and prod Synapse configs.

## Test plan

- [x] Deployed to dev, Synapse SSO login completes successfully
- [x] E2E Element smoke test passes 3/3 (5-7s each)
- [ ] Deploy to prod and verify SSO login

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — No issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 2 | **LOW**: 1

MEDIUM findings are about `skip_verification` and plaintext HTTP for in-cluster OIDC communication — this is the established architectural pattern already used by admin-portal, account-portal, Roundcube, and Stalwart. Traffic stays within K8s cluster boundaries, and the code documents the rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)