### PR TITLE
Fix Docs Redis OOMKill with memory limits and eviction

### DIFF
--- a/docs/redis-deployment.yaml
+++ b/docs/redis-deployment.yaml
@@ -24,11 +24,19 @@ spec:
       containers:
         - image: redis:8
           name: redis
+          command: ["redis-server"]
+          args:
+            - "--maxmemory"
+            - "896mb"
+            - "--maxmemory-policy"
+            - "allkeys-lru"
+            - "--save"
+            - ""
           resources:
             requests:
               cpu: 10m
-              memory: 64Mi
+              memory: 128Mi
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 1024Mi
       restartPolicy: Always


### PR DESCRIPTION
## Summary

- Fix Docs Redis OOMKill by configuring `maxmemory 896mb` with `allkeys-lru` eviction policy
- Disable RDB persistence (`--save ""`) — sessions are ephemeral and recreated via OIDC
- Increase container memory limit from 128Mi to 1024Mi (request from 64Mi to 128Mi)

## Root cause

The Docs Redis stored 810K+ Django session keys (30-day TTL) with no `maxmemory` or eviction policy. BGSAVE `fork()` doubled memory usage every ~5 minutes, pushing past the 128Mi container limit. Both `tn-mothertree-docs` (OOMKilled) and `tn-innba-docs` (at 97% capacity) were affected.

A live hotfix has already been applied to both tenants via `kubectl set resources` and `redis-cli CONFIG SET`.

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — Clean, no issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 1 (pre-existing) | **MEDIUM**: 2 (pre-existing) | **LOW**: 4 (pre-existing)

The HIGH finding is that Docs Redis lacks `--requirepass` authentication, unlike Nextcloud and Admin Portal Redis. This is a **pre-existing gap not introduced by this change** — tracked in #100 for follow-up.

## Test plan

- [x] Verified live hotfix on both prod tenants (`tn-mothertree-docs`, `tn-innba-docs`)
- [x] Confirmed `maxmemory`, `maxmemory-policy`, and `save` config applied correctly via `redis-cli CONFIG GET`
- [ ] Deploy via `deploy-docs.sh` to verify manifest applies cleanly


🤖 Generated with [Claude Code](https://claude.com/claude-code)