### PR TITLE
Upgrade Jitsi Meet from stable-10710 to stable-10741

### DIFF
--- a/apps/manifests/jitsi/jicofo.yaml.tpl
+++ b/apps/manifests/jitsi/jicofo.yaml.tpl
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: jicofo
-        image: jitsi/jicofo:stable-10710
+        image: jitsi/jicofo:stable-10741
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/apps/manifests/jitsi/jvb.yaml.tpl
+++ b/apps/manifests/jitsi/jvb.yaml.tpl
@@ -126,7 +126,7 @@ spec:
           mountPath: /shared
       containers:
       - name: jvb
-        image: jitsi/jvb:stable-10710
+        image: jitsi/jvb:stable-10741
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/apps/manifests/jitsi/prosody.yaml.tpl
+++ b/apps/manifests/jitsi/prosody.yaml.tpl
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: prosody
-        image: jitsi/prosody:stable-10710
+        image: jitsi/prosody:stable-10741
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/apps/manifests/jitsi/web.yaml.tpl
+++ b/apps/manifests/jitsi/web.yaml.tpl
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: web
-        image: jitsi/web:stable-10710
+        image: jitsi/web:stable-10741
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Summary

- Upgrades all four Jitsi components (web, prosody, jicofo, jvb) from `stable-10710` to `stable-10741`
- All image tags verified on Docker Hub before updating

Closes #67

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues found. All domain references use template variables, all secrets use `secretKeyRef`, no private registry references, no personal info or tenant data exposed.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No security issues found. Straightforward image tag bump with no configuration, network, or permission changes. All secrets remain in K8s secret refs. Image tags are pinned (not floating). No new attack surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)