### PR TITLE
Add E2E email round-trip test and Stalwart principal creation in dev-test-users

### DIFF
--- a/.woodpecker/e2e-shard-1.yaml
+++ b/.woodpecker/e2e-shard-1.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: e2e_base_domain
       E2E_TENANT:
         from_secret: e2e_tenant
+      E2E_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_echo_group_address
       CI: "true"
     commands:
       - ci/scripts/e2e-playwright.sh

--- a/.woodpecker/e2e-shard-10.yaml
+++ b/.woodpecker/e2e-shard-10.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: e2e_base_domain
       E2E_TENANT:
         from_secret: e2e_tenant
+      E2E_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_echo_group_address
       CI: "true"
     commands:
       - ci/scripts/e2e-playwright.sh

--- a/.woodpecker/e2e-shard-2.yaml
+++ b/.woodpecker/e2e-shard-2.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: e2e_base_domain
       E2E_TENANT:
         from_secret: e2e_tenant
+      E2E_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_echo_group_address
       CI: "true"
     commands:
       - ci/scripts/e2e-playwright.sh

--- a/.woodpecker/e2e-shard-3.yaml
+++ b/.woodpecker/e2e-shard-3.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: e2e_base_domain
       E2E_TENANT:
         from_secret: e2e_tenant
+      E2E_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_echo_group_address
       CI: "true"
     commands:
       - ci/scripts/e2e-playwright.sh

--- a/.woodpecker/e2e-shard-4.yaml
+++ b/.woodpecker/e2e-shard-4.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: e2e_base_domain
       E2E_TENANT:
         from_secret: e2e_tenant
+      E2E_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_echo_group_address
       CI: "true"
     commands:
       - ci/scripts/e2e-playwright.sh

--- a/.woodpecker/e2e-shard-5.yaml
+++ b/.woodpecker/e2e-shard-5.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: e2e_base_domain
       E2E_TENANT:
         from_secret: e2e_tenant
+      E2E_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_echo_group_address
       CI: "true"
     commands:
       - ci/scripts/e2e-playwright.sh

--- a/.woodpecker/e2e-shard-6.yaml
+++ b/.woodpecker/e2e-shard-6.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: e2e_base_domain
       E2E_TENANT:
         from_secret: e2e_tenant
+      E2E_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_echo_group_address
       CI: "true"
     commands:
       - ci/scripts/e2e-playwright.sh

--- a/.woodpecker/e2e-shard-7.yaml
+++ b/.woodpecker/e2e-shard-7.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: e2e_base_domain
       E2E_TENANT:
         from_secret: e2e_tenant
+      E2E_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_echo_group_address
       CI: "true"
     commands:
       - ci/scripts/e2e-playwright.sh

--- a/.woodpecker/e2e-shard-8.yaml
+++ b/.woodpecker/e2e-shard-8.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: e2e_base_domain
       E2E_TENANT:
         from_secret: e2e_tenant
+      E2E_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_echo_group_address
       CI: "true"
     commands:
       - ci/scripts/e2e-playwright.sh

--- a/.woodpecker/e2e-shard-9.yaml
+++ b/.woodpecker/e2e-shard-9.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: e2e_base_domain
       E2E_TENANT:
         from_secret: e2e_tenant
+      E2E_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_echo_group_address
       CI: "true"
     commands:
       - ci/scripts/e2e-playwright.sh

--- a/e2e/e2e.config.json
+++ b/e2e/e2e.config.json
@@ -1,4 +1,5 @@
 {
   "echoGroupAddress": "",
-  "emailTestUser": "e2e-email-test1"
+  "emailSendUser": "e2e-mailrt",
+  "emailRecvUser": "e2e-mailrcv"
 }

--- a/e2e/fixtures/authenticated.ts
+++ b/e2e/fixtures/authenticated.ts
@@ -13,6 +13,7 @@ type AuthFixtures = {
   adminPage: Page;
   memberPage: Page;
   emailTestPage: Page;
+  emailRecvPage: Page;
 };
 
 /**
@@ -42,6 +43,11 @@ const ROLE_PORTAL: Record<keyof typeof TEST_USERS, {
     validationSelector: 'h1:has-text("Welcome,")',
   },
   emailTest: {
+    loginUrl: `${urls.accountPortal}/auth/login`,
+    validationUrl: `${urls.accountPortal}/home`,
+    validationSelector: 'h1:has-text("Welcome,")',
+  },
+  emailRecv: {
     loginUrl: `${urls.accountPortal}/auth/login`,
     validationUrl: `${urls.accountPortal}/home`,
     validationSelector: 'h1:has-text("Welcome,")',
@@ -193,6 +199,12 @@ export const test = base.extend<AuthFixtures>({
 
   emailTestPage: async ({ context }, use) => {
     const page = await getAuthenticatedPage(context, 'emailTest');
+    await use(page);
+    await page.context().close();
+  },
+
+  emailRecvPage: async ({ context }, use) => {
+    const page = await getAuthenticatedPage(context, 'emailRecv');
     await use(page);
     await page.context().close();
   },

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -16,7 +16,8 @@ interface TestUser {
 const TEST_USERS: TestUser[] = [
   { username: 'e2e-admin', password: 'e2e-testpass-admin', admin: true },
   { username: 'e2e-member', password: 'e2e-testpass-member' },
-  { username: 'e2e-email-test1', password: 'e2e-testpass-email' },
+  { username: 'e2e-mailrt', password: 'e2e-testpass-mailrt' },
+  { username: 'e2e-mailrcv', password: 'e2e-testpass-mailrcv' },
 ];
 
 function run(cmd: string): string {

--- a/e2e/helpers/test-users.ts
+++ b/e2e/helpers/test-users.ts
@@ -17,9 +17,15 @@ export const TEST_USERS = {
     email: `e2e-member@${baseDomain}`,
   },
   emailTest: {
-    username: 'e2e-email-test1',
-    password: 'e2e-testpass-email',
-    email: `e2e-email-test1@${baseDomain}`,
+    username: 'e2e-mailrt',
+    password: 'e2e-testpass-mailrt',
+    email: `e2e-mailrt@${baseDomain}`,
+  },
+  /** Receiver for email round-trip test — member of the echo group. */
+  emailRecv: {
+    username: 'e2e-mailrcv',
+    password: 'e2e-testpass-mailrcv',
+    email: `e2e-mailrcv@${baseDomain}`,
   },
 } as const;
 

--- a/e2e/tests/email/email-roundtrip.spec.ts
+++ b/e2e/tests/email/email-roundtrip.spec.ts
@@ -11,73 +11,97 @@ const config = fs.existsSync(configPath)
   ? JSON.parse(fs.readFileSync(configPath, 'utf-8'))
   : {};
 
-const echoGroupAddress = config.echoGroupAddress;
+const echoGroupAddress = process.env.E2E_ECHO_GROUP_ADDRESS || config.echoGroupAddress;
+
+/**
+ * Helper: log into Roundcube via OIDC for the given page/user.
+ * Triggers the OIDC flow directly, handles Keycloak login if no SSO session.
+ */
+async function roundcubeLogin(page: import('@playwright/test').Page, username: string, password: string) {
+  await page.goto(`${urls.webmail}/?_task=login&_action=oauth`);
+  await page.waitForLoadState('networkidle');
+
+  // Check hostname (not full URL) — the OIDC callback URL contains 'auth.' in
+  // query params (iss=https://auth.../realms/...) which would false-positive.
+  const onKeycloak = new URL(page.url()).hostname.startsWith('auth.');
+  if (onKeycloak) {
+    await keycloakLogin(page, username, password);
+    await page.waitForLoadState('networkidle');
+  }
+
+  await page.waitForSelector('#messagelist, #mailboxlist, .mailbox-list', { timeout: 30_000 });
+}
 
 test.describe('Email — Round-Trip via Echo Group', () => {
   test.skip(!echoGroupAddress, 'Skipped: echoGroupAddress not configured in e2e.config.json');
 
-  test('send email to echo group and receive bounce-back', async ({ emailTestPage: page }) => {
-    const user = TEST_USERS.emailTest;
+  // This test verifies the full email path: outbound (Roundcube → Stalwart → Postfix → internet)
+  // and inbound (internet → Postfix → Stalwart → inbox). It sends from one user (e2e-mailrt)
+  // to an external echo group, which forwards to a different user (e2e-mailrcv) who is a
+  // member of the group. Using two users avoids Stalwart's duplicate message detection
+  // (same Message-ID in sender's Sent folder vs. the forwarded copy).
+  test('send email to echo group and verify delivery to group member', async ({
+    emailTestPage: senderPage,
+    emailRecvPage: receiverPage,
+  }) => {
+    test.setTimeout(40_000); // Email round-trip through external echo group needs extra time
 
-    // Navigate to Roundcube
-    await page.goto(urls.webmail);
-    await page.waitForLoadState('networkidle');
+    const sender = TEST_USERS.emailTest;
+    const receiver = TEST_USERS.emailRecv;
 
-    if (page.url().includes('auth.')) {
-      await keycloakLogin(page, user.username, user.password);
-      await page.waitForLoadState('networkidle');
-    }
+    // ── Step 1: Sender logs into Roundcube and sends email to the echo group ──
+    await roundcubeLogin(senderPage, sender.username, sender.password);
 
-    // Wait for Roundcube inbox to load
-    await page.waitForSelector('#messagelist, #mailboxlist, .mailbox-list', { timeout: 30_000 });
+    await senderPage.getByRole('button', { name: 'Compose' }).click();
+    const subjectInput = senderPage.getByRole('textbox', { name: 'Subject' });
+    await subjectInput.waitFor({ timeout: 15_000 });
 
-    // Click compose
-    await page.locator('a.compose, [data-command="compose"], .button.compose').first().click();
-    await page.waitForSelector('input[name="_to"], #compose-to', { timeout: 15_000 });
+    const toInput = senderPage.locator('.recipient-input input').first();
+    await toInput.click();
+    await toInput.pressSequentially(echoGroupAddress);
+    await toInput.press('Enter');
 
-    // Fill compose form
     const subject = `E2E Round-Trip Test ${Date.now()}`;
-    await page.locator('input[name="_to"], #compose-to').first().fill(echoGroupAddress);
-    await page.locator('input[name="_subject"], #compose-subject').first().fill(subject);
+    await subjectInput.fill(subject);
 
-    // Type message body in the editor
-    const bodyFrame = page.frameLocator('iframe[name="composebody"], iframe.mce-edit-area');
-    const bodyInput = page.locator('textarea[name="_message"], #composebody');
-    if (await bodyInput.isVisible()) {
-      await bodyInput.fill('E2E round-trip test message');
-    } else {
-      await bodyFrame.locator('body').fill('E2E round-trip test message');
-    }
+    const bodyFrame = senderPage.frameLocator('iframe').first();
+    await bodyFrame.locator('body').fill('E2E round-trip test message');
 
-    // Send the email
-    await page.locator('a.send, [data-command="send"], .button.send').first().click();
+    await senderPage.getByRole('button', { name: 'Send' }).click();
 
-    // Wait for send confirmation and return to inbox
-    await page.waitForSelector('#messagelist, #mailboxlist, .mailbox-list', { timeout: 30_000 });
+    // Wait for send to complete (returns to inbox)
+    await senderPage.waitForSelector('#messagelist, #mailboxlist, .mailbox-list', { timeout: 30_000 });
 
-    // Poll inbox for the echo response (up to 2 minutes)
+    // ── Step 2: Receiver logs into Roundcube and polls for the forwarded email ──
+    await roundcubeLogin(receiverPage, receiver.username, receiver.password);
+
     const maxWait = 120_000;
     const pollInterval = 5_000;
     let found = false;
     const start = Date.now();
 
     while (Date.now() - start < maxWait) {
-      // Refresh the inbox
-      await page.locator('a.refresh, [data-command="checkmail"], .button.refresh').first().click();
-      await page.waitForTimeout(2000);
+      // Refresh inbox
+      const refreshed = await receiverPage.getByRole('button', { name: /refresh|check/i }).first()
+        .click({ timeout: 3000 }).then(() => true).catch(() => false);
+      if (!refreshed) {
+        await receiverPage.reload();
+        await receiverPage.waitForSelector('#messagelist, #mailboxlist, .mailbox-list', { timeout: 15_000 });
+      }
+      await receiverPage.waitForTimeout(2000);
 
-      // Check if the echoed email appears in the message list
-      const messageList = page.locator('#messagelist');
-      const hasSubject = await messageList.locator(`text=${subject}`).isVisible().catch(() => false);
+      // Check if the email appears in the message list
+      const hasSubject = await receiverPage.locator(`td:has-text("${subject}")`).first()
+        .isVisible().catch(() => false);
 
       if (hasSubject) {
         found = true;
         break;
       }
 
-      await page.waitForTimeout(pollInterval);
+      await receiverPage.waitForTimeout(pollInterval);
     }
 
-    expect(found).toBe(true);
+    expect(found, `Expected email with subject "${subject}" to appear in receiver's inbox within ${maxWait / 1000}s`).toBe(true);
   });
 });

--- a/modules/openvpn-server/user-data.yaml
+++ b/modules/openvpn-server/user-data.yaml
@@ -350,6 +350,13 @@ runcmd:
   - ufw allow from ${vpn_network_cidr} to any port 80
   - ufw allow from ${vpn_network_cidr} to any port 443
   - ufw allow from ${vpn_network_cidr} to any port 53
+  # SMTP relay - K8s cluster nodes and VPN clients send outbound mail here
+  - ufw allow from 10.0.0.0/8 to any port 25 proto tcp
+  - ufw allow from 172.16.0.0/12 to any port 25 proto tcp
+  - ufw allow from 192.168.0.0/16 to any port 25 proto tcp
+  - ufw allow 25/tcp
+  # SOCKS5 proxy for Blackbox Exporter probes
+  - ufw allow from 192.168.0.0/16 to any port 1080 proto tcp
   - echo 'net.ipv4.ip_forward=1' >> /etc/sysctl.conf
   - sysctl -p
   # Add FORWARD rules for VPN traffic (must be before iptables-save)

--- a/scripts/dev-test-users.sh
+++ b/scripts/dev-test-users.sh
@@ -133,7 +133,9 @@ REALM="$TENANT_KEYCLOAK_REALM"
 
 cleanup() {
     kill $PF_PID 2>/dev/null || true
+    kill $STALWART_PF_PID 2>/dev/null || true
 }
+STALWART_PF_PID=""
 trap cleanup EXIT
 
 # Get admin credentials
@@ -191,6 +193,80 @@ assign_role() {
 }
 
 # ============================================================================
+# Helper: ensure Stalwart mail principal exists for a user
+# Uses /api/principal/deploy (works with OIDC directory mode).
+# ============================================================================
+ensure_stalwart_principal() {
+    local email="$1"
+    local display_name="${2:-$email}"
+
+    if [ -z "${STALWART_ADMIN_PASSWORD:-}" ]; then
+        print_warning "STALWART_ADMIN_PASSWORD not set — skipping Stalwart principal creation"
+        return 0
+    fi
+
+    # Start port-forward to Stalwart if not already running
+    if [ -z "$STALWART_PF_PID" ] || ! kill -0 "$STALWART_PF_PID" 2>/dev/null; then
+        print_status "Setting up port-forward to Stalwart service..."
+        kubectl -n "$NS_STALWART" port-forward svc/stalwart 8090:8080 > /tmp/stalwart-pf.log 2>&1 &
+        STALWART_PF_PID=$!
+        sleep 3
+    fi
+
+    local stalwart_url="http://localhost:8090"
+    local admin_auth
+    admin_auth="Basic $(printf 'admin:%s' "$STALWART_ADMIN_PASSWORD" | base64)"
+
+    # Use username (without domain) as the principal name to match what Stalwart's
+    # OIDC auto-provisioner creates (uses preferred_username from the token).
+    local principal_name="${email%%@*}"
+
+    # Check if principal already exists (by username, not full email)
+    local check_body
+    check_body=$(curl -s "$stalwart_url/api/principal/$principal_name" \
+      -H "Authorization: $admin_auth")
+
+    if echo "$check_body" | jq -e '.error' > /dev/null 2>&1; then
+        # Principal doesn't exist (error = "notFound") or other error — try to create
+        :
+    else
+        print_status "Stalwart principal already exists for $principal_name"
+        return 0
+    fi
+
+    # Create principal via /api/principal/deploy
+    local deploy_body
+    deploy_body=$(jq -n \
+      --arg name "$principal_name" \
+      --arg email "$email" \
+      --arg desc "$display_name" \
+      '{type: "individual", name: $name, emails: [$email], description: $desc, secrets: []}')
+
+    local response
+    response=$(curl -s -X POST "$stalwart_url/api/principal/deploy" \
+      -H "Authorization: $admin_auth" \
+      -H "Content-Type: application/json" \
+      -d "$deploy_body")
+
+    local error
+    error=$(echo "$response" | jq -r '.error // empty')
+    if [ -n "$error" ]; then
+        if [ "$error" = "fieldAlreadyExists" ]; then
+            print_status "Stalwart principal already exists for $email"
+            return 0
+        fi
+        print_warning "Stalwart principal creation returned: $error"
+        return 0
+    fi
+
+    # Reload config so RCPT TO picks up the new principal immediately
+    curl -s -X GET "$stalwart_url/api/reload" \
+      -H "Authorization: $admin_auth" > /dev/null 2>&1
+
+    print_success "Created Stalwart mail principal for $email"
+}
+
+# ============================================================================
 # Commands
 # ============================================================================
 
@@ -212,6 +288,8 @@ cmd_create() {
     if [ -n "$EXISTING" ]; then
         print_warning "User '$USERNAME' already exists (ID: $EXISTING)"
         print_status "Use 'reset-password' to change their password"
+        # Still ensure Stalwart principal exists (may be missing for pre-existing users)
+        ensure_stalwart_principal "$email" "$USERNAME Test"
         return 0
     fi
 
@@ -277,6 +355,9 @@ USERJSON
     if $ADMIN_FLAG; then
         assign_role "$USER_ID" "tenant-admin"
     fi
+
+    # Create Stalwart mail principal so the user can receive email immediately
+    ensure_stalwart_principal "$email" "$USERNAME Test"
 
     echo ""
     print_success "Test user ready!"


### PR DESCRIPTION
## Summary

- Add two-user E2E email round-trip test that verifies the full outbound+inbound email path through an external echo group
- Add Stalwart mail principal creation to `dev-test-users.sh` so test users can receive email immediately
- Add VPN UFW rules for SMTP relay and SOCKS5 proxy
- Wire `E2E_ECHO_GROUP_ADDRESS` Woodpecker secret into all E2E shard pipelines

## Details

**Email round-trip test** (`e2e/tests/email/email-roundtrip.spec.ts`):
- Sender (`e2e-mailrt`) logs into Roundcube via OIDC, composes and sends to an external Google Groups echo address
- Receiver (`e2e-mailrcv`), a member of the echo group, logs into Roundcube and polls inbox for the forwarded copy
- Two users avoid Stalwart's duplicate message detection (same Message-ID in sender's Sent folder vs. the forwarded copy)
- Roundcube OIDC login checks hostname (not full URL) to avoid false-positive from `iss` query parameter

**Stalwart principal creation** (`scripts/dev-test-users.sh`):
- New `ensure_stalwart_principal()` function creates mail principals via `/api/principal/deploy`
- Uses username (not email) as the principal `name` field, matching what Stalwart's OIDC auto-provisioner creates from `preferred_username`
- Called both for new users and pre-existing users (handles `fieldAlreadyExists` gracefully)
- Reloads Stalwart config after creation so SMTP RCPT TO picks up the new mailbox immediately

## Test plan

- [x] Full round-trip test passes locally (25.5s) — email sent, forwarded by echo group, received by different user
- [x] Both users authenticate via Roundcube OIDC successfully
- [x] Stalwart principal creation works for new and existing users
- [ ] Woodpecker secret `e2e_echo_group_address` configured on CI server
- [ ] E2E test passes in CI pipeline

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — No issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 2

- UFW `allow 25/tcp` opens port 25 publicly — intentional for inbound MX delivery to VPN Postfix
- Test user passwords are hardcoded `e2e-testpass-*` — follows existing pattern, ephemeral dev users only

🤖 Generated with [Claude Code](https://claude.com/claude-code)