### PR TITLE
Add exponential backoff and dead-letter for failed iTIP processing

### DIFF
--- a/apps/calendar-automation/server.js
+++ b/apps/calendar-automation/server.js
@@ -59,6 +59,23 @@ const config = {
   logLevel: process.env.LOG_LEVEL || 'info',
 };
 
+// ---------------------------------------------------------------------------
+// Retry and dead-letter constants
+// ---------------------------------------------------------------------------
+
+const RETRY_BASE_DELAY_MS = 60_000;       // 1 poll cycle
+const RETRY_MAX_DELAY_MS = 3_600_000;     // 1 hour cap
+const MAX_RETRIES = 5;                     // dead-letter after 5 failures
+const DEAD_LETTER_FOLDER = 'INBOX/iTIP-Failed';
+const RETRY_PRUNE_INTERVAL = 100;          // prune stale entries every N cycles
+const RETRY_STALE_MS = 24 * 60 * 60 * 1000; // 24h
+
+// Key: "${stalwartName}:${uid}", Value: { retries, nextRetryAfter, lastError }
+const retryTracker = new Map();
+
+// Key: stalwartName, Value: { consecutiveFullFailures, nextRetryAfter }
+const userBackoff = new Map();
+
 function requiredEnv(name) {
   const value = process.env[name];
   if (!value) {
@@ -101,6 +118,10 @@ const metrics = {
   lastPollTime: null,
   lastPollDurationMs: 0,
   usersScanned: 0,
+  messagesDeadLettered: 0,
+  messagesSkippedBackoff: 0,
+  usersSkippedBackoff: 0,
+  retryTrackerSize: 0,
   healthy: true,
 };
 
@@ -115,6 +136,7 @@ function startHealthServer() {
       res.writeHead(status, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ status: metrics.healthy ? 'ok' : 'unhealthy' }));
     } else if (req.url === '/metrics') {
+      metrics.retryTrackerSize = retryTracker.size;
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(metrics, null, 2));
     } else {
@@ -342,6 +364,129 @@ async function markAsProcessed(stalwartName, uid) {
     } catch {
       // Ignore logout errors
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Retry tracking and dead-letter helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a retry tracker key from stalwart name and message UID.
+ */
+function retryTrackerKey(stalwartName, uid) {
+  return `${stalwartName}:${uid}`;
+}
+
+/**
+ * Check if a message should be skipped because it's in a backoff window.
+ * Returns true if the message has a retry entry and the backoff hasn't expired.
+ */
+function shouldSkipMessage(stalwartName, uid) {
+  const key = retryTrackerKey(stalwartName, uid);
+  const entry = retryTracker.get(key);
+  if (!entry) return false;
+  return Date.now() < entry.nextRetryAfter;
+}
+
+/**
+ * Record a processing failure for a message. Increments retry count and
+ * computes exponential backoff delay.
+ * Returns true if max retries exceeded (message should be dead-lettered).
+ */
+function recordFailure(stalwartName, uid, errorMessage) {
+  const key = retryTrackerKey(stalwartName, uid);
+  const entry = retryTracker.get(key) || { retries: 0, nextRetryAfter: 0, lastError: '' };
+  entry.retries++;
+  entry.lastError = errorMessage;
+  const delay = Math.min(RETRY_BASE_DELAY_MS * Math.pow(2, entry.retries - 1), RETRY_MAX_DELAY_MS);
+  entry.nextRetryAfter = Date.now() + delay;
+  retryTracker.set(key, entry);
+
+  log('warn', 'Message processing failed, backing off', {
+    user: stalwartName,
+    uid,
+    retries: entry.retries,
+    nextRetryMs: delay,
+    error: errorMessage,
+  });
+
+  return entry.retries >= MAX_RETRIES;
+}
+
+/**
+ * Move a message to the dead-letter folder (INBOX/iTIP-Failed).
+ * Flags the message with $CalendarProcessed BEFORE moving, because
+ * IMAP MOVE changes the message UID.
+ */
+async function moveToDeadLetter(stalwartName, uid) {
+  const client = createImapClient(stalwartName);
+
+  try {
+    await client.connect();
+    await client.mailboxOpen('INBOX');
+
+    // Create dead-letter folder if it doesn't exist
+    try {
+      await client.mailboxCreate(DEAD_LETTER_FOLDER);
+      log('info', 'Created dead-letter folder', { user: stalwartName, folder: DEAD_LETTER_FOLDER });
+    } catch {
+      // Folder already exists — this is fine
+    }
+
+    // Flag BEFORE move (move changes UID, so flag must come first)
+    await client.messageFlagsAdd(uid, ['$CalendarProcessed'], { uid: true });
+    await client.messageMove(uid, DEAD_LETTER_FOLDER, { uid: true });
+
+    // Clean up retry tracker entry
+    const key = retryTrackerKey(stalwartName, uid);
+    retryTracker.delete(key);
+
+    metrics.messagesDeadLettered++;
+    log('warn', 'Dead-lettered message after max retries', {
+      user: stalwartName,
+      uid,
+      folder: DEAD_LETTER_FOLDER,
+    });
+  } finally {
+    try {
+      await client.logout();
+    } catch {
+      // Ignore logout errors
+    }
+  }
+}
+
+/**
+ * Prune stale entries from retryTracker and userBackoff maps.
+ * Removes entries whose backoff window expired more than RETRY_STALE_MS ago.
+ */
+function pruneRetryTracker() {
+  const now = Date.now();
+  let prunedRetry = 0;
+  let prunedBackoff = 0;
+
+  for (const [key, entry] of retryTracker) {
+    if (now - entry.nextRetryAfter > RETRY_STALE_MS) {
+      retryTracker.delete(key);
+      prunedRetry++;
+    }
+  }
+
+  for (const [key, entry] of userBackoff) {
+    if (now - entry.nextRetryAfter > RETRY_STALE_MS) {
+      userBackoff.delete(key);
+      prunedBackoff++;
+    }
+  }
+
+  if (prunedRetry > 0 || prunedBackoff > 0) {
+    log('info', 'Pruned stale retry entries', {
+      prunedRetry,
+      prunedBackoff,
+      remainingRetry: retryTracker.size,
+      remainingBackoff: userBackoff.size,
+    });
   }
 }
 
@@ -961,6 +1106,19 @@ async function processCancel(userEmail, icalData) {
  */
 async function processUser(user) {
   const { name: stalwartName, email: userEmail } = user;
+
+  // Check per-user backoff — skip entirely if user is in backoff window
+  const ub = userBackoff.get(stalwartName);
+  if (ub && Date.now() < ub.nextRetryAfter) {
+    metrics.usersSkippedBackoff++;
+    log('debug', 'Skipping user (in backoff)', {
+      user: stalwartName,
+      consecutiveFullFailures: ub.consecutiveFullFailures,
+      nextRetryAfter: new Date(ub.nextRetryAfter).toISOString(),
+    });
+    return;
+  }
+
   let messages;
   try {
     messages = await scanUserInbox(stalwartName);
@@ -976,7 +1134,19 @@ async function processUser(user) {
 
   log('info', `Found ${messages.length} iTIP message(s)`, { user: userEmail });
 
+  let anySucceeded = false;
+
   for (const msg of messages) {
+    // Skip messages that are in a backoff window from a previous failure
+    if (shouldSkipMessage(stalwartName, msg.uid)) {
+      metrics.messagesSkippedBackoff++;
+      log('debug', 'Skipping message (in backoff)', {
+        user: stalwartName,
+        uid: msg.uid,
+      });
+      continue;
+    }
+
     try {
       let processed = false;
 
@@ -1002,18 +1172,45 @@ async function processUser(user) {
       if (processed) {
         await markAsProcessed(stalwartName, msg.uid);
         metrics.messagesProcessed++;
+        anySucceeded = true;
       }
     } catch (err) {
       metrics.errors++;
-      log('error', 'Failed to process iTIP message', {
-        user: userEmail,
-        uid: msg.uid,
-        method: msg.method,
-        error: err.message,
-        stack: err.stack,
-      });
+
+      const maxExceeded = recordFailure(stalwartName, msg.uid, err.message);
+      if (maxExceeded) {
+        try {
+          await moveToDeadLetter(stalwartName, msg.uid);
+        } catch (dlErr) {
+          log('error', 'Failed to dead-letter message', {
+            user: stalwartName,
+            uid: msg.uid,
+            error: dlErr.message,
+          });
+        }
+      }
       // Continue processing other messages -- don't let one failure block the rest
     }
+  }
+
+  // Per-user backoff: if all messages are in the retry tracker (none succeeded),
+  // increment consecutive failure count and back off the entire user
+  if (messages.length > 0 && !anySucceeded) {
+    const existing = userBackoff.get(stalwartName) || { consecutiveFullFailures: 0, nextRetryAfter: 0 };
+    existing.consecutiveFullFailures++;
+    const delay = Math.min(
+      RETRY_BASE_DELAY_MS * Math.pow(2, existing.consecutiveFullFailures - 1),
+      RETRY_MAX_DELAY_MS,
+    );
+    existing.nextRetryAfter = Date.now() + delay;
+    userBackoff.set(stalwartName, existing);
+    log('info', 'All messages failed for user, applying user-level backoff', {
+      user: stalwartName,
+      consecutiveFullFailures: existing.consecutiveFullFailures,
+      nextRetryMs: delay,
+    });
+  } else if (anySucceeded) {
+    userBackoff.delete(stalwartName);
   }
 }
 
@@ -1023,6 +1220,11 @@ async function processUser(user) {
 async function pollCycle() {
   const startTime = Date.now();
   metrics.pollCycles++;
+
+  // Periodically prune stale retry tracker entries
+  if (metrics.pollCycles % RETRY_PRUNE_INTERVAL === 0) {
+    pruneRetryTracker();
+  }
 
   log('debug', 'Starting poll cycle', { cycle: metrics.pollCycles });
 
@@ -1109,6 +1311,12 @@ function shutdown(signal) {
     clearInterval(pollTimer);
     pollTimer = null;
   }
+
+  const retrySize = retryTracker.size;
+  const backoffSize = userBackoff.size;
+  retryTracker.clear();
+  userBackoff.clear();
+  log('info', 'Cleared retry state', { retryTrackerEntries: retrySize, userBackoffEntries: backoffSize });
 
   if (healthServer) {
     healthServer.close(() => {

--- a/apps/calendar-automation/server.test.js
+++ b/apps/calendar-automation/server.test.js
@@ -19,6 +19,35 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const source = readFileSync(join(__dirname, 'server.js'), 'utf-8');
 
 /**
+ * Extract the body of a named function from source code.
+ * Handles both "function name()" and "async function name()" forms.
+ * Returns the function body string (including braces) or null if not found.
+ */
+function extractFunctionBody(src, funcName) {
+  const pattern = new RegExp(`(?:async\\s+)?function\\s+${funcName}\\s*\\([^)]*\\)\\s*\\{`);
+  const match = pattern.exec(src);
+  if (!match) return null;
+
+  let depth = 0;
+  let inFunc = false;
+  let body = '';
+  for (let i = match.index; i < src.length; i++) {
+    if (src[i] === '{') {
+      depth++;
+      inFunc = true;
+    }
+    if (src[i] === '}') {
+      depth--;
+    }
+    if (inFunc) {
+      body += src[i];
+    }
+    if (inFunc && depth === 0) break;
+  }
+  return body;
+}
+
+/**
  * Extract all fetch() call blocks that use method: 'PUT' from the source.
  * Returns an array of { functionName, fetchBlock } objects.
  */
@@ -101,5 +130,69 @@ describe('CalDAV PUT requests include Schedule-Reply header', () => {
         `${call.functionName} PUT fetch is missing Schedule-Reply header:\n${call.fetchBlock}`,
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retry and dead-letter handling
+// ---------------------------------------------------------------------------
+
+describe('Retry and dead-letter handling', () => {
+  it('DEAD_LETTER_FOLDER constant should be INBOX/iTIP-Failed', () => {
+    assert.ok(
+      source.includes("DEAD_LETTER_FOLDER = 'INBOX/iTIP-Failed'"),
+      'DEAD_LETTER_FOLDER constant not found or has wrong value',
+    );
+  });
+
+  it('MAX_RETRIES constant should exist', () => {
+    assert.ok(
+      source.includes('MAX_RETRIES = 5'),
+      'MAX_RETRIES constant not found or has wrong value',
+    );
+  });
+
+  it('moveToDeadLetter should flag message before moving', () => {
+    const body = extractFunctionBody(source, 'moveToDeadLetter');
+    assert.ok(body, 'moveToDeadLetter function not found');
+
+    const flagIndex = body.indexOf('messageFlagsAdd');
+    const moveIndex = body.indexOf('messageMove');
+
+    assert.ok(flagIndex !== -1, 'messageFlagsAdd not found in moveToDeadLetter');
+    assert.ok(moveIndex !== -1, 'messageMove not found in moveToDeadLetter');
+    assert.ok(
+      flagIndex < moveIndex,
+      `messageFlagsAdd (index ${flagIndex}) must come before messageMove (index ${moveIndex}) — flag before move is critical because IMAP MOVE changes the UID`,
+    );
+  });
+
+  it('processUser should call shouldSkipMessage', () => {
+    const body = extractFunctionBody(source, 'processUser');
+    assert.ok(body, 'processUser function not found');
+    assert.ok(
+      body.includes('shouldSkipMessage'),
+      'processUser should call shouldSkipMessage to skip messages in backoff',
+    );
+  });
+
+  it('metrics should include messagesDeadLettered and messagesSkippedBackoff', () => {
+    assert.ok(
+      source.includes('messagesDeadLettered'),
+      'metrics.messagesDeadLettered not found in source',
+    );
+    assert.ok(
+      source.includes('messagesSkippedBackoff'),
+      'metrics.messagesSkippedBackoff not found in source',
+    );
+  });
+
+  it('backoff should use exponential formula', () => {
+    const body = extractFunctionBody(source, 'recordFailure');
+    assert.ok(body, 'recordFailure function not found');
+    assert.ok(
+      body.includes('Math.pow(2,'),
+      'recordFailure should use Math.pow(2, ...) for exponential backoff',
+    );
   });
 });


### PR DESCRIPTION
## Summary

Closes #195.

- **Exponential backoff per message**: Failed iTIP messages are tracked in-memory with retry count. Backoff delays: 60s → 120s → 240s → 480s → dead-letter (~15 min total).
- **Dead-letter after 5 failures**: Messages exceeding `MAX_RETRIES` are flagged `$CalendarProcessed` and moved to `INBOX/iTIP-Failed` folder.
- **Per-user backoff**: When ALL messages for a user fail, the entire user's inbox scan is backed off with the same exponential formula (prevents hammering IMAP for users with no Nextcloud principal).
- **Stale entry pruning**: Retry tracker entries older than 24h are pruned every 100 poll cycles.
- **New metrics**: `messagesDeadLettered`, `messagesSkippedBackoff`, `usersSkippedBackoff`, `retryTrackerSize` exposed via `/metrics`.

All state is in-memory (two `Map`s) — resets on pod restart, which is intentional (gives fresh chance after deploy).

## OSS Compliance Review

CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0

No real domains, credentials, personal info, or private registry references found. All sensitive values come from environment variables via `requiredEnv()`.

## Security Review

CRITICAL: 0 | HIGH: 0 | MEDIUM: 1 | LOW: 2

- **MEDIUM**: `recordFailure()` stores `err.message` verbatim in the in-memory Map (not exposed via `/metrics`, only logged). Could truncate for hygiene.
- **LOW**: Unbounded Map growth between prune cycles — bounded in practice by 100 msgs/user cap and MAX_RETRIES dead-lettering.
- **LOW**: `DEAD_LETTER_FOLDER` is hardcoded constant — no injection vector.

No command injection, IMAP injection, or DoS vectors. Exponential backoff + dead-lettering is specifically designed to prevent the retry storm DoS described in the issue.

## Test plan

- [x] `npm test` passes (10 tests including 6 new retry/dead-letter source-level tests)
- [ ] Deploy to dev, send iTIP to user without Nextcloud principal → verify backoff logs and eventual dead-lettering
- [ ] Check `/metrics` endpoint shows new fields
- [ ] Existing calendar e2e tests still pass (valid messages succeed on first attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)