### PR TITLE
Separate CI and local E2E test users

### DIFF
--- a/e2e/e2e.config.json
+++ b/e2e/e2e.config.json
@@ -1,5 +1,3 @@
 {
-  "echoGroupAddress": "",
-  "emailSendUser": "e2e-mailrt",
-  "emailRecvUser": "e2e-mailrcv"
+  "echoGroupAddress": ""
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,23 +1,19 @@
 import { execSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
+import { TEST_USERS } from './helpers/test-users';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const SCRIPT = path.join(REPO_ROOT, 'scripts', 'dev-test-users.sh');
 const TENANT = process.env.E2E_TENANT || 'example';
 const IS_CI = !!process.env.CI;
 
-interface TestUser {
-  username: string;
-  password: string;
-  admin?: boolean;
-}
-
-const TEST_USERS: TestUser[] = [
-  { username: 'e2e-admin', password: 'e2e-testpass-admin', admin: true },
-  { username: 'e2e-member', password: 'e2e-testpass-member' },
-  { username: 'e2e-mailrt', password: 'e2e-testpass-mailrt' },
-  { username: 'e2e-mailrcv', password: 'e2e-testpass-mailrcv' },
+/** Local users to create/reset during setup (derived from TEST_USERS). */
+const LOCAL_USERS = [
+  { username: TEST_USERS.admin.username, password: TEST_USERS.admin.password, admin: true },
+  { username: TEST_USERS.member.username, password: TEST_USERS.member.password },
+  { username: TEST_USERS.emailTest.username, password: TEST_USERS.emailTest.password },
+  { username: TEST_USERS.emailRecv.username, password: TEST_USERS.emailRecv.password },
 ];
 
 function run(cmd: string): string {
@@ -75,7 +71,7 @@ export default async function globalSetup(): Promise<void> {
   // only deletes users this run created — not permanent CI users.
   const createdUsers: string[] = [];
 
-  for (const user of TEST_USERS) {
+  for (const user of LOCAL_USERS) {
     const adminFlag = user.admin ? ' --admin' : '';
     try {
       run(

--- a/e2e/helpers/test-users.ts
+++ b/e2e/helpers/test-users.ts
@@ -1,31 +1,37 @@
 /**
  * Test user credentials for E2E tests.
- * These users are created/deleted by global-setup/teardown via dev-test-users.sh.
+ *
+ * CI and local runs use DIFFERENT users to avoid conflicts:
+ * - CI: e2e-admin, e2e-member, e2e-mailrt, e2e-mailrcv (permanent, never deleted)
+ * - Local: e2e-local-admin, e2e-local-member, e2e-local-mailrt, e2e-local-mailrcv (transient, created/deleted per run)
+ *
+ * Passwords are the same for both — only the username prefix differs.
  */
 
 const baseDomain = process.env.E2E_BASE_DOMAIN || 'dev.example.com';
+const prefix = process.env.CI ? 'e2e' : 'e2e-local';
 
 export const TEST_USERS = {
   admin: {
-    username: 'e2e-admin',
+    username: `${prefix}-admin`,
     password: 'e2e-testpass-admin',
-    email: `e2e-admin@${baseDomain}`,
+    email: `${prefix}-admin@${baseDomain}`,
   },
   member: {
-    username: 'e2e-member',
+    username: `${prefix}-member`,
     password: 'e2e-testpass-member',
-    email: `e2e-member@${baseDomain}`,
+    email: `${prefix}-member@${baseDomain}`,
   },
   emailTest: {
-    username: 'e2e-mailrt',
+    username: `${prefix}-mailrt`,
     password: 'e2e-testpass-mailrt',
-    email: `e2e-mailrt@${baseDomain}`,
+    email: `${prefix}-mailrt@${baseDomain}`,
   },
   /** Receiver for email round-trip test — member of the echo group. */
   emailRecv: {
-    username: 'e2e-mailrcv',
+    username: `${prefix}-mailrcv`,
     password: 'e2e-testpass-mailrcv',
-    email: `e2e-mailrcv@${baseDomain}`,
+    email: `${prefix}-mailrcv@${baseDomain}`,
   },
 } as const;
 

--- a/e2e/tests/account-portal/login.spec.ts
+++ b/e2e/tests/account-portal/login.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../../fixtures/authenticated';
 import { urls } from '../../helpers/urls';
 import { selectors } from '../../helpers/selectors';
+import { TEST_USERS } from '../../helpers/test-users';
 
 test.describe('Account Portal — Login', () => {
   test('redirects to home after login and shows welcome message', async ({ memberPage: page }) => {
@@ -11,7 +12,7 @@ test.describe('Account Portal — Login', () => {
 
   test('shows user email on home page', async ({ memberPage: page }) => {
     const emailText = await page.locator('p.text-warm-gray').first().textContent();
-    expect(emailText).toContain('e2e-member');
+    expect(emailText).toContain(TEST_USERS.member.username);
   });
 
   test('sign out redirects to login page', async ({ memberPage: page }) => {

--- a/e2e/tests/admin-portal/dashboard.spec.ts
+++ b/e2e/tests/admin-portal/dashboard.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../fixtures/authenticated';
 import { selectors } from '../../helpers/selectors';
+import { TEST_USERS } from '../../helpers/test-users';
 
 test.describe('Admin Portal — Dashboard', () => {
   // The adminPage fixture already authenticates and navigates to admin portal.
@@ -11,8 +12,8 @@ test.describe('Admin Portal — Dashboard', () => {
     // Wait for the members list to load (replaces "Loading members...")
     await expect(page.locator(ap.membersList)).not.toContainText('Loading members...', { timeout: 10_000 });
 
-    // Should contain at least the e2e-admin user
-    await expect(page.locator(ap.membersList)).toContainText('e2e-admin');
+    // Should contain at least the admin test user
+    await expect(page.locator(ap.membersList)).toContainText(TEST_USERS.admin.username);
   });
 
   test('shows guests section', async ({ adminPage: page }) => {

--- a/e2e/tests/admin-portal/invite-user.spec.ts
+++ b/e2e/tests/admin-portal/invite-user.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../fixtures/authenticated';
 import { selectors } from '../../helpers/selectors';
+import { TEST_USERS } from '../../helpers/test-users';
 
 test.describe('Admin Portal — Invite User', () => {
   // The adminPage fixture already authenticates and navigates to admin portal.
@@ -52,7 +53,7 @@ test.describe('Admin Portal — Invite User', () => {
     // Try to invite with an existing username
     await page.fill(ap.firstNameInput, 'Duplicate');
     await page.fill(ap.lastNameInput, 'Test');
-    await page.fill(ap.emailUsernameInput, 'e2e-admin');
+    await page.fill(ap.emailUsernameInput, TEST_USERS.admin.username);
     await page.fill(ap.recoveryEmailInput, 'dup@example.com');
 
     await page.click(ap.inviteSubmitBtn);


### PR DESCRIPTION
## Summary

- CI and local E2E runs now use **different users** to prevent local teardown from deleting CI's permanent test users
- CI uses `e2e-*` prefix (permanent, never deleted), local uses `e2e-local-*` prefix (transient, created/deleted per run)
- The prefix is determined by the `CI` env var — no new CI secrets needed
- Replaced hardcoded usernames in test specs with `TEST_USERS.*` references
- Removed unused `emailSendUser`/`emailRecvUser` fields from `e2e.config.json`

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — No issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 2 (pre-existing) | **LOW**: 1

Both MEDIUM findings are pre-existing patterns not introduced by this PR:
- Hardcoded test passwords in source (acceptable — dev-only, `dev-test-users.sh` refuses to run outside dev)
- Shell command construction via string interpolation in `global-setup.ts` (values are constants, not user input)

## Test plan

- [ ] CI E2E tests pass (users `e2e-admin`, `e2e-member`, `e2e-mailrt`, `e2e-mailrcv` are pre-provisioned)
- [ ] Local E2E run creates `e2e-local-*` users and cleans them up on teardown
- [ ] Local teardown no longer deletes `e2e-*` CI users

🤖 Generated with [Claude Code](https://claude.com/claude-code)