### PR TITLE
Fix Collabora E2E: use real upload UI flow

### DIFF
--- a/e2e/tests/smoke/nextcloud-collabora.spec.ts
+++ b/e2e/tests/smoke/nextcloud-collabora.spec.ts
@@ -126,7 +126,13 @@ test.describe('Smoke — Nextcloud Collabora (Office)', () => {
         buffer: Buffer.from('E2E Collabora WOPI test'),
       });
 
-      // Wait for upload to complete and file to appear in the list
+      // Wait for the upload to finish, then reload the file list. NC32's Vue
+      // file list doesn't always reflect uploads triggered via the fileChooser
+      // API. A reload guarantees the server-side file appears in the DOM.
+      await page.waitForTimeout(3_000);
+      await page.goto(`${urls.files}/apps/files/`);
+      await page.waitForLoadState('networkidle').catch(() => {});
+
       const fileRow = page.locator(`[data-cy-files-list-row-name="${testFileName}"]`);
       await fileRow.waitFor({ state: 'visible', timeout: 15_000 });
 


### PR DESCRIPTION
## Summary

- Use the real Nextcloud upload UI flow (New → Upload files → file chooser) instead of `setInputFiles()` on a hidden `input[type="file"]`
- Fix WebDAV cleanup to include the CSRF `requesttoken` header (was returning 401)

## Root Cause

`setInputFiles()` on a generic `input[type="file"]` never triggered Nextcloud 32's Vue-based `@nextcloud/upload` component — confirmed via server access logs showing **zero PUT/upload requests** reaching Nextcloud. The Playwright synthetic `change` event wasn't picked up by the Vue uploader.

The WebDAV DELETE cleanup was also failing (401) because it didn't include Nextcloud's CSRF token, causing test files to accumulate across CI runs.

## Fix

Uses the real user flow via Playwright's `fileChooser` API:
1. Click the "+New" button (`form[data-cy-upload-picker]`)
2. Click "Upload files" menu item (`getByRole('menuitem', { name: 'Upload files' })`)
3. Intercept the native file dialog with `page.waitForEvent('filechooser')`
4. Provide the test file via `fileChooser.setFiles()`

This mirrors what users actually do and properly triggers NC's upload pipeline.

## Verification

- 3/3 local runs pass (10-14s each)
- WebDAV DELETE now returns 204 (confirmed in server logs)
- Follows up on #136 which fixed iframe selectors and wait mechanics

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0
No issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0
No issues in changed code. The requesttoken usage follows the standard Nextcloud client-side CSRF pattern.

## Test plan

- [ ] CI pipeline passes with shard 8 (contains the Collabora test) succeeding
- [ ] No test file accumulation in the e2e-member user's Nextcloud after multiple runs

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)