### PR TITLE
Restructure CI: separate E2E tests, build images on all branches

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,12 @@
 # Buildkite CI Pipeline for Mothertree
 #
 # Validation: runs on every push and PR
-# Image builds: runs on main branch only after validation passes
+# E2E browser tests: run in parallel — never block image builds
+# Image builds: runs on every build after validation passes
 
 steps:
   - group: ":mag: Validation"
+    key: "validation"
     steps:
       - label: ":bash: ShellCheck"
         command: ".buildkite/scripts/shellcheck.sh"
@@ -27,10 +29,13 @@ steps:
       - label: ":label: Version bump check"
         command: ".buildkite/scripts/version-check.sh"
 
-  - wait: ~
+  - group: ":playwright: E2E Browser Tests"
+    steps:
+      - label: ":playwright: Element smoke test"
+        command: ".buildkite/scripts/e2e-playwright.sh"
 
   - group: ":docker: Build Images"
-    if: build.branch == "main"
+    depends_on: "validation"
     steps:
       - label: ":docker: Admin Portal"
         command: ".buildkite/scripts/build-image.sh admin-portal"


### PR DESCRIPTION
## Summary

- **E2E browser tests** moved into their own parallel group — failures never block image builds
- **Image builds** now run on every push/PR (not just main) — catches build failures early
- Validation → Build Images dependency uses `depends_on` key instead of `wait`

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues found. Pipeline config contains only CI script paths and labels.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 4 | **LOW**: 3

No critical/high findings. Medium findings are all defense-in-depth suggestions from prior commits in this branch (e2e test infrastructure):
- Hardcoded test passwords for dedicated e2e dev accounts
- `execSync` string interpolation in test setup (CI-env-only risk)
- Rate limit env vars without bounds validation (operator-controlled)

None require action before merge. See full review in PR discussion.

## Test plan

- [ ] Verify Buildkite pipeline renders three parallel groups: Validation, E2E Browser Tests, Build Images
- [ ] Confirm Build Images runs after Validation passes (not after E2E)
- [ ] Confirm E2E test failure does not block Build Images
- [ ] Confirm image builds trigger on non-main branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)