### PR TITLE
Restrict Woodpecker CI login to org members

### DIFF
--- a/ci/ansible/templates/woodpecker-server.env.j2
+++ b/ci/ansible/templates/woodpecker-server.env.j2
@@ -3,6 +3,7 @@
 
 WOODPECKER_HOST={{ woodpecker_host }}
 WOODPECKER_OPEN=false
+WOODPECKER_ORGS=mothertree-labs
 WOODPECKER_ADMIN={{ woodpecker_admin }}
 WOODPECKER_AGENT_SECRET={{ woodpecker_agent_secret }}
 WOODPECKER_GITHUB=true


### PR DESCRIPTION
## Summary

- Add `WOODPECKER_ORGS=mothertree-labs` to the Woodpecker server env template to restrict CI login to members of the `mothertree-labs` GitHub organization
- Prevents arbitrary GitHub users from authenticating via OAuth

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No issues. `mothertree-labs` is the public GitHub org that owns this repo.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No issues. This is a security hardening change adding defense-in-depth on top of `WOODPECKER_OPEN=false`.

## Test plan

- [ ] Re-run Ansible playbook with vars file to deploy the updated env
- [ ] Verify org member can still log in
- [ ] Verify non-org GitHub user is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)