### PR TITLE
Fix Jitsi SSO login and add E2E test for full OIDC flow

### DIFF
--- a/apps/manifests/jitsi/keycloak-adapter.yaml.tpl
+++ b/apps/manifests/jitsi/keycloak-adapter.yaml.tpl
@@ -38,6 +38,11 @@ spec:
         env:
         - name: KEYCLOAK_ORIGIN
           value: "https://${AUTH_HOST}"
+        # Internal URL for server-to-server calls (code→token exchange).
+        # Bypasses the external ingress which requires PROXY protocol headers
+        # that in-cluster pods don't send, causing ECONNRESET.
+        - name: KEYCLOAK_ORIGIN_INTERNAL
+          value: "http://keycloak-keycloakx-http.infra-auth.svc.cluster.local"
         - name: KEYCLOAK_REALM
           value: "${TENANT_KEYCLOAK_REALM}"
         - name: KEYCLOAK_CLIENT_ID

--- a/e2e/tests/smoke/jitsi.spec.ts
+++ b/e2e/tests/smoke/jitsi.spec.ts
@@ -1,5 +1,7 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/authenticated';
 import { urls } from '../../helpers/urls';
+import { TEST_USERS } from '../../helpers/test-users';
+import { keycloakLogin } from '../../helpers/auth';
 
 test.describe('Smoke — Jitsi (Video)', () => {
   test('Jitsi application loads', async ({ page }) => {
@@ -53,5 +55,65 @@ test.describe('Smoke — Jitsi (Video)', () => {
 
     // Either we landed on Keycloak or we're in the OIDC flow
     expect(hasAuth || hasOidc).toBe(true);
+  });
+
+  test('SSO login loads Jitsi room', async ({ memberPage: page }) => {
+    const roomUrl = `${urls.jitsi}/e2e-auth-test`;
+    const response = await page.goto(roomUrl).catch(() => null);
+
+    if (!response) {
+      test.skip(true, 'Jitsi not reachable (DNS or connection error)');
+    }
+
+    const status = response!.status();
+    test.skip(status >= 500, `Jitsi returned server error ${status}`);
+
+    // The OIDC redirect chain:
+    //   nginx serves oidc-redirect.html (JS) → /oidc/redirect (adapter 302) →
+    //   Keycloak (auto-login or form) → /static/oidc-adapter.html (JS) →
+    //   /oidc/tokenize (adapter returns JWT) → /room?oidc=authorized&jwt=...
+    //
+    // If the memberPage SSO session is valid, Keycloak auto-redirects (no form).
+    // Wait for the final room URL with oidc= param. If the chain stalls on
+    // Keycloak (session expired), catch the timeout and complete login manually.
+    try {
+      await page.waitForURL(
+        url => url.searchParams.has('oidc'),
+        { timeout: 30_000 },
+      );
+    } catch {
+      // Chain stalled — if we're on Keycloak, complete login and retry
+      if (page.url().includes('auth.')) {
+        await keycloakLogin(page, TEST_USERS.member.username, TEST_USERS.member.password);
+        await page.waitForURL(
+          url => url.searchParams.has('oidc'),
+          { timeout: 30_000 },
+        );
+      } else {
+        throw new Error(
+          `Jitsi OIDC flow did not complete. Current URL: ${page.url()}`,
+        );
+      }
+    }
+
+    const finalUrl = new URL(page.url());
+
+    // Verify we're on the Jitsi domain (not stuck on auth)
+    expect(finalUrl.hostname).not.toContain('auth.');
+
+    // Verify the OIDC flow succeeded (not "failed" or "unauthorized")
+    expect(finalUrl.searchParams.get('oidc')).toBe('authorized');
+
+    // Verify a JWT token was provided
+    expect(finalUrl.searchParams.get('jwt')).toBeTruthy();
+
+    // Wait for the Jitsi room UI to render
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(3_000);
+
+    // Check for server errors
+    const pageText = await page.locator('body').textContent().catch(() => '') || '';
+    const hasServerError = /Server Error|Internal Server Error|\b500\b|\b502\b|\b503\b/i.test(pageText);
+    expect(hasServerError, 'Jitsi returned a server error after SSO login').toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **Fix**: The Jitsi keycloak-adapter's token exchange (`/oidc/tokenize`) was failing with ECONNRESET because it called Keycloak via the external URL, which routes through the PROXY-protocol-enabled ingress. In-cluster pods don't send PROXY protocol headers. Set `KEYCLOAK_ORIGIN_INTERNAL` to the internal Keycloak service URL to bypass the external ingress for server-to-server calls.
- **Test**: Added an E2E test ("SSO login loads Jitsi room") that exercises the full OIDC→JWT login flow — navigates to a Jitsi room with a pre-authenticated Keycloak session, follows the redirect chain, and verifies `oidc=authorized` with a valid JWT token.

## Test plan

- [x] New E2E test confirmed the bug (`oidc=failed` before fix)
- [x] After fix, new test passes (`oidc=authorized` with JWT)
- [x] All 3 Jitsi smoke tests pass (app loads, OIDC redirect, SSO login)
- [ ] CI pipeline validates on push

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues. All URLs use `example.com` defaults or internal K8s DNS names. No credentials, real domains, or personal info in changes.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 2 (accepted patterns) | **LOW**: 2

- MEDIUM: Internal Keycloak URL uses plain HTTP — consistent with 5+ other components in the codebase (admin-portal, account-portal, stalwart, synapse). In-cluster traffic only.
- MEDIUM: E2E test credentials hardcoded in test helpers — pre-existing, synthetic dev-only accounts (`e2e-testpass-*`), created/destroyed per test run.
- LOW: Verify adapter supports `KEYCLOAK_ORIGIN_INTERNAL` — confirmed via adapter logs and upstream source.
- LOW: JWT may appear in CI logs on test failure — short-lived dev E2E token, standard test risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)