### PR TITLE
Fix docs backend crash loop: raise CPU limit, relax probes, add HPA alert

### DIFF
--- a/apps/values/prometheus.yaml
+++ b/apps/values/prometheus.yaml
@@ -674,6 +674,17 @@ additionalPrometheusRulesMap:
             for: 5m
             labels:
               severity: critical
+      - name: hpa-alerts
+        rules:
+          - alert: HPAMaxedOut
+            annotations:
+              summary: 'HPA {{ $labels.horizontalpodautoscaler }} in {{ $labels.namespace }} is at max replicas'
+              description: 'HPA {{ $labels.horizontalpodautoscaler }} in {{ $labels.namespace }} has been running at its maximum replica count for over 5 minutes. This may indicate the service needs more capacity or is in a crash loop.'
+            expr: |-
+              kube_horizontalpodautoscaler_status_current_replicas == kube_horizontalpodautoscaler_spec_max_replicas
+            for: 5m
+            labels:
+              severity: warning
 
 # Node exporter subchart resources — kube-prometheus-stack passes these via the subchart key
 prometheus-node-exporter:

--- a/docs/backend-deployment.yaml
+++ b/docs/backend-deployment.yaml
@@ -141,16 +141,16 @@ spec:
             httpGet:
               path: /__heartbeat__
               port: 8000
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /__lbheartbeat__
               port: 8000
             initialDelaySeconds: 10
             periodSeconds: 5
-            timeoutSeconds: 3
+            timeoutSeconds: 5
             failureThreshold: 3
           # Memory INCREASED based on actual usage (~385Mi observed)
           resources:
@@ -158,7 +158,7 @@ spec:
               cpu: 100m  # Minimum 100m to prevent HPA triggering on idle fluctuations
               memory: 512Mi
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 1Gi
           securityContext:
             runAsUser: 0

--- a/e2e/tests/smoke/docs-health.spec.ts
+++ b/e2e/tests/smoke/docs-health.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { urls } from '../../helpers/urls';
+
+test.describe('Smoke — Docs Backend Health', () => {
+  test('backend config endpoint returns 200', async ({ request }) => {
+    // /api/v1.0/config/ is served by the Django backend directly.
+    // When the backend is down (crash loop, CPU throttling, gunicorn timeout),
+    // the frontend may still serve static assets but API calls return 502/503.
+    // This catches backend-specific outages that the frontend UI masks.
+    const response = await request.get(`${urls.docs}/api/v1.0/config/`);
+    const status = response.status();
+
+    if (status === 0) {
+      test.skip(true, 'Docs not reachable (DNS or connection error)');
+    }
+
+    expect(
+      status,
+      `Docs backend returned HTTP ${status}. ` +
+      (status === 502 || status === 503
+        ? 'Backend is likely down (crash loop or CPU throttled). ' +
+          'Check: kubectl get pods -n tn-<tenant>-docs -l io.kompose.service=backend'
+        : `Expected 200, got ${status}`)
+    ).toBe(200);
+  });
+
+  test('backend config endpoint returns valid JSON', async ({ request }) => {
+    // When nginx can't reach the backend, it may return an HTML error page
+    // with a 502 status. But even with 200, we should verify the response
+    // is actual JSON from Django, not an nginx error page.
+    const response = await request.get(`${urls.docs}/api/v1.0/config/`);
+
+    if (!response.ok()) {
+      test.skip(true, `Docs backend not OK (HTTP ${response.status()})`);
+    }
+
+    const contentType = response.headers()['content-type'] || '';
+    expect(
+      contentType,
+      'Expected JSON content-type from Django backend, got: ' + contentType +
+      '. This may indicate nginx is serving an error page instead of proxying to the backend.'
+    ).toContain('application/json');
+
+    const body = await response.json();
+    expect(body).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Raise CPU limit** from 500m to 1000m on docs backend — steady-state is 4-10m but gunicorn workers spike past 500m during requests, triggering kernel CFS throttling → worker timeout → SIGKILL → liveness probe kills pod → restart triggers `pip install boto3` CPU spike → throttles neighboring pods → cascade
- **Relax liveness probe** (time-to-kill 30s → 75s) so gunicorn has time to respawn killed workers before kubelet terminates the pod; widen readiness timeout 3s → 5s for contention headroom
- **Add cluster-wide HPAMaxedOut Prometheus alert** — fires when any HPA runs at max replicas for 5min (would have flagged this issue before the crash loop started)
- **Add E2E smoke test** for docs backend `/api/v1.0/config/` endpoint — catches backend-specific 502/503 that the frontend UI masks

## Test plan

- [ ] Deploy to dev for both tenants: `./apps/deploy-docs.sh -e dev -t mothertree` and `-t innba`
- [ ] Verify pods stabilize and restart count stops increasing
- [ ] Verify HPA scales down from 5 as CPU load decreases
- [ ] Deploy monitoring: `cd apps && helmfile -e dev -l name=kube-prometheus-stack sync`
- [ ] Verify HPAMaxedOut alert fires in Prometheus if HPA is still maxed
- [ ] Run E2E test: `cd e2e && npx playwright test tests/smoke/docs-health.spec.ts`

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues found. All secrets use `secretKeyRef`, E2E test uses `example.com` default, no real tenant domains or private registry references.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 1 (pre-existing) | **LOW**: 2

- **MEDIUM** (pre-existing): Container runs as `runAsUser: 0` — not introduced by this PR, flagged for awareness
- **LOW**: Relaxed liveness probe increases window for unhealthy pod (mitigated by readiness probe still gating traffic)
- **LOW**: CPU limit doubled — mitigated by the new HPAMaxedOut alert providing visibility

No blocking security issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)