### PR TITLE
Always show magic-link signup option on WebAuthn registration page

### DIFF
--- a/apps/themes/platform/login/webauthn-register.ftl
+++ b/apps/themes/platform/login/webauthn-register.ftl
@@ -87,6 +87,13 @@
                 </a>
             </div>
 
+            <div id="magic-link-subtle" style="display:none; text-align: center; margin-top: 0.75rem; font-family: 'Figtree', sans-serif;">
+                <a id="magic-link-subtle-link" href="#"
+                   style="color: #6b6b6b; text-decoration: none; font-size: 0.9rem;">
+                    Sign up using a magic link instead
+                </a>
+            </div>
+
             <#if !isSetRetry?has_content && isAppInitiatedAction?has_content>
                 <div style="text-align: center; margin-top: 1.5rem;">
                     <form action="${url.loginAction}" method="post">
@@ -196,8 +203,41 @@
         </script>
         <script type="text/javascript" src="${url.resourcesCommonPath}/node_modules/base64url/dist/base64url.min.js"></script>
         <script type="text/javascript">
+            // Build the /switch-to-magic-link URL from the mt-setup-info cookie (set by /beginSetup).
+            // Returns the URL string, or null if the cookie is missing/invalid.
+            function buildSwitchToMagicLinkUrl() {
+                try {
+                    var cookies = document.cookie.split(';');
+                    for (var i = 0; i < cookies.length; i++) {
+                        var c = cookies[i].trim();
+                        if (c.indexOf('mt-setup-info=') === 0) {
+                            var payload = JSON.parse(atob(c.substring('mt-setup-info='.length).replace(/-/g, '+').replace(/_/g, '/')));
+                            var accountHost = window.location.hostname.replace(/^auth\./, 'account.');
+                            var currentUrl = window.location.href;
+                            return 'https://' + accountHost + '/switch-to-magic-link'
+                                + '?userId=' + encodeURIComponent(payload.userId)
+                                + '&token=' + encodeURIComponent(payload.token)
+                                + '&next=' + encodeURIComponent(currentUrl);
+                        }
+                    }
+                } catch(e) {
+                    // Cookie not found or invalid
+                }
+                return null;
+            }
+
+            // Show the always-visible subtle magic-link option (if cookie is available)
+            (function initSubtleMagicLink() {
+                var switchUrl = buildSwitchToMagicLinkUrl();
+                var subtleDiv = document.getElementById('magic-link-subtle');
+                if (switchUrl && subtleDiv) {
+                    document.getElementById('magic-link-subtle-link').href = switchUrl;
+                    subtleDiv.style.display = 'block';
+                }
+            })();
+
             // Detect whether this device has a platform authenticator (Touch ID, Windows Hello, etc.)
-            // If not, show the magic-link alternative for email-based sign-in.
+            // If not, show the prominent magic-link alternative for email-based sign-in.
             (function detectPlatformAuthenticator() {
                 if (typeof PublicKeyCredential === 'undefined' ||
                     typeof PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable !== 'function') {
@@ -217,29 +257,20 @@
 
             function showMagicLinkOption() {
                 document.getElementById('no-platform-auth-banner').style.display = 'block';
-                document.getElementById('magic-link-btn').style.display = 'block';
                 document.getElementById('registerBtn').style.display = 'none';
                 document.getElementById('register-btn-secondary').style.display = 'block';
 
-                // Build the switch URL from the mt-setup-info cookie (set by /beginSetup)
+                // Hide the subtle link — the prominent button replaces it
+                var subtleDiv = document.getElementById('magic-link-subtle');
+                if (subtleDiv) subtleDiv.style.display = 'none';
+
                 var magicBtn = document.getElementById('magic-link-btn');
-                try {
-                    var cookies = document.cookie.split(';');
-                    for (var i = 0; i < cookies.length; i++) {
-                        var c = cookies[i].trim();
-                        if (c.indexOf('mt-setup-info=') === 0) {
-                            var payload = JSON.parse(atob(c.substring('mt-setup-info='.length).replace(/-/g, '+').replace(/_/g, '/')));
-                            var accountHost = window.location.hostname.replace(/^auth\./, 'account.');
-                            var currentUrl = window.location.href;
-                            magicBtn.href = 'https://' + accountHost + '/switch-to-magic-link'
-                                + '?userId=' + encodeURIComponent(payload.userId)
-                                + '&token=' + encodeURIComponent(payload.token)
-                                + '&next=' + encodeURIComponent(currentUrl);
-                            return;
-                        }
-                    }
-                } catch(e) {
-                    // Cookie not found or invalid — hide the magic link button
+                var switchUrl = buildSwitchToMagicLinkUrl();
+                if (switchUrl) {
+                    magicBtn.href = switchUrl;
+                    magicBtn.style.display = 'block';
+                } else {
+                    // No cookie — revert to normal passkey UI
                     magicBtn.style.display = 'none';
                     document.getElementById('no-platform-auth-banner').style.display = 'none';
                     document.getElementById('registerBtn').style.display = 'block';

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -27,6 +27,8 @@ export const selectors = {
     adminPasswordInput: '#admin-login-form #password',
     passKeyLoginBtn: '#passkey-login-btn',
     magicLinkLogin: '#magic-link-login',
+    magicLinkSubtle: '#magic-link-subtle',
+    magicLinkSubtleLink: '#magic-link-subtle-link',
   },
 
   // ─── Account Portal ────────────────────────────────────────────────

--- a/e2e/tests/onboarding/onboarding-magic-link-flow.spec.ts
+++ b/e2e/tests/onboarding/onboarding-magic-link-flow.spec.ts
@@ -169,6 +169,9 @@ test.describe('Onboarding — Magic Link Flow (No Platform Authenticator)', () =
 
         await expect(userPage.locator('#register-btn-secondary')).toBeVisible();
 
+        // The subtle always-visible link should be hidden when the prominent banner is shown
+        await expect(userPage.locator('#magic-link-subtle')).not.toBeVisible();
+
         console.log('  [magic-link] Step 4: Banner and magic-link button verified');
 
         // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/e2e/tests/onboarding/webauthn-register-magic-link-option.spec.ts
+++ b/e2e/tests/onboarding/webauthn-register-magic-link-option.spec.ts
@@ -1,0 +1,205 @@
+import { test, expect } from '../../fixtures/authenticated';
+import { urls } from '../../helpers/urls';
+import { selectors } from '../../helpers/selectors';
+import { TEST_USERS } from '../../helpers/test-users';
+import { e2ePrefix } from '../../helpers/e2e-prefix';
+import { isImapConfigured, waitForEmailBody } from '../../helpers/imap';
+
+const baseDomain = urls.baseDomain;
+
+/**
+ * E2E test for the always-visible magic-link option on the WebAuthn registration page.
+ *
+ * Verifies that users whose device DOES support passkeys still see a subtle
+ * "Sign up using a magic link instead" link as an alternative to passkey
+ * registration. This is separate from the prominent banner/button shown when
+ * the device lacks a platform authenticator (tested in onboarding-magic-link-flow).
+ *
+ * Flow:
+ * 1. Admin portal: invite a new user
+ * 2. IMAP: read invitation email, extract setup URL
+ * 3. Navigate to setup URL WITH virtual authenticator (device supports passkeys)
+ * 4. Assert: subtle magic-link link is visible, Register Passkey button is visible,
+ *    no-platform-auth banner is NOT visible
+ * 5. Click subtle magic-link link → /switch-to-magic-link → "Check your email" page
+ */
+test.describe('WebAuthn Register — Always-Visible Magic Link Option', () => {
+  test.setTimeout(300_000);
+
+  test('subtle magic-link link is visible when device supports passkeys', async ({ adminPage }) => {
+    test.skip(!isImapConfigured(), 'IMAP not configured (E2E_STALWART_ADMIN_PASSWORD not set)');
+
+    const ap = selectors.adminPortal;
+    const kc = selectors.keycloak;
+    const uniqueId = `${Date.now()}`;
+    const username = `${e2ePrefix('mlsub')}-${uniqueId}`;
+    const firstName = `MLSub${uniqueId}`;
+    const lastName = 'E2ETest';
+    const recoveryEmail = `e2e-mailrt+mlsub-${uniqueId}@${baseDomain}`;
+
+    let invitedUserId: string | null = null;
+
+    try {
+      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      // Step 1: Admin Portal — Create invitation
+      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+      await adminPage.fill(ap.firstNameInput, firstName);
+      await adminPage.fill(ap.lastNameInput, lastName);
+      await adminPage.fill(ap.emailUsernameInput, username);
+      await adminPage.fill(ap.recoveryEmailInput, recoveryEmail);
+
+      const responsePromise = adminPage.waitForResponse(
+        (r) => r.url().includes('/api/invite') && r.request().method() === 'POST',
+      );
+      await adminPage.click(ap.inviteSubmitBtn);
+      const apiResponse = await responsePromise;
+      const apiResult = await apiResponse.json();
+      invitedUserId = apiResult.userId || null;
+
+      await expect(adminPage.locator(ap.formMessage)).toBeVisible({ timeout: 30_000 });
+      const messageText = await adminPage.locator(ap.formMessage).textContent();
+      expect(messageText).toContain('successfully');
+
+      console.log(`  [ml-subtle] Invite sent: userId=${invitedUserId}`);
+
+      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      // Step 2: Read invitation email
+      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+      const rawEmail = await waitForEmailBody({
+        userEmail: TEST_USERS.emailTest.email,
+        bodyContains: uniqueId,
+        timeoutMs: 180_000,
+        pollIntervalMs: 3_000,
+      });
+
+      const decodedEmail = rawEmail
+        .replace(/=\r?\n/g, '')
+        .replace(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+
+      const urlMatch = decodedEmail.match(/https:\/\/account\.[^\s"<>]+beginSetup[^\s"<>]+/);
+      const actionUrlFallback = decodedEmail.match(/https:\/\/auth\.[^\s"<>]+action-token[^\s"<>]+/);
+      let setupUrl = (urlMatch?.[0] || actionUrlFallback?.[0])?.replace(/&amp;/g, '&');
+
+      if (setupUrl?.includes('beginSetup?userId=&') || setupUrl?.includes('beginSetup?userId=&amp;')) {
+        const nextParam = new URL(setupUrl).searchParams.get('next');
+        if (nextParam) {
+          console.log('  [ml-subtle] beginSetup has empty userId — using next param directly');
+          setupUrl = nextParam;
+        }
+      }
+
+      expect(setupUrl, 'Could not find setup URL in invitation email').toBeTruthy();
+      console.log(`  [ml-subtle] Setup URL: ${setupUrl!.substring(0, 80)}...`);
+
+      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      // Step 3: Navigate to setup WITH virtual authenticator
+      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+      const userContext = await adminPage.context().browser()!.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      const userPage = await userContext.newPage();
+
+      try {
+        // Enable CDP virtual authenticator — device "supports" passkeys
+        const cdpSession = await userPage.context().newCDPSession(userPage);
+        await cdpSession.send('WebAuthn.enable');
+        await cdpSession.send('WebAuthn.addVirtualAuthenticator', {
+          options: {
+            protocol: 'ctap2',
+            transport: 'internal',
+            hasResidentKey: true,
+            hasUserVerification: true,
+            isUserVerified: true,
+          },
+        });
+
+        console.log('  [ml-subtle] Step 3: Navigating to setup URL (with virtual authenticator)...');
+        await userPage.goto(setupUrl!);
+        await userPage.waitForLoadState('load');
+        console.log(`  [ml-subtle] Step 3: Landed on ${userPage.url().substring(0, 80)}`);
+
+        // Handle "Click here to proceed" intermediate page
+        const proceedLink = userPage.locator('a:has-text("Click here to proceed"), a:has-text("click here")');
+        const registerBtn = userPage.locator('#registerBtn, button:has-text("Register Passkey")');
+
+        const firstVisible = await Promise.race([
+          proceedLink.first().waitFor({ timeout: 30_000 }).then(() => 'proceed' as const),
+          registerBtn.first().waitFor({ timeout: 30_000 }).then(() => 'register' as const),
+        ]).catch(() => 'timeout' as const);
+
+        if (firstVisible === 'proceed') {
+          console.log('  [ml-subtle] Step 3: Clicking "proceed" on action token info page...');
+          await proceedLink.first().click();
+          await userPage.waitForLoadState('load');
+        } else if (firstVisible === 'timeout') {
+          const visibleText = await userPage.evaluate(() => {
+            const el = document.querySelector('#kc-content-wrapper') || document.body;
+            return el?.innerText || '';
+          }).catch(() => '');
+          throw new Error(`Neither proceed link nor register button found. URL: ${userPage.url()}, text: ${visibleText.substring(0, 300)}`);
+        }
+
+        // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+        // Step 4: Verify page state — subtle link visible, banner NOT visible
+        // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+        // Wait for the Register Passkey button (confirms we're on the right page)
+        await expect(userPage.locator('#registerBtn')).toBeVisible({ timeout: 15_000 });
+
+        // The subtle magic-link link should be visible
+        const subtleLink = userPage.locator(kc.magicLinkSubtle);
+        await expect(subtleLink).toBeVisible({ timeout: 10_000 });
+        console.log('  [ml-subtle] Step 4: Subtle magic-link link is visible');
+
+        // The link text should match
+        await expect(userPage.locator(kc.magicLinkSubtleLink)).toContainText('magic link');
+
+        // The href should point to /switch-to-magic-link
+        const href = await userPage.locator(kc.magicLinkSubtleLink).getAttribute('href');
+        expect(href).toContain('/switch-to-magic-link');
+        expect(href).toContain('userId=');
+        expect(href).toContain('token=');
+        console.log(`  [ml-subtle] Step 4: Link href verified: ${href!.substring(0, 80)}...`);
+
+        // The no-platform-auth banner should NOT be visible (device supports passkeys)
+        await expect(userPage.locator('#no-platform-auth-banner')).not.toBeVisible();
+
+        // The prominent magic-link button should NOT be visible
+        await expect(userPage.locator('#magic-link-btn')).not.toBeVisible();
+
+        // The "I have a security key" secondary option should NOT be visible
+        await expect(userPage.locator('#register-btn-secondary')).not.toBeVisible();
+
+        console.log('  [ml-subtle] Step 4: All visibility assertions passed');
+
+        // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+        // Step 5: Click subtle link → verify "Check your email" page
+        // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+        await userPage.locator(kc.magicLinkSubtleLink).click();
+        console.log('  [ml-subtle] Step 5: Clicked subtle magic-link link');
+
+        await userPage.waitForLoadState('load');
+        await expect(
+          userPage.locator('text=Check your email'),
+        ).toBeVisible({ timeout: 30_000 });
+
+        console.log('  [ml-subtle] Step 5: "Check your email" page displayed — test passed');
+
+      } finally {
+        await userContext.close();
+      }
+    } finally {
+      if (invitedUserId) {
+        await adminPage.evaluate(async (userId) => {
+          await fetch(`/api/users/${userId}`, { method: 'DELETE' });
+        }, invitedUserId).catch((err) => {
+          console.log(`  [ml-subtle] Cleanup failed for ${username}: ${(err as Error).message}`);
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a subtle "Sign up using a magic link instead" link on the WebAuthn registration page, always visible when the `mt-setup-info` cookie is present
- When the device lacks a platform authenticator, the existing prominent banner + button is shown and the subtle link is hidden (no redundancy)
- Refactors cookie-based URL construction into a reusable `buildSwitchToMagicLinkUrl()` function

Closes #203

## Test plan

- [ ] New E2E test (`webauthn-register-magic-link-option.spec.ts`): verifies the subtle link is visible with a virtual authenticator, Register Passkey button is visible, no-platform-auth banner is NOT visible, and clicking the link reaches the "Check your email" page
- [ ] Updated existing magic-link E2E test: verifies the subtle link is hidden when the no-platform-auth detection fires
- [ ] CI green across all shards

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — No issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 2 (informational) | **LOW**: 1

- **MEDIUM**: Cookie values used in URL are `encodeURIComponent()`-encoded and server-side HMAC-validated — no XSS or auth bypass risk. Pre-existing pattern, just refactored.
- **MEDIUM**: Hostname derivation via `hostname.replace(/^auth\./, 'account.')` — pre-existing pattern, not exploitable in current deployment.
- **LOW**: `mt-setup-info` cookie is non-httpOnly by design (contains HMAC token, not session credential).

No critical or high findings. All cookie-derived values are URL-encoded and server-side validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)