### PR TITLE
Add magic-link login option to all Keycloak login pages

### DIFF
--- a/apps/themes/platform/login/login-username.ftl
+++ b/apps/themes/platform/login/login-username.ftl
@@ -266,6 +266,11 @@
                 <a href="#" id="recover-link">Lost your passkey?</a>
             </div>
 
+            <#-- Magic-link login link -->
+            <div class="bottom-links" style="margin-top: 0.5rem;">
+                <a href="#" id="magic-link-login">Sign in with email link</a>
+            </div>
+
             <#-- Guest registration link -->
             <div class="bottom-links" style="margin-top: 0.5rem;">
                 <a href="#" id="guest-register-link">Guest? Register here</a>
@@ -335,6 +340,13 @@
                     var currentHost = window.location.hostname;
                     var adminHost = currentHost.replace(/^auth\./, 'admin.');
                     guestRegisterLink.href = 'https://' + adminHost + '/register';
+                }
+
+                // Set up magic-link login link
+                var magicLinkLogin = document.getElementById('magic-link-login');
+                if (magicLinkLogin) {
+                    var accountHost = window.location.hostname.replace(/^auth\./, 'account.');
+                    magicLinkLogin.href = 'https://' + accountHost + '/magic-link-login';
                 }
             });
         </script>

--- a/apps/themes/platform/login/login.ftl
+++ b/apps/themes/platform/login/login.ftl
@@ -349,6 +349,11 @@
                 <a href="#" id="recover-link">Lost your passkey?</a>
             </div>
 
+            <#-- Magic-link login link -->
+            <div class="forgot-password" style="margin-top: 0.75rem;">
+                <a href="#" id="magic-link-login">Sign in with email link</a>
+            </div>
+
             <#-- Guest registration link -->
             <div class="guest-register" style="text-align: center; margin-top: 0.75rem;">
                 <a href="#" id="guest-register-link" style="color: #A7AE8D; font-family: 'Figtree', sans-serif; font-size: 0.9rem; text-decoration: none;">Guest? Register here</a>
@@ -459,6 +464,13 @@
                     var currentHost = window.location.hostname;
                     var adminHost = currentHost.replace(/^auth\./, 'admin.');
                     guestRegisterLink.href = 'https://' + adminHost + '/register';
+                }
+
+                // Set up magic-link login link
+                var magicLinkLogin = document.getElementById('magic-link-login');
+                if (magicLinkLogin) {
+                    var accountHost = window.location.hostname.replace(/^auth\./, 'account.');
+                    magicLinkLogin.href = 'https://' + accountHost + '/magic-link-login';
                 }
             });
         </script>

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -26,6 +26,7 @@ export const selectors = {
     adminLoginForm: '#admin-login-form',
     adminPasswordInput: '#admin-login-form #password',
     passKeyLoginBtn: '#passkey-login-btn',
+    magicLinkLogin: '#magic-link-login',
   },
 
   // ─── Account Portal ────────────────────────────────────────────────

--- a/e2e/tests/onboarding/magic-link-from-files.spec.ts
+++ b/e2e/tests/onboarding/magic-link-from-files.spec.ts
@@ -1,0 +1,276 @@
+import { test, expect } from '../../fixtures/authenticated';
+import { urls } from '../../helpers/urls';
+import { selectors } from '../../helpers/selectors';
+import { TEST_USERS } from '../../helpers/test-users';
+import { e2ePrefix } from '../../helpers/e2e-prefix';
+import { isImapConfigured, waitForEmailBody } from '../../helpers/imap';
+
+const baseDomain = urls.baseDomain;
+
+/**
+ * E2E test for magic-link login starting from files.* (Nextcloud).
+ *
+ * Verifies that the "Sign in with email link" option is visible on Keycloak
+ * login pages rendered for non-account-portal properties, and that the full
+ * magic-link flow works end-to-end when initiated from files.*.
+ *
+ * Flow:
+ * 1. Setup: invite user, complete onboarding via magic-link
+ * 2. Navigate to files.* (not logged in) -> Keycloak login page
+ * 3. Assert "Sign in with email link" is visible
+ * 4. Click link -> account portal /magic-link-login
+ * 5. Enter tenant email, submit -> "Check your email" page
+ * 6. IMAP: read magic-link email, extract sign-in URL
+ * 7. Click magic link -> Keycloak authenticates -> account portal /home
+ * 8. Navigate to files.* -> SSO auto-logs in -> Nextcloud loads
+ * 9. Cleanup: delete user
+ */
+test.describe('Magic Link from Files (Keycloak Login)', () => {
+  test.setTimeout(300_000); // 5 minutes
+
+  test('magic-link login option is available on Keycloak page when redirected from files', async ({ adminPage }) => {
+    test.skip(!isImapConfigured(), 'IMAP not configured (E2E_STALWART_ADMIN_PASSWORD not set)');
+
+    const ap = selectors.adminPortal;
+    const kc = selectors.keycloak;
+    const uniqueId = `${Date.now()}`;
+    const username = `${e2ePrefix('mlfiles')}-${uniqueId}`;
+    const firstName = `MLFiles${uniqueId}`;
+    const lastName = 'E2ETest';
+    const recoveryEmail = `e2e-mailrt+mlfiles-${uniqueId}@${baseDomain}`;
+    const tenantEmail = `${username}@${baseDomain}`;
+
+    let invitedUserId: string | null = null;
+
+    try {
+      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      // SETUP: Create user and complete magic-link onboarding
+      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+      console.log('  [mlfiles] SETUP: Creating user via admin invite...');
+
+      await adminPage.fill(ap.firstNameInput, firstName);
+      await adminPage.fill(ap.lastNameInput, lastName);
+      await adminPage.fill(ap.emailUsernameInput, username);
+      await adminPage.fill(ap.recoveryEmailInput, recoveryEmail);
+
+      const responsePromise = adminPage.waitForResponse(
+        (r) => r.url().includes('/api/invite') && r.request().method() === 'POST',
+      );
+      await adminPage.click(ap.inviteSubmitBtn);
+      const apiResponse = await responsePromise;
+      const apiResult = await apiResponse.json();
+      invitedUserId = apiResult.userId || null;
+
+      await expect(adminPage.locator(ap.formMessage)).toBeVisible({ timeout: 30_000 });
+
+      // Read invitation email
+      console.log('  [mlfiles] SETUP: Waiting for invitation email...');
+      const rawEmail = await waitForEmailBody({
+        userEmail: TEST_USERS.emailTest.email,
+        bodyContains: uniqueId,
+        timeoutMs: 180_000,
+        pollIntervalMs: 3_000,
+      });
+
+      const decodedEmail = rawEmail
+        .replace(/=\r?\n/g, '')
+        .replace(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+
+      const urlMatch = decodedEmail.match(/https:\/\/account\.[^\s"<>]+beginSetup[^\s"<>]+/);
+      const actionUrlFallback = decodedEmail.match(/https:\/\/auth\.[^\s"<>]+action-token[^\s"<>]+/);
+      let setupUrl = (urlMatch?.[0] || actionUrlFallback?.[0])?.replace(/&amp;/g, '&');
+
+      if (setupUrl?.includes('beginSetup?userId=&') || setupUrl?.includes('beginSetup?userId=&amp;')) {
+        const nextParam = new URL(setupUrl).searchParams.get('next');
+        if (nextParam) setupUrl = nextParam;
+      }
+
+      expect(setupUrl, 'Could not find setup URL in invitation email').toBeTruthy();
+
+      // Navigate to setup, go through magic-link onboarding
+      const setupContext = await adminPage.context().browser()!.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      const setupPage = await setupContext.newPage();
+
+      try {
+        console.log('  [mlfiles] SETUP: Navigating to setup URL...');
+        await setupPage.goto(setupUrl!);
+        await setupPage.waitForLoadState('load');
+
+        // Handle "Click here to proceed" page
+        const proceedLink = setupPage.locator('a:has-text("Click here to proceed"), a:has-text("click here")');
+        if (await proceedLink.first().isVisible({ timeout: 10_000 }).catch(() => false)) {
+          await proceedLink.first().click();
+          await setupPage.waitForLoadState('load');
+        }
+
+        // Wait for magic-link button (device lacks platform authenticator in headless)
+        const magicLinkButton = setupPage.locator('#magic-link-btn');
+        await magicLinkButton.waitFor({ state: 'visible', timeout: 15_000 });
+
+        await magicLinkButton.click();
+        console.log('  [mlfiles] SETUP: Clicked magic-link button');
+
+        await setupPage.waitForLoadState('load');
+        await expect(setupPage.locator('text=Check your email')).toBeVisible({ timeout: 30_000 });
+
+        // Read magic-link email
+        console.log('  [mlfiles] SETUP: Waiting for magic-link email...');
+        const magicRawEmail = await waitForEmailBody({
+          userEmail: TEST_USERS.emailTest.email,
+          bodyContains: uniqueId,
+          subjectContains: 'Complete your',
+          timeoutMs: 120_000,
+          pollIntervalMs: 3_000,
+        });
+
+        const decodedMagicEmail = magicRawEmail
+          .replace(/=\r?\n/g, '')
+          .replace(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+
+        const setupMagicMatch = decodedMagicEmail.match(
+          /https:\/\/auth\.[^\s"<>]+(?:action-token|magic-link)[^\s"<>]*/,
+        );
+        const setupAuthFallback = decodedMagicEmail.match(/https:\/\/auth\.[^\s"<>]+/);
+        const setupMagicUrl = (setupMagicMatch?.[0] || setupAuthFallback?.[0])?.replace(/&amp;/g, '&');
+        expect(setupMagicUrl, 'No magic-link URL in onboarding email').toBeTruthy();
+
+        await setupPage.goto(setupMagicUrl!);
+
+        await setupPage.waitForURL(
+          url => url.pathname.includes('/home'),
+          { timeout: 60_000 },
+        );
+
+        await expect(setupPage.locator(selectors.accountPortal.welcomeHeading)).toBeVisible({ timeout: 15_000 });
+        console.log('  [mlfiles] SETUP: Onboarding complete');
+
+        await setupPage.click(selectors.accountPortal.signOutLink);
+        await setupPage.waitForLoadState('load');
+        console.log('  [mlfiles] SETUP: Signed out');
+
+      } finally {
+        await setupContext.close();
+      }
+
+      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      // TEST: Navigate to files.* -> Keycloak -> magic-link -> SSO
+      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+      const testContext = await adminPage.context().browser()!.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      const testPage = await testContext.newPage();
+
+      try {
+        // Step 1: Navigate to files.* (not logged in) -> redirects to Keycloak
+        console.log('  [mlfiles] Step 1: Navigating to files (unauthenticated)...');
+        await testPage.goto(urls.files);
+        await testPage.waitForLoadState('load');
+
+        // Should be on Keycloak login page (either login.ftl or login-username.ftl)
+        await testPage.waitForURL(
+          url => url.hostname.startsWith('auth.'),
+          { timeout: 30_000 },
+        );
+        console.log(`  [mlfiles] Step 1: Redirected to Keycloak: ${testPage.url()}`);
+
+        // Step 2: Assert "Sign in with email link" is visible
+        const magicLinkOption = testPage.locator(kc.magicLinkLogin);
+        await expect(magicLinkOption).toBeVisible({ timeout: 15_000 });
+        console.log('  [mlfiles] Step 2: "Sign in with email link" is visible on Keycloak page');
+
+        // Step 3: Click the link -> arrives at account portal /magic-link-login
+        await magicLinkOption.click();
+        await testPage.waitForLoadState('load');
+
+        await testPage.waitForURL(
+          url => url.pathname.includes('/magic-link-login'),
+          { timeout: 15_000 },
+        );
+        console.log('  [mlfiles] Step 3: Arrived at account portal /magic-link-login');
+
+        // Step 4: Enter tenant email and submit
+        const emailInput = testPage.locator('#magicLinkEmail');
+        await expect(emailInput).toBeVisible({ timeout: 15_000 });
+        await emailInput.fill(tenantEmail);
+
+        await testPage.locator('button[type="submit"]').click();
+        console.log(`  [mlfiles] Step 4: Submitted email: ${tenantEmail}`);
+
+        // Step 5: Expect "Check your email" page
+        await testPage.waitForLoadState('load');
+        await expect(testPage.locator('text=Check your email')).toBeVisible({ timeout: 30_000 });
+        console.log('  [mlfiles] Step 5: "Check your email" page displayed');
+
+        // Step 6: Read magic-link login email from IMAP
+        console.log('  [mlfiles] Step 6: Polling IMAP for magic-link login email...');
+
+        const loginMagicEmail = await waitForEmailBody({
+          userEmail: TEST_USERS.emailTest.email,
+          bodyContains: uniqueId,
+          subjectContains: 'Sign in',
+          timeoutMs: 120_000,
+          pollIntervalMs: 3_000,
+        });
+
+        const decodedLoginEmail = loginMagicEmail
+          .replace(/=\r?\n/g, '')
+          .replace(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+
+        const loginMagicMatch = decodedLoginEmail.match(
+          /https:\/\/auth\.[^\s"<>]+(?:action-token|magic-link)[^\s"<>]*/,
+        );
+        const loginAuthFallback = decodedLoginEmail.match(/https:\/\/auth\.[^\s"<>]+/);
+        const loginMagicUrl = (loginMagicMatch?.[0] || loginAuthFallback?.[0])?.replace(/&amp;/g, '&');
+
+        expect(loginMagicUrl, 'Could not find magic-link URL in login email').toBeTruthy();
+        console.log(`  [mlfiles] Step 6: Magic-link URL: ${loginMagicUrl!.substring(0, 80)}...`);
+
+        // Step 7: Click magic-link URL -> authenticate -> /home
+        await testPage.goto(loginMagicUrl!);
+
+        await testPage.waitForURL(
+          url => url.pathname.includes('/home') || url.pathname.includes('/complete'),
+          { timeout: 60_000 },
+        );
+
+        const finalUrl = testPage.url();
+        if (finalUrl.includes('/complete')) {
+          await testPage.waitForURL(url => url.pathname.includes('/home'), { timeout: 30_000 });
+        }
+
+        await expect(
+          testPage.locator(selectors.accountPortal.welcomeHeading),
+        ).toBeVisible({ timeout: 15_000 });
+        console.log('  [mlfiles] Step 7: Magic-link login complete - user reached /home');
+
+        // Step 8: Navigate back to files.* -> SSO session auto-logs in
+        console.log('  [mlfiles] Step 8: Navigating back to files (should be SSO-authenticated)...');
+        await testPage.goto(urls.files);
+        await testPage.waitForLoadState('load');
+
+        // Should NOT be redirected back to Keycloak — SSO session is active.
+        // Nextcloud dashboard should load (the page stays on files.* hostname).
+        await testPage.waitForURL(
+          url => url.hostname.startsWith('files.'),
+          { timeout: 30_000 },
+        );
+        console.log(`  [mlfiles] Step 8: Files loaded with SSO: ${testPage.url()}`);
+
+      } finally {
+        await testContext.close();
+      }
+    } finally {
+      if (invitedUserId) {
+        await adminPage.evaluate(async (userId) => {
+          await fetch(`/api/users/${userId}`, { method: 'DELETE' });
+        }, invitedUserId).catch((err) => {
+          console.log(`  [mlfiles] Cleanup failed for ${username}: ${(err as Error).message}`);
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add "Sign in with email link" to both `login.ftl` and `login-username.ftl` Keycloak theme templates
- Link points to account portal's `/magic-link-login` page, constructed dynamically from the auth hostname
- Positioned between "Lost your passkey?" and "Guest? Register here" in the bottom links
- New E2E test verifies the full flow: files.* → Keycloak redirect → magic-link → SSO back to files

Closes #201

## Why

Users who onboarded via magic-link couldn't log in from non-account-portal properties (files, webmail, docs, jitsi, etc.) because Keycloak's login pages only offered passkey + Google. Since all properties funnel through Keycloak for authentication, adding the link to the FTL templates covers every property in one change.

## Test plan

- [x] Theme deployed to dev via `sync-keycloak-theme.sh`
- [ ] Visit `files.dev.*` unauthenticated → Keycloak login → "Sign in with email link" visible
- [ ] Visit `webmail.dev.*` → Keycloak login → link visible
- [ ] Click link → account portal `/magic-link-login` → complete flow → SSO works
- [ ] E2E: `magic-link-from-files.spec.ts` passes
- [ ] Existing magic-link E2E tests still pass

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues found. No real domains, credentials, PII, or private registry references.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 1 | **LOW**: 0

- **MEDIUM**: Client-side hostname replacement (`auth.` → `account.`) follows the same pre-existing pattern used by recovery link and guest registration link throughout the codebase. Low exploitability — requires attacker to control Keycloak's hostname (DNS + TLS misconfiguration). Not newly introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)