### PR TITLE
Remove CPU limits from all managed pods

### DIFF
--- a/apps/manifests/account-portal/deployment.yaml.tpl
+++ b/apps/manifests/account-portal/deployment.yaml.tpl
@@ -133,7 +133,6 @@ spec:
               cpu: "100m"
             limits:
               memory: "128Mi"
-              cpu: "200m"
           livenessProbe:
             httpGet:
               path: /health

--- a/apps/manifests/admin-portal/deployment.yaml.tpl
+++ b/apps/manifests/admin-portal/deployment.yaml.tpl
@@ -125,7 +125,6 @@ spec:
               cpu: "100m"  # Minimum 100m to prevent HPA triggering on idle fluctuations
             limits:
               memory: "128Mi"
-              cpu: "200m"
           livenessProbe:
             httpGet:
               path: /health

--- a/apps/manifests/alerting/matrix-alertmanager-deployment.yaml.tpl
+++ b/apps/manifests/alerting/matrix-alertmanager-deployment.yaml.tpl
@@ -50,7 +50,6 @@ spec:
               cpu: 10m
               memory: 32Mi
             limits:
-              cpu: 50m
               memory: 64Mi
           livenessProbe:
             httpGet:

--- a/apps/manifests/jitsi/jicofo.yaml.tpl
+++ b/apps/manifests/jitsi/jicofo.yaml.tpl
@@ -84,10 +84,9 @@ spec:
             port: 8888
         resources:
           requests:
-            cpu: 10m
+            cpu: 50m
             memory: 256Mi
           limits:
-            cpu: 500m
             memory: 1Gi
 
 ---

--- a/apps/manifests/jitsi/jitsi-dashboard-configmap.yaml
+++ b/apps/manifests/jitsi/jitsi-dashboard-configmap.yaml
@@ -1,6 +1,6 @@
-# NOTE: The gauge thresholds (3.1% for request boundary) depend on JVB CPU
-# request/limit ratio in jvb.yaml. Currently: 100m/3200m = 3.1%
-# If you change the CPU values, update the threshold at 3.1 below.
+# NOTE: JVB has no CPU limit (can burst freely). The gauge threshold at 3.1
+# is a legacy value from when the limit was 3200m. Consider updating the
+# dashboard to use absolute CPU values instead of percentages.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/apps/manifests/jitsi/jvb-hpa.yaml.tpl
+++ b/apps/manifests/jitsi/jvb-hpa.yaml.tpl
@@ -1,7 +1,7 @@
 # HPA for Jitsi Video Bridge (JVB)
 # Scales based on absolute CPU usage per pod (not % of request).
-# CPU request is kept low (100m) for bin-packing; limit is 3200m for burst.
-# Target 2800m means: scale up when JVBs approach their CPU limit.
+# No CPU limit — JVB can burst freely. Target 2800m means: scale up when
+# JVB CPU usage is high enough that adding capacity improves call quality.
 # Note: JVB uses hostPort, so scaling beyond node count requires cluster autoscaler
 # to provision new nodes. Pods will be Pending until nodes are available.
 apiVersion: autoscaling/v2

--- a/apps/manifests/jitsi/jvb.yaml.tpl
+++ b/apps/manifests/jitsi/jvb.yaml.tpl
@@ -238,17 +238,12 @@ spec:
           httpGet:
             path: /about/health
             port: 8080
-        # NOTE: If you change CPU request/limit values, update the threshold in
-        # jitsi-dashboard-configmap.yaml gauge panel (id: 3). The green/yellow
-        # threshold should be (request/limit * 100)%. Currently: 50m/3200m = 1.6%
-        # Low request allows scheduling on smaller nodes; high limit allows burst for video
         # Memory tuned based on actual usage (~250Mi observed idle)
         resources:
           requests:
             cpu: 100m  # Minimum 100m to prevent HPA triggering on idle fluctuations
             memory: 300Mi
           limits:
-            cpu: 3200m  # 80% of g6-standard-4 (4 cores)
             memory: 2Gi
       volumes:
       - name: shared-data

--- a/apps/manifests/jitsi/keycloak-adapter.yaml.tpl
+++ b/apps/manifests/jitsi/keycloak-adapter.yaml.tpl
@@ -65,7 +65,6 @@ spec:
             cpu: 10m
             memory: 64Mi
           limits:
-            cpu: 100m
             memory: 128Mi
         livenessProbe:
           httpGet:

--- a/apps/manifests/jitsi/prosody.yaml.tpl
+++ b/apps/manifests/jitsi/prosody.yaml.tpl
@@ -155,10 +155,9 @@ spec:
         # Memory raised from 256Mi after Feb 2026 incident: XML stream corruption at ~342Mi usage
         resources:
           requests:
-            cpu: 10m
+            cpu: 50m
             memory: 64Mi
           limits:
-            cpu: 300m
             memory: 512Mi
       volumes:
       - name: prosody-config

--- a/apps/manifests/jitsi/web.yaml.tpl
+++ b/apps/manifests/jitsi/web.yaml.tpl
@@ -136,7 +136,6 @@ spec:
             cpu: 100m  # Minimum 100m to prevent HPA triggering on idle fluctuations
             memory: 48Mi
           limits:
-            cpu: 300m
             memory: 128Mi
       volumes:
       - name: web-config

--- a/apps/manifests/synapse-admin/synapse-admin.yaml.tpl
+++ b/apps/manifests/synapse-admin/synapse-admin.yaml.tpl
@@ -52,7 +52,6 @@ spec:
               cpu: 100m  # Minimum 100m to prevent HPA triggering on idle fluctuations
               memory: 64Mi
             limits:
-              cpu: 200m
               memory: 128Mi
           volumeMounts:
             - name: config

--- a/apps/manifests/vpn-route-daemonset.yaml.tpl
+++ b/apps/manifests/vpn-route-daemonset.yaml.tpl
@@ -86,6 +86,5 @@ spec:
               cpu: 5m
               memory: 16Mi
             limits:
-              cpu: 100m
               memory: 32Mi
       terminationGracePeriodSeconds: 5

--- a/docs/frontend-deployment.yaml.tpl
+++ b/docs/frontend-deployment.yaml.tpl
@@ -51,7 +51,6 @@ spec:
               cpu: 100m
               memory: 32Mi
             limits:
-              cpu: 200m
               memory: 128Mi
           securityContext:
             runAsUser: 101

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -798,7 +798,6 @@ resource "kubernetes_deployment" "postfix" {
               memory = "32Mi"
             }
             limits = {
-              cpu    = "100m"
               memory = "64Mi"
             }
           }
@@ -1023,7 +1022,6 @@ resource "kubernetes_deployment" "postfix" {
               memory = "64Mi"
             }
             limits = {
-              cpu    = "200m"
               memory = "256Mi"
             }
           }


### PR DESCRIPTION
## Summary

- Remove CPU limits from 13 containers across all managed components (Jitsi, portals, synapse-admin, docs frontend, alertmanager, vpn-route-manager, postfix, opendkim)
- Bump jicofo and prosody CPU requests from 10m to 50m — both are critical Jitsi components that spike during calls, 10m was too tight
- Update stale comments in JVB HPA and Grafana dashboard configmap that referenced the old 3200m CPU limit

CPU limits cause unnecessary CFS throttling without meaningfully protecting the cluster (memory limits, which are retained, are the important safeguard). This is a well-established K8s best practice.

**Not touched**: `kube-system/cloud-firewall-controller` — Linode-managed, out of our control.

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues found. Changes are purely resource spec modifications with no credentials, domains, or PII.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 2

- **LOW**: Removing CPU limits means a misbehaving container can consume all node CPU. Mitigated by CPU requests (scheduling guarantees), memory limits (retained), and cluster autoscaler.
- **LOW**: HPA `Utilization` percentage is computed against requests (not limits), so removing CPU limits does not change HPA scaling behavior.

MEDIUM stale-comment findings from initial review were fixed in this PR (JVB HPA + dashboard configmap comments updated).

## Test plan

- [ ] Deploy to dev and verify all pods start without issues
- [ ] Confirm `kubectl top pods` shows expected CPU usage patterns
- [ ] Run a Jitsi call to verify JVB can burst CPU without throttling
- [ ] Check HPA scaling still triggers correctly under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)