### PR TITLE
Enable test-level sharding for even E2E distribution

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,7 +8,7 @@ const baseDomain = process.env.E2E_BASE_DOMAIN || 'dev.example.com';
 
 export default defineConfig({
   testDir: './tests',
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: 1,


### PR DESCRIPTION
## Summary

- Switches `fullyParallel` from `false` to `true` in `e2e/playwright.config.ts`
- Playwright now distributes individual tests across shards instead of whole files, preventing clustering (e.g. Nextcloud tests always landing in shards 9-10)
- Workers remain at 1 — tests still run sequentially within each shard, only the shard assignment algorithm changes

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 1 (pre-existing, unrelated) | **MEDIUM**: 2 (pre-existing) | **LOW**: 2 (pre-existing)

The HIGH finding is a pre-existing `ufw allow 25/tcp` rule in `modules/openvpn-server/user-data.yaml` that opens SMTP port 25 to the internet — not introduced or modified by this PR. All other findings are also pre-existing.

## Test plan

- [ ] Verify CI pipeline passes — all 10 shards should still run successfully
- [ ] Compare shard test counts before/after to confirm more even distribution
- [ ] Spot-check that tests with no `beforeAll` hooks (all of ours) work correctly when split across shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)