### PR TITLE
Split E2E tests into 3 parallel shards

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,8 +7,20 @@
 steps:
   - group: ":playwright: E2E Browser Tests"
     steps:
-      - label: ":playwright: Smoke tests"
+      - label: ":playwright: E2E (1/3)"
         command: ".buildkite/scripts/e2e-playwright.sh"
+        env:
+          E2E_SHARD: "1/3"
+
+      - label: ":playwright: E2E (2/3)"
+        command: ".buildkite/scripts/e2e-playwright.sh"
+        env:
+          E2E_SHARD: "2/3"
+
+      - label: ":playwright: E2E (3/3)"
+        command: ".buildkite/scripts/e2e-playwright.sh"
+        env:
+          E2E_SHARD: "3/3"
 
   - group: ":mag: Validation"
     key: "validation"

--- a/.buildkite/scripts/e2e-playwright.sh
+++ b/.buildkite/scripts/e2e-playwright.sh
@@ -15,4 +15,11 @@ npm ci --ignore-scripts
 # System deps (libnss3, libatk, etc.) are pre-installed by Ansible.
 # Only download the Chromium browser binary here.
 npx playwright install chromium
-npx playwright test --project=ci
+
+SHARD_ARG=""
+if [[ -n "${E2E_SHARD:-}" ]]; then
+  SHARD_ARG="--shard=${E2E_SHARD}"
+  echo "Running shard ${E2E_SHARD}"
+fi
+
+npx playwright test --project=ci ${SHARD_ARG}


### PR DESCRIPTION
## Summary

- Splits the single E2E Playwright step into 3 parallel shards using `--shard=N/3`
- Each shard runs on a separate Buildkite agent, leveraging all 3 available workers
- New test files are automatically distributed across shards — no test can be forgotten

**Files changed:** `.buildkite/pipeline.yml`, `.buildkite/scripts/e2e-playwright.sh`

## How it works

Playwright's built-in `--shard` flag distributes test files evenly across N shards. With 17 spec files and 3 shards, each shard gets ~6 files. The `E2E_SHARD` env var is optional — omitting it runs all tests (backward compatible for local runs).

## OSS Compliance Review

No findings. CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0

## Security Review

No blocking findings. CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0

One minor shell hygiene note (MEDIUM): unquoted `${SHARD_ARG}` expansion — intentional so that an empty value doesn't pass an empty arg to Playwright. The value is hardcoded in pipeline YAML, not user-controlled.

## Test plan

- [ ] Verify Buildkite shows 3 parallel E2E steps
- [ ] Confirm each shard runs a subset of tests (check "Running shard X/3" in logs)
- [ ] Confirm all 17 spec files are covered across the 3 shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)