### PR TITLE
Persist OIDC-only login across Nextcloud pod restarts

### DIFF
--- a/apps/deploy-nextcloud.sh
+++ b/apps/deploy-nextcloud.sh
@@ -359,6 +359,20 @@ else
 fi
 rm -rf "$CUSTOM_APPS_STAGING"
 
+# Step 5b: Create before-starting hook ConfigMap
+# This hook runs on every pod start to enforce OIDC-only login.
+# Because /var/www/html is an emptyDir, pod restarts trigger a fresh Nextcloud
+# install which resets user_oidc allow_multiple_user_backends to its default (1).
+# The hook sets it back to 0, preventing the native login form from appearing.
+HOOK_SCRIPT="$REPO_ROOT/apps/manifests/nextcloud/before-starting-hook.sh"
+if [ -f "$HOOK_SCRIPT" ]; then
+    kubectl create configmap nextcloud-before-starting \
+        --namespace "$NS_FILES" \
+        --from-file=enforce-oidc-login.sh="$HOOK_SCRIPT" \
+        --dry-run=client -o yaml | kubectl apply -f -
+    print_status "before-starting hook ConfigMap created/updated"
+fi
+
 # Step 6: Deploy Nextcloud via helmfile
 print_status "Deploying Nextcloud via helmfile..."
 pushd "$REPO_ROOT/apps" >/dev/null

--- a/apps/manifests/nextcloud/before-starting-hook.sh
+++ b/apps/manifests/nextcloud/before-starting-hook.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Nextcloud before-starting hook
+# Runs on every pod start AFTER Nextcloud initialization but BEFORE Apache launches.
+#
+# Because /var/www/html is an emptyDir, every pod restart triggers a fresh
+# Nextcloud install from the image. The user_oidc app re-initializes with its
+# default allow_multiple_user_backends=1, which shows the native login form
+# instead of auto-redirecting to Keycloak. This hook enforces OIDC-only login.
+
+set -e
+
+echo "[before-starting] Enforcing OIDC-only login (allow_multiple_user_backends=0)..."
+php /var/www/html/occ config:app:set --type=string --value=0 user_oidc allow_multiple_user_backends 2>/dev/null || {
+    echo "[before-starting] Warning: could not set allow_multiple_user_backends (user_oidc may not be installed yet)"
+}
+
+echo "[before-starting] Done"

--- a/apps/values/nextcloud.yaml
+++ b/apps/values/nextcloud.yaml
@@ -206,12 +206,19 @@ nextcloud:
       configMap:
         name: nextcloud-appstore-urls
         optional: true
+    - name: before-starting-hook
+      configMap:
+        name: nextcloud-before-starting
+        defaultMode: 0755
+        optional: true
 
   # Mount pandoc binary in Nextcloud container
   extraVolumeMounts:
     - name: pandoc-bin
       mountPath: /usr/local/bin/pandoc
       subPath: pandoc
+    - name: before-starting-hook
+      mountPath: /docker-entrypoint-hooks.d/before-starting
 
 # Ingress will be configured in environment-specific files
 ingress:

--- a/e2e/tests/smoke/nextcloud.spec.ts
+++ b/e2e/tests/smoke/nextcloud.spec.ts
@@ -5,10 +5,10 @@ import { keycloakLogin } from '../../helpers/auth';
 import { Page } from '@playwright/test';
 
 /**
- * Handle Nextcloud login — covers both Keycloak redirect and Nextcloud's
- * native login page. Sometimes the OIDC auto-redirect fails and Nextcloud
- * shows its own login form instead. When that happens, trigger the OIDC
- * flow manually by navigating to the user_oidc login endpoint.
+ * Handle Nextcloud login — completes the Keycloak OIDC flow when redirected.
+ * This should ONLY need to handle the Keycloak redirect case. If Nextcloud
+ * shows its native login page, that's a configuration bug (allow_multiple_user_backends=1)
+ * and the dedicated 'login redirects to Keycloak' test will catch it.
  */
 async function handleNextcloudLogin(page: Page): Promise<void> {
   if (page.url().includes('auth.')) {
@@ -108,6 +108,84 @@ test.describe('Smoke — Nextcloud (Files)', () => {
       const htmlLength = (await page.content()).length;
       expect(htmlLength).toBeGreaterThan(1000);
     }
+  });
+
+  test('login redirects to Keycloak, not native login form', async ({ memberPage: page }) => {
+    // Use a fresh browser context without any existing session cookies.
+    // This simulates an unauthenticated user visiting Nextcloud for the first time.
+    const freshContext = await page.context().browser()!.newContext({ ignoreHTTPSErrors: true });
+    const freshPage = await freshContext.newPage();
+
+    const response = await freshPage.goto(`${urls.files}/login`).catch(() => null);
+
+    if (!response) {
+      await freshPage.close();
+      await freshContext.close();
+      test.skip(true, 'Nextcloud not reachable (DNS or connection error)');
+      return; // unreachable but satisfies TS
+    }
+
+    // Follow redirects and check where we end up
+    await freshPage.waitForLoadState('networkidle').catch(() => {});
+    const finalUrl = freshPage.url();
+
+    // The native Nextcloud login page has a visible password field.
+    // If allow_multiple_user_backends=0 (correct), /login auto-redirects to
+    // /apps/user_oidc/login/1 which then redirects to Keycloak (auth.*).
+    // If allow_multiple_user_backends=1 (broken), /login shows the native form.
+    const hasPasswordField = await freshPage
+      .locator('input[name="password"], #password')
+      .isVisible({ timeout: 3_000 })
+      .catch(() => false);
+
+    const onNativeLogin = !finalUrl.includes('user_oidc') &&
+      !finalUrl.includes('auth.') &&
+      hasPasswordField;
+
+    await freshPage.close();
+    await freshContext.close();
+
+    expect(
+      onNativeLogin,
+      'Nextcloud is showing its native login page instead of redirecting to Keycloak. ' +
+      'This means allow_multiple_user_backends is set to 1 (should be 0). ' +
+      'Fix: run "php occ config:app:set --value=0 user_oidc allow_multiple_user_backends" ' +
+      'or redeploy Nextcloud to trigger the before-starting hook.'
+    ).toBe(false);
+  });
+
+  test('calendar app responds (pretty URLs working)', async ({ memberPage: page }) => {
+    // Test that /apps/calendar doesn't return a raw Apache 404.
+    // This catches missing .htaccess pretty URL rewrite rules
+    // (occ maintenance:update:htaccess not run, or overwrite.cli.url not set).
+    const freshContext = await page.context().browser()!.newContext({ ignoreHTTPSErrors: true });
+    const freshPage = await freshContext.newPage();
+
+    const response = await freshPage.goto(`${urls.files}/apps/calendar`).catch(() => null);
+
+    if (!response) {
+      await freshPage.close();
+      await freshContext.close();
+      test.skip(true, 'Nextcloud not reachable (DNS or connection error)');
+      return;
+    }
+
+    const status = response.status();
+    const bodyText = await freshPage.locator('body').textContent().catch(() => '') || '';
+    await freshPage.close();
+    await freshContext.close();
+
+    // A raw Apache 404 (not PHP) indicates broken .htaccess rewrite rules.
+    // Valid responses: 302 (redirect to login/OIDC), 401 (unauthorized), 200 (loaded).
+    // Invalid: 404 with Apache error page text.
+    const isApache404 = status === 404 &&
+      /Apache.*Server|The requested URL was not found/i.test(bodyText);
+
+    expect(
+      isApache404,
+      'Nextcloud /apps/calendar returns Apache 404 — .htaccess pretty URL rewrite rules are missing. ' +
+      'Fix: run "php occ maintenance:update:htaccess" (requires overwrite.cli.url to be set).'
+    ).toBe(false);
   });
 
   test('can upload a file when Nextcloud is accessible', async ({ memberPage: page }) => {


### PR DESCRIPTION
## Summary

- **Root cause**: Nextcloud uses an emptyDir for `/var/www/html`, so every pod restart triggers a fresh install from the image. The `user_oidc` app re-initializes with `allow_multiple_user_backends=1` (default), which shows the native login form instead of auto-redirecting to Keycloak. The OIDC config job is a one-shot Job that doesn't re-run on restarts.
- **Fix**: Add a `before-starting` hook (runs on every pod start, after Nextcloud init but before Apache) that enforces `allow_multiple_user_backends=0`
- **E2E tests**: Two new smoke tests catch regressions — one verifies `/login` redirects to Keycloak (not native form), one verifies `/apps/calendar` returns a PHP response (not Apache 404 from missing `.htaccess` rewrite rules)

## Changes

- `apps/manifests/nextcloud/before-starting-hook.sh` — New startup hook script
- `apps/deploy-nextcloud.sh` — Creates ConfigMap from the hook script during deploy
- `apps/values/nextcloud.yaml` — Mounts hook at `/docker-entrypoint-hooks.d/before-starting/`
- `e2e/tests/smoke/nextcloud.spec.ts` — Two new smoke tests + updated comment on `handleNextcloudLogin`

## Test plan

- [ ] Verify `npx playwright test --list tests/smoke/nextcloud.spec.ts` shows 5 tests (3 existing + 2 new)
- [ ] Deploy to dev and verify Nextcloud redirects to Keycloak on `/login`
- [ ] Delete the Nextcloud pod, wait for restart, verify OIDC-only login persists
- [ ] Run E2E smoke tests against dev to verify both new tests pass

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues found. No real domains, credentials, personal info, or private registry references.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 1

The change improves security posture by ensuring OIDC-only authentication survives pod restarts. One LOW finding: the ConfigMap has `optional: true` which allows silent degradation if the ConfigMap is missing — acceptable tradeoff to prevent pod startup failures, and the new E2E test catches this in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)