### PR TITLE
Add cleanup to Nextcloud upload E2E test, prevent file accumulation

### DIFF
--- a/e2e/tests/smoke/nextcloud.spec.ts
+++ b/e2e/tests/smoke/nextcloud.spec.ts
@@ -174,20 +174,34 @@ test.describe('Smoke — Nextcloud (Files)', () => {
     // Wait for files view (retries if Nextcloud is in maintenance mode during HPA scale-up)
     await waitForNextcloudReady(page);
 
-    // Nextcloud has a hidden file input for uploads
-    const fileInput = page.locator('input[type="file"]');
-    if (await fileInput.count() > 0) {
-      const testFileName = `e2e-test-${Date.now()}.txt`;
-      await fileInput.first().setInputFiles({
-        name: testFileName,
-        mimeType: 'text/plain',
-        buffer: Buffer.from('E2E test file content'),
-      });
+    // Upload a file via WebDAV and verify it appears in the page.
+    const testFileName = `e2e-test-${Date.now()}.txt`;
+    try {
+      const uploadStatus = await page.evaluate(async (name) => {
+        const token = document.querySelector('head[data-requesttoken]')?.getAttribute('data-requesttoken') || '';
+        const resp = await fetch('/remote.php/dav/files/' + OC.currentUser + '/' + name, {
+          method: 'PUT',
+          headers: { 'requesttoken': token, 'Content-Type': 'text/plain' },
+          body: 'E2E test file content',
+        });
+        return resp.status;
+      }, testFileName);
 
-      // Wait for upload to complete
-      await page.waitForTimeout(3_000);
+      expect(uploadStatus, `WebDAV upload returned HTTP ${uploadStatus}`).toBeLessThan(300);
+
+      await page.goto(`${urls.files}/apps/files/recent`);
+      await page.waitForLoadState('networkidle').catch(() => {});
       const pageContent = await page.content();
       expect(pageContent).toContain('e2e-test');
+    } finally {
+      // Clean up — prevent file accumulation on persistent CI users
+      await page.evaluate(async (name) => {
+        const token = document.querySelector('head[data-requesttoken]')?.getAttribute('data-requesttoken') || '';
+        await fetch('/remote.php/dav/files/' + OC.currentUser + '/' + name, {
+          method: 'DELETE',
+          headers: { 'requesttoken': token },
+        }).catch(() => {});
+      }, testFileName).catch(() => {});
     }
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #148. The Nextcloud upload test (`nextcloud.spec.ts`) was leaving `e2e-test-*.txt` files behind on every CI run — **42 accumulated files** found on the pre-provisioned `e2e-member` user. This was the root cause of the Collabora test failure: Nextcloud's virtual scrolling hid the test file below the fold in the "All files" view.

Changes:
- Replace `setInputFiles` on hidden file input with WebDAV PUT (deterministic, verifiable)
- Navigate to Recent view instead of All files (just-uploaded file appears at top)
- Add `finally` block to DELETE the test file via WebDAV after the test
- Cleaned up the 42 accumulated files on the CI user (done manually, not in this PR)

## Test plan

- [x] Test passes locally with `CI=true` (pre-provisioned user): 8.7s
- [x] Test passes locally without CI flag (fresh user)
- [ ] Verify no new file accumulation after several CI pipeline runs

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — No issues.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 1 (informational — test-controlled values in URL path, not user input) | **LOW**: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)