### PR TITLE
Fix external images blocked in Roundcube by CSP policy

### DIFF
--- a/apps/manifests/roundcube/ingress.yaml.tpl
+++ b/apps/manifests/roundcube/ingress.yaml.tpl
@@ -29,7 +29,7 @@ metadata:
       proxy_hide_header X-Frame-Options;
       proxy_hide_header Content-Security-Policy;
       # CSP - Roundcube needs unsafe-inline for its UI, and connects to auth for OIDC
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'self'; form-action 'self' https://*.${TENANT_DOMAIN}; base-uri 'self';" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self'; form-action 'self' https://*.${TENANT_DOMAIN}; base-uri 'self';" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header X-Frame-Options "SAMEORIGIN" always;
       add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary

- The `Content-Security-Policy` header on the Roundcube ingress had `img-src 'self' data:` which blocked all external image URLs at the browser level — even when Roundcube decided to display them (sender in contacts/trusted senders)
- Add `https:` to `img-src` to allow external HTTPS images, which is standard for webmail clients

Closes #207

## Root Cause

The CSP was written as a generic security-hardening default, but webmail clients inherently need to display external images. Roundcube's `show_images = 1` setting correctly decides whether to render `<img>` tags (only for senders in address book), but the browser's CSP enforcement silently blocked the network request before it could load. No "Show images" button appeared because Roundcube already decided to show them.

## Test plan

- [ ] Deploy to dev tenants and verify external images display for trusted senders
- [ ] Check browser DevTools Network tab — image requests should succeed (no CSP violations in Console)
- [ ] Verify `curl -sI https://webmail.<domain>/ | grep content-security-policy` shows `img-src 'self' data: https:`
- [ ] Deploy to prod tenants

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — No issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 1 | **LOW**: 0

- **MEDIUM**: CSP `img-src` broadened to all HTTPS origins — inherent and well-understood tradeoff for webmail (tracking pixels). Mitigated by: `https:` only (no mixed content), existing `Referrer-Policy: strict-origin-when-cross-origin`, and Roundcube's `show_images = 1` which only renders images for contacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)