### PR TITLE
Fix guest bridge ECONNRESET by using internal service URL

### DIFF
--- a/apps/deploy-network-policies.sh
+++ b/apps/deploy-network-policies.sh
@@ -211,6 +211,18 @@ else
 fi
 
 # =============================================================================
+# Apply files-to-admin egress (Nextcloud guest_bridge → Account Portal API on port 3000)
+# =============================================================================
+if kubectl get namespace "$NS_FILES" &>/dev/null && kubectl get namespace "$NS_ADMIN" &>/dev/null; then
+    export NAMESPACE="$NS_FILES"
+    print_status "[$NS_FILES] Applying allow-files-to-admin-egress (guest_bridge → Account Portal port 3000)..."
+    envsubst '${NAMESPACE} ${TENANT_NAME}' < "$MANIFEST_DIR/allow-files-to-admin-egress.yaml.tpl" | kubectl apply -f -
+    print_success "[$NS_FILES] Files-to-admin egress policy applied"
+else
+    print_warning "Files or admin namespace does not exist, skipping files-to-admin egress policy"
+fi
+
+# =============================================================================
 # Apply Redis protection to admin namespace
 # =============================================================================
 if kubectl get namespace "$NS_ADMIN" &>/dev/null; then
@@ -256,6 +268,7 @@ print_status "  - allow-webmail-to-mail-egress  (webmail → mail: IMAP/SMTP/Sie
 print_status "  - allow-admin-to-mail-egress    (admin → mail: Stalwart HTTP API)"
 print_status "  - allow-mail-to-files-egress    (mail → files: CalDAV port 8080)"
 print_status "  - allow-files-to-office-egress  (files → office: Collabora port 9980)"
+print_status "  - allow-files-to-admin-egress   (files → admin: Account Portal API port 3000)"
 print_status "  - allow-mail-ingress            (mail: accept from Postfix + Roundcube + Admin)"
 print_status "Targeted ingress restrictions:"
 print_status "  - protect-redis              (admin namespace: only portal pods)"

--- a/apps/deploy-nextcloud.sh
+++ b/apps/deploy-nextcloud.sh
@@ -761,8 +761,8 @@ if [ -d "$REPO_ROOT/apps/nextcloud-guest-bridge" ]; then
         kubectl exec -n "$NS_FILES" "$NEXTCLOUD_POD" -- su -s /bin/sh www-data -c "php occ app:enable guest_bridge" 2>/dev/null || true
 
         # Configure guest_bridge API settings
-        # ACCOUNT_HOST comes from config.sh (e.g., account.dev.example.com)
-        GUEST_BRIDGE_API_URL="https://${ACCOUNT_HOST}/api/provision-guest"
+        # Use internal K8s service URL to avoid PROXY protocol issues on external ingress
+        GUEST_BRIDGE_API_URL="http://account-portal.${NS_ADMIN}.svc.cluster.local/api/provision-guest"
         kubectl exec -n "$NS_FILES" "$NEXTCLOUD_POD" -- su -s /bin/sh www-data -c "php occ config:system:set guest_bridge.api_url --value='$GUEST_BRIDGE_API_URL'"
 
         # Get the guest provisioning API key from the account portal secret
@@ -770,6 +770,19 @@ if [ -d "$REPO_ROOT/apps/nextcloud-guest-bridge" ]; then
         if [ -n "$GUEST_API_KEY" ]; then
             kubectl exec -n "$NS_FILES" "$NEXTCLOUD_POD" -- su -s /bin/sh www-data -c "php occ config:system:set guest_bridge.api_key --value='$GUEST_API_KEY'"
             print_success "guest_bridge app enabled and configured (API: $GUEST_BRIDGE_API_URL)"
+
+            # Verify guest bridge can reach account portal internally
+            print_status "Verifying guest_bridge connectivity to account portal..."
+            HEALTH_CHECK=$(kubectl exec -n "$NS_FILES" "$NEXTCLOUD_POD" -- \
+                curl -sf -o /dev/null -w "%{http_code}" \
+                --connect-timeout 5 --max-time 10 \
+                "http://account-portal.${NS_ADMIN}.svc.cluster.local/health" 2>/dev/null || echo "000")
+            if [ "$HEALTH_CHECK" = "200" ]; then
+                print_success "guest_bridge → account portal connectivity verified"
+            else
+                print_warning "guest_bridge cannot reach account portal (HTTP $HEALTH_CHECK)"
+                print_warning "Guest provisioning may fail — check network policies and account-portal deployment"
+            fi
         else
             print_warning "Guest provisioning API key not found in account-portal-secrets"
             print_warning "guest_bridge app enabled but will not provision guests until API key is configured"

--- a/apps/manifests/network-policies/allow-files-to-admin-egress.yaml.tpl
+++ b/apps/manifests/network-policies/allow-files-to-admin-egress.yaml.tpl
@@ -1,0 +1,33 @@
+# Allow Files → Admin Egress (Guest Bridge → Account Portal API)
+# Applied to tn-<tenant>-files namespace only.
+# Permits Nextcloud pods to reach the Account Portal in tn-<tenant>-admin
+# on port 3000 for guest user provisioning via the guest_bridge app.
+# Note: Calico evaluates egress after DNAT, so we use the pod port (3000)
+# not the Service port (80).
+#
+# Required environment variables:
+#   NAMESPACE   - Source namespace (e.g., tn-example-files)
+#   TENANT_NAME - Tenant name (e.g., example)
+#
+# Applied to files namespace only by deploy-network-policies.sh
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-files-to-admin-egress
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: network-policies
+    policy-type: allow-files-admin
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tn-${TENANT_NAME}-admin
+      ports:
+        - protocol: TCP
+          port: 3000


### PR DESCRIPTION
## Summary

- Switch guest_bridge API URL from external hostname (`https://${ACCOUNT_HOST}`) to internal K8s service (`http://account-portal.${NS_ADMIN}.svc.cluster.local`) to avoid PROXY protocol ECONNRESET
- Add `allow-files-to-admin-egress` NetworkPolicy (port 3000, post-DNAT for Calico) enabling cross-namespace traffic from Nextcloud to account-portal
- Add deploy-time connectivity health check verifying guest_bridge can reach the account portal

Closes #118

## Verification

- [x] Shell lint (`bash -n`) passes on both modified scripts
- [x] Network policy deployed to dev (`allow-files-to-admin-egress created`)
- [x] Nextcloud config updated with internal URL
- [x] Health check from Nextcloud pod → account portal `/health` returns `{"status":"ok"}`
- [x] Provision endpoint reachable (HTTP 401 without API key — correct)
- [x] End-to-end test: shared folder with external email, Nextcloud log confirms `Guest bridge: guest provisioned for michel+share2@bablooka.com`, account-portal log confirms `Created guest user` with matching timestamp and userId

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues found. All changes use environment variable substitution (`${NS_ADMIN}`, `${TENANT_NAME}`), no real domains, credentials, or personal info.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 2 | **LOW**: 2

- **MEDIUM**: Internal HTTP (vs HTTPS) for in-cluster service call — standard K8s pattern, API key in header is mitigated by NetworkPolicy scoping
- **MEDIUM**: Comment/code port mismatch — fixed before commit
- **LOW**: Broad `podSelector: {}` — consistent with all other cross-namespace egress policies
- **LOW**: Health check doesn't verify auth end-to-end — deployment validation gap, not security issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)