### PR TITLE
Add mothertree-build gate pipeline

### DIFF
--- a/.woodpecker/mothertree-build.yaml
+++ b/.woodpecker/mothertree-build.yaml
@@ -17,6 +17,8 @@ when:
   - event: push
     branch: main
 
+skip_clone: true
+
 steps:
   - name: complete
     image: bash


### PR DESCRIPTION
## Summary

- Adds a single `mothertree-build` gate pipeline that depends on all 12 other pipelines (validate, build-images, e2e-shard-1 through 10)
- Enables setting one required status check in GitHub branch protection instead of listing each pipeline individually
- Only succeeds when every dependency pipeline succeeds

## Test plan

- [ ] Verify the `mothertree-build` status check appears on a PR after merging
- [ ] Set `mothertree-build` as the sole required check in repo settings > branch protection rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)