### PR TITLE
Gitignore e2e generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,13 @@ override.tf.json
 .terraformrc
 terraform.rc
 
+# E2E test artifacts (Playwright)
+e2e/node_modules/
+e2e/.auth/
+e2e/.env
+e2e/playwright-report/
+e2e/test-results/
+
 # Performance test artifacts
 tf
 perf/users/**


### PR DESCRIPTION
## Summary
- Adds `.gitignore` entries for Playwright-generated artifacts in `e2e/`: `node_modules/`, `.auth/`, `.env`, `playwright-report/`, `test-results/`
- Prevents local test run output from showing up as untracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)