### PR TITLE
Handle timeout when OIDC endpoint hangs during Nextcloud login

### DIFF
--- a/e2e/tests/smoke/nextcloud.spec.ts
+++ b/e2e/tests/smoke/nextcloud.spec.ts
@@ -26,7 +26,14 @@ async function handleNextcloudLogin(page: Page): Promise<void> {
   if (onNativeLogin) {
     // Trigger OIDC flow — navigate to the user_oidc login endpoint,
     // which redirects to Keycloak. The existing SSO session should auto-complete.
-    await page.goto(`${urls.files}/apps/user_oidc/login/1`);
+    // Use a timeout since this can hang when Nextcloud can't reach Keycloak.
+    const oidcResponse = await page.goto(`${urls.files}/apps/user_oidc/login/1`, { timeout: 30_000 }).catch(() => null);
+
+    if (!oidcResponse) {
+      // OIDC endpoint timed out — Nextcloud can't reach Keycloak, nothing we can do
+      return;
+    }
+
     await page.waitForLoadState('networkidle').catch(() => {});
 
     // If Keycloak session expired, we'll land on the Keycloak login page


### PR DESCRIPTION
## Summary

- Follow-up to #115: the `handleNextcloudLogin()` helper's `page.goto` to `/apps/user_oidc/login/1` can hang when Nextcloud can't reach Keycloak, causing a hard `TimeoutError` that crashes the test
- Wrap the navigation in a `.catch()` and return early if it times out, so downstream assertions can report the actual issue (server error, missing content) instead of an opaque navigation timeout

## Test plan

- [ ] CI E2E shard containing `nextcloud.spec.ts` passes (or fails with a meaningful assertion, not a navigation timeout)

## OSS Compliance Review

No issues found. Test file only, no domains/credentials/private references.

## Security Review

No issues found. Purely test-layer error handling with no security implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)