### PR TITLE
Fix missing Keycloak user profile attributes breaking magic-link flow

### DIFF
--- a/docs/import-keycloak-realm.sh
+++ b/docs/import-keycloak-realm.sh
@@ -1830,6 +1830,62 @@ else
     fi
 fi
 
+# Ensure user profile attributes required by the invitation flow are registered.
+# Keycloak 26.x enforces User Profile — unregistered attributes are invisible
+# in email templates, breaking the beginSetup URL generation.
+print_status "Configuring user profile attributes..."
+CURRENT_PROFILE=$(curl -s ${KEYCLOAK_SKIP_SSL_VERIFY} \
+  "$KEYCLOAK_URL/admin/realms/$TENANT_KEYCLOAK_REALM/users/profile" \
+  -H "Authorization: Bearer $ACCESS_TOKEN")
+
+REQUIRED_ATTRS='["beginSetupToken","isRecoveryFlow","setupUserId"]'
+MISSING_ATTRS=$(echo "$CURRENT_PROFILE" | python3 -c "
+import json, sys
+profile = json.load(sys.stdin)
+existing = {a['name'] for a in profile.get('attributes', [])}
+required = $REQUIRED_ATTRS
+missing = [r for r in required if r not in existing]
+print(json.dumps(missing))
+")
+
+if [ "$MISSING_ATTRS" = "[]" ]; then
+    print_success "All required user profile attributes already registered"
+else
+    print_status "Adding missing attributes: $MISSING_ATTRS"
+    UPDATED_PROFILE=$(echo "$CURRENT_PROFILE" | python3 -c "
+import json, sys
+profile = json.load(sys.stdin)
+existing = {a['name'] for a in profile.get('attributes', [])}
+required = $REQUIRED_ATTRS
+admin_only_attr = {
+    'permissions': {'view': ['admin'], 'edit': ['admin']},
+    'multivalued': False
+}
+for name in required:
+    if name not in existing:
+        profile['attributes'].append({
+            'name': name,
+            **admin_only_attr
+        })
+print(json.dumps(profile))
+")
+
+    UP_RESULT=$(curl -s ${KEYCLOAK_SKIP_SSL_VERIFY} -w "%{http_code}" -o /tmp/user_profile_update.json -X PUT \
+      "$KEYCLOAK_URL/admin/realms/$TENANT_KEYCLOAK_REALM/users/profile" \
+      -H "Authorization: Bearer $ACCESS_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "$UPDATED_PROFILE")
+
+    if [ "$UP_RESULT" = "200" ]; then
+        print_success "User profile attributes updated"
+    else
+        print_warning "Failed to update user profile (HTTP $UP_RESULT)"
+        if [ -f /tmp/user_profile_update.json ]; then
+            print_warning "Details: $(cat /tmp/user_profile_update.json)"
+        fi
+    fi
+fi
+
 # Create tenant-admin role if it doesn't exist
 print_status "Ensuring tenant-admin role exists..."
 TENANT_ADMIN_ROLE_CHECK=$(curl -s ${KEYCLOAK_SKIP_SSL_VERIFY} -w "%{http_code}" -o /tmp/tenant_admin_role.json \

--- a/e2e/tests/onboarding/login-magic-link-flow.spec.ts
+++ b/e2e/tests/onboarding/login-magic-link-flow.spec.ts
@@ -84,6 +84,13 @@ test.describe('Login — Magic Link Flow (Returning User)', () => {
       const actionUrlFallback = decodedEmail.match(/https:\/\/auth\.[^\s"<>]+action-token[^\s"<>]+/);
       let setupUrl = (urlMatch?.[0] || actionUrlFallback?.[0])?.replace(/&amp;/g, '&');
 
+      // The email MUST contain a beginSetup URL (not a direct Keycloak action-token link).
+      // If it doesn't, the Keycloak realm is missing user profile attributes
+      // (setupUserId, beginSetupToken, isRecoveryFlow) — see docs/import-keycloak-realm.sh.
+      expect(urlMatch, 'Invitation email should contain a beginSetup URL, not a direct Keycloak link. ' +
+        'Check that the Keycloak realm has setupUserId, beginSetupToken, and isRecoveryFlow ' +
+        'registered in the User Profile configuration.').toBeTruthy();
+
       if (setupUrl?.includes('beginSetup?userId=&') || setupUrl?.includes('beginSetup?userId=&amp;')) {
         const nextParam = new URL(setupUrl).searchParams.get('next');
         if (nextParam) setupUrl = nextParam;


### PR DESCRIPTION
## Summary

- Root cause of flaky magic-link E2E test failures on the innba tenant: Keycloak 26.x User Profile enforcement hides unregistered custom attributes from email templates
- The `docs` (mothertree) realm had `setupUserId`, `beginSetupToken`, and `isRecoveryFlow` manually configured; `innba` did not
- Without these, invitation emails skip the `/beginSetup` URL, so the `mt-setup-info` cookie is never set, and `#magic-link-btn` stays hidden
- **Already fixed on dev innba** via kcadm — this PR ensures it's provisioned automatically for all tenants

## Changes

- `docs/import-keycloak-realm.sh`: Add user profile attribute provisioning (idempotent — checks for existing attributes before adding)
- `e2e/tests/onboarding/login-magic-link-flow.spec.ts`: Add assertion that invitation email contains a `beginSetup` URL, with a diagnostic message pointing to the fix if it doesn't

## Test plan

- [ ] CI build passes (innba realm already fixed manually)
- [ ] Verify `import-keycloak-realm.sh` is idempotent (re-running doesn't duplicate attributes)
- [ ] Magic-link tests pass on both mothertree and innba tenants

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — Clean.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 1 (pre-existing `/tmp` file pattern) | **LOW**: 1 (positive: admin-only permissions on new attributes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)