### PR TITLE
Fix Docs OIDC login: use internal Keycloak URL for token exchange

### DIFF
--- a/docs/docs-config.yaml.tpl
+++ b/docs/docs-config.yaml.tpl
@@ -85,11 +85,14 @@ data:
   DJANGO_SUPERUSER_PASSWORD: "${DJANGO_SUPERUSER_PASSWORD}"
   
   # OIDC settings for Keycloak (realm name is tenant-specific)
-  OIDC_OP_JWKS_ENDPOINT: "https://${AUTH_HOST}/realms/${TENANT_KEYCLOAK_REALM}/protocol/openid-connect/certs"
+  # Browser-facing endpoints use external AUTH_HOST (user's browser redirects here)
   OIDC_OP_AUTHORIZATION_ENDPOINT: "https://${AUTH_HOST}/realms/${TENANT_KEYCLOAK_REALM}/protocol/openid-connect/auth"
-  OIDC_OP_TOKEN_ENDPOINT: "https://${AUTH_HOST}/realms/${TENANT_KEYCLOAK_REALM}/protocol/openid-connect/token"
-  OIDC_OP_USER_ENDPOINT: "https://${AUTH_HOST}/realms/${TENANT_KEYCLOAK_REALM}/protocol/openid-connect/userinfo"
   OIDC_OP_LOGOUT_ENDPOINT: "https://${AUTH_HOST}/realms/${TENANT_KEYCLOAK_REALM}/protocol/openid-connect/logout"
+  # Server-side endpoints use internal Keycloak URL to avoid PROXY protocol issue
+  # (in-cluster traffic to external URL bypasses NodeBalancer → ECONNRESET)
+  OIDC_OP_TOKEN_ENDPOINT: "${KEYCLOAK_INTERNAL_URL}/realms/${TENANT_KEYCLOAK_REALM}/protocol/openid-connect/token"
+  OIDC_OP_USER_ENDPOINT: "${KEYCLOAK_INTERNAL_URL}/realms/${TENANT_KEYCLOAK_REALM}/protocol/openid-connect/userinfo"
+  OIDC_OP_JWKS_ENDPOINT: "${KEYCLOAK_INTERNAL_URL}/realms/${TENANT_KEYCLOAK_REALM}/protocol/openid-connect/certs"
   OIDC_RP_CLIENT_ID: "docs-app"
   OIDC_RP_SIGN_ALGO: "RS256"
   OIDC_RP_SCOPES: "openid email profile"

--- a/e2e/tests/smoke/docs.spec.ts
+++ b/e2e/tests/smoke/docs.spec.ts
@@ -35,19 +35,12 @@ test.describe('Smoke — Docs', () => {
     await page.waitForLoadState('networkidle').catch(() => {});
     await page.waitForTimeout(2_000);
 
-    // Check if the OIDC callback or server returned an error.
-    // Known issue: the Docs backend's OIDC token exchange can fail when the
-    // backend reaches Keycloak via the external URL (PROXY protocol issue —
-    // in-cluster traffic bypasses the NodeBalancer, causing ECONNRESET).
+    // After OIDC callback, verify no server errors on the page
     const pageText = await page.locator('body').textContent().catch(() => '') || '';
     const hasServerError = /Server Error|Internal Server Error|\b500\b|\b502\b|\b503\b/i.test(pageText);
     const hasOidcError = /OIDC|OpenID|token|callback.*error/i.test(pageText);
-    test.skip(
-      hasServerError || hasOidcError,
-      hasOidcError
-        ? 'Docs OIDC callback failed (likely PROXY protocol issue — backend cannot reach Keycloak)'
-        : 'Docs server returned an error — not a test issue',
-    );
+    expect(hasServerError, 'Docs returned a server error after OIDC callback').toBe(false);
+    expect(hasOidcError, 'Docs OIDC callback failed').toBe(false);
 
     // Verify we left the auth pages
     const hostname = new URL(page.url()).hostname;


### PR DESCRIPTION
## Summary

- Switch Docs backend server-side OIDC endpoints (token, userinfo, JWKS) from external `AUTH_HOST` to internal Keycloak service URL (`KEYCLOAK_INTERNAL_URL`) to fix ECONNRESET caused by PROXY protocol mismatch on in-cluster traffic
- Keep browser-facing endpoints (authorization, logout) on external URL since they're used for browser redirects
- Update E2E smoke test to assert on OIDC success instead of skipping on the known failure

Closes #86

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues found. All domains use variable substitution, no hardcoded credentials or tenant data.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 1 (acceptable) | **LOW**: 1 (pre-existing)

- **MEDIUM**: Server-side OIDC endpoints use HTTP for in-cluster traffic. This follows the established pattern used by Synapse, Roundcube, admin-portal, and account-portal — standard for trusted pod-to-pod networking.
- **LOW**: Pre-existing `DJANGO_SUPERUSER_PASSWORD` in ConfigMap (not introduced by this PR).

## Test plan

- [x] Deployed to dev (`deploy-docs.sh -e dev -t mothertree`) — ConfigMap verified with internal URLs
- [x] Backend pods healthy, no OIDC errors in logs
- [ ] CI E2E smoke test "SSO login loads Docs main page" passes (no longer skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)