### PR TITLE
Disable Keycloak brute force protection for dev

### DIFF
--- a/docs/import-keycloak-realm.sh
+++ b/docs/import-keycloak-realm.sh
@@ -245,6 +245,23 @@ else
     exit 1
 fi
 
+# Disable brute force protection in dev — CI runs 10 parallel E2E shards that
+# authenticate the same test user simultaneously, triggering Keycloak's quick
+# login check and temporarily disabling the account.
+if [ "$MT_ENV" = "dev" ]; then
+    print_status "Disabling brute force protection (dev environment)..."
+    BF_RESPONSE=$(curl -s ${KEYCLOAK_SKIP_SSL_VERIFY} -w "%{http_code}" -o /dev/null -X PUT \
+      "$KEYCLOAK_URL/admin/realms/$TENANT_KEYCLOAK_REALM" \
+      -H "Authorization: Bearer $ACCESS_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"bruteForceProtected": false}')
+    if [ "$BF_RESPONSE" = "204" ]; then
+        print_success "Brute force protection disabled for dev"
+    else
+        print_warning "Failed to disable brute force protection (HTTP $BF_RESPONSE), continuing..."
+    fi
+fi
+
 # Update realm frontendUrl to use tenant's auth domain (multi-domain support)
 # This ensures the realm uses the correct domain for redirects and links
 print_status "Setting realm frontendUrl to https://${AUTH_HOST}..."


### PR DESCRIPTION
## Summary

- Adds an `MT_ENV=dev` conditional in the Keycloak realm import script to disable brute force protection after realm creation/update
- Production realms remain protected — the realm template keeps `bruteForceProtected: true`
- Also applied live to existing dev realms (`docs`, `innba`) and cleared existing lockout status

## Root Cause

Keycloak's brute force protection with default thresholds (`quickLoginCheck: 1000ms`, `waitIncrement: 60s`, `failureFactor: 30`) causes `user_temporarily_disabled` errors when 10 parallel CI E2E shards authenticate the same `e2e-member` user simultaneously.

**Evidence from Keycloak pod logs:**
```
WARN type="LOGIN_ERROR", realmName="docs", error="user_temporarily_disabled", username="e2e-member"
```
(13 occurrences in a single CI run, spanning ~10 minutes)

This caused 4 out of 10 E2E shards to fail with `Keycloak login failed for "e2e-member": Invalid username or password.` (Keycloak shows "Invalid username or password" for temporarily disabled accounts for security reasons).

## Approach

Follows the existing pattern of `MT_ENV`-conditional overrides in `import-keycloak-realm.sh` (already used for password auth flows, etc). After the realm is created/updated, a dev-only API call sets `bruteForceProtected: false`.

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0
No OSS compliance issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0
Initial review flagged disabling brute force globally (HIGH). Addressed by scoping the change to dev only — production realms remain protected.

## Test plan

- [ ] Verify CI E2E shards no longer fail with `user_temporarily_disabled`
- [ ] Verify brute force protection remains enabled on production realms
- [ ] Re-run realm import on dev to confirm the conditional works

🤖 Generated with [Claude Code](https://claude.com/claude-code)