### PR TITLE
Fix Nextcloud 503 on HPA scale-up

### DIFF
--- a/apps/manifests/nextcloud/before-starting-hook.sh
+++ b/apps/manifests/nextcloud/before-starting-hook.sh
@@ -9,6 +9,16 @@
 
 set -e
 
+# Run occ upgrade to reconcile app version mismatches between the filesystem
+# and database. This is critical for HPA scale-up: the custom-apps ConfigMap
+# may contain an older app version than what was auto-updated on the first pod.
+# Without this, Nextcloud returns 503 ("Update needed") because needUpgrade()
+# detects the mismatch. Safe to run when nothing needs upgrading (no-op).
+echo "[before-starting] Running occ upgrade (reconcile app versions)..."
+php /var/www/html/occ upgrade --no-interaction 2>/dev/null || {
+    echo "[before-starting] Warning: occ upgrade returned non-zero (may be first install)"
+}
+
 echo "[before-starting] Enforcing OIDC-only login (allow_multiple_user_backends=0)..."
 php /var/www/html/occ config:app:set --type=string --value=0 user_oidc allow_multiple_user_backends 2>/dev/null || {
     echo "[before-starting] Warning: could not set allow_multiple_user_backends (user_oidc may not be installed yet)"

--- a/e2e/tests/smoke/nextcloud-health.spec.ts
+++ b/e2e/tests/smoke/nextcloud-health.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { urls } from '../../helpers/urls';
+
+test.describe('Smoke — Nextcloud Health', () => {
+  test('status.php reports no maintenance or upgrade needed', async ({ request }) => {
+    // status.php is the canonical health endpoint — returns JSON with
+    // maintenance mode and DB upgrade flags. Critically, status.php bypasses
+    // the upgrade check, so it returns 200 even when Nextcloud is serving 503
+    // on ALL other endpoints. This test catches the root cause of the
+    // "Update needed — use the command line updater" 503 page that can occur
+    // after HPA scale-up or image upgrades.
+    const response = await request.get(`${urls.files}/status.php`);
+
+    if (response.status() === 0 || !response.ok()) {
+      test.skip(true, `Nextcloud not reachable (HTTP ${response.status()})`);
+    }
+
+    const status = await response.json();
+
+    expect(status.installed, 'Nextcloud should report as installed').toBe(true);
+
+    expect(status.maintenance,
+      'Nextcloud is in maintenance mode — all requests return 503. ' +
+      'Fix: kubectl exec into the Nextcloud pod and run "php occ maintenance:mode --off"'
+    ).toBe(false);
+
+    expect(status.needsDbUpgrade,
+      'Nextcloud needs a database upgrade — all requests return 503 with ' +
+      '"Update needed — Please use the command line updater". This happens when new pods ' +
+      'start with a newer Nextcloud version before the DB schema is migrated. ' +
+      'Fix: kubectl exec into the Nextcloud pod and run "php occ upgrade"'
+    ).toBe(false);
+  });
+
+  test('Nextcloud root does not return 503', async ({ request }) => {
+    // Hit the root URL directly. When Nextcloud is in "update needed" or
+    // maintenance mode, it returns 503 instead of the normal 302-to-OIDC
+    // redirect. This catches the symptom that users see in their browser.
+    //
+    // We use maxRedirects: 0 to check the raw Nextcloud response before
+    // any OIDC redirect chain.
+    const response = await request.get(urls.files, { maxRedirects: 0 });
+    const status = response.status();
+
+    if (status === 0) {
+      test.skip(true, 'Nextcloud not reachable (DNS or connection error)');
+    }
+
+    expect(
+      status,
+      `Nextcloud root returned HTTP ${status}. ` +
+      (status === 503
+        ? 'This is the "Update needed" or maintenance mode page. ' +
+          'Fix: kubectl exec into the Nextcloud pod and run "php occ upgrade" ' +
+          'or "php occ maintenance:mode --off"'
+        : `Expected 200 or 302 (OIDC redirect), got ${status}`)
+    ).not.toBe(503);
+  });
+});


### PR DESCRIPTION
## Summary

- When HPA scales up new Nextcloud pods, the custom-apps ConfigMap may have an older app version than what was auto-updated on the original pod (e.g. `files_linkeditor` 1.1.23 on disk vs 1.1.24 in DB). Nextcloud's `needUpgrade()` detects the mismatch and returns **503 on all requests** — while `status.php` keeps returning 200, so readiness probes pass and the broken pod stays in the Service.
- **Fix**: Run `occ upgrade --no-interaction` in the before-starting hook on every pod start. Reconciles app version mismatches. No-op when nothing needs upgrading.
- **E2E test**: New `nextcloud-health.spec.ts` catches this by checking `status.php` JSON flags and verifying the root URL doesn't return 503.

## Root cause

1. First pod installs `files_linkeditor` 1.1.23 from ConfigMap, then Nextcloud auto-updates it to 1.1.24 (DB records 1.1.24)
2. HPA scales up → new pods extract 1.1.23 from the same ConfigMap
3. `OC_App::shouldUpgrade("files_linkeditor")` returns true (DB 1.1.24 ≠ disk 1.1.23)
4. `Util::needUpgrade()` returns true → Nextcloud serves 503 "Update needed" on all endpoints
5. But `status.php` bypasses this check → readiness probe passes → broken pod stays in Service

Verified fix on dev: deleted a pod, watched it restart with the new hook, confirmed `occ upgrade` ran and pod serves 302 (not 503).

## Test plan

- [x] Verified `occ upgrade` fixes 503 on affected pods (manual kubectl exec)
- [x] Updated ConfigMap on dev, deleted a pod, confirmed new pod runs `occ upgrade` in before-starting hook and serves 302
- [x] E2E test `nextcloud-health.spec.ts` passes on healthy Nextcloud, fails when 503 is present

## OSS Compliance Review

CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0 — No issues found.

## Security Review

CRITICAL: 0 | HIGH: 0 | MEDIUM: 1 (stderr suppression on occ upgrade — pre-existing pattern) | LOW: 1 — No blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)