### PR TITLE
Name CalDAV app tokens 'calendar-automation' instead of 'cli'

### DIFF
--- a/apps/deploy-calendar-automation.sh
+++ b/apps/deploy-calendar-automation.sh
@@ -208,6 +208,15 @@ else
             sh -c "echo '' | php occ user:auth-tokens:add '$user_email'" 2>/dev/null \
             | grep -A1 "app password:" | tail -1 | tr -d '[:space:]')
         if [ -n "$APP_PASS" ]; then
+            # Rename the token from default "cli" to "calendar-automation" for clarity
+            # (occ user:auth-tokens:add hardcodes the name "cli" with no override option)
+            kubectl exec -n "$NS_FILES" "$NEXTCLOUD_POD" -c nextcloud -- \
+                env NC_TOKEN_USER="$user_email" php -r '
+define("OC_CONSOLE", 1);
+require "/var/www/html/lib/base.php";
+$db = \OC::$server->getDatabaseConnection();
+$db->executeStatement("UPDATE oc_authtoken SET name = ? WHERE uid = ? AND name = ?", ["calendar-automation", getenv("NC_TOKEN_USER"), "cli"]);
+' 2>/dev/null || true
             # Build JSON incrementally using jq
             CALDAV_TOKENS=$(echo "$CALDAV_TOKENS" | jq --arg k "$user_email" --arg v "$APP_PASS" '. + {($k): $v}')
             TOKEN_COUNT=$((TOKEN_COUNT + 1))


### PR DESCRIPTION
## Summary

- The `occ user:auth-tokens:add` command hardcodes the token name as "cli" with no `--name` flag
- This caused confusing Nextcloud activity notifications: *"An administrator created an app password for a session named 'cli'"*
- After creating each token, rename it in the database via Nextcloud's DB connection to "calendar-automation"
- Uses parameterized queries (no SQL injection risk) and is non-fatal (`|| true`) if the rename fails

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — No issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 1 (pre-existing, not in this diff) | **LOW**: 0

The new code uses parameterized SQL and passes user input via environment variables. One pre-existing MEDIUM: the existing `occ user:auth-tokens:add` line interpolates `$user_email` inside `sh -c` single quotes — a shell injection anti-pattern (low practical risk since emails come from Keycloak-validated OIDC).

## Test plan

- [ ] Deploy calendar-automation to dev (`./apps/deploy-calendar-automation.sh -e dev -t mothertree`)
- [ ] Verify token creation succeeds and tokens are named "calendar-automation" in Nextcloud
- [ ] Verify calendar-automation pod starts and can sync calendars using the renamed tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)