### PR TITLE
Add total build time reporting to gate pipeline

### DIFF
--- a/.woodpecker/mothertree-build.yaml
+++ b/.woodpecker/mothertree-build.yaml
@@ -23,12 +23,4 @@ steps:
   - name: complete
     image: bash
     commands:
-      - elapsed=$(( $(date +%s) - CI_PIPELINE_CREATED ))
-      - minutes=$((elapsed / 60))
-      - seconds=$((elapsed % 60))
-      - echo ""
-      - echo "====================================="
-      - echo "  All checks passed!"
-      - 'echo "  Total build time: ${minutes}m ${seconds}s"'
-      - echo "====================================="
-      - echo ""
+      - 'elapsed=$(( $(date +%s) - CI_PIPELINE_CREATED )); echo ""; echo "====================================="; echo "  All checks passed!"; echo "  Total build time: $((elapsed / 60))m $((elapsed % 60))s"; echo "====================================="; echo ""'


### PR DESCRIPTION
## Summary

- Use `CI_PIPELINE_CREATED` in the mothertree-build gate step to calculate and display total wall-clock build duration
- Makes it easy to see how long the full CI pipeline took by clicking into the gate step

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues found. Changes are safe to merge.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No security issues in the new changes. One pre-existing MEDIUM noted (unpinned `bash` image tag) — not introduced by this PR.

## Test plan

- [ ] Verify the gate step logs show the build time after a full pipeline run
- [ ] Confirm `CI_PIPELINE_CREATED` is correctly provided by Woodpecker

🤖 Generated with [Claude Code](https://claude.com/claude-code)