### PR TITLE
Update prerequisites docs with complete CLI tool list and install guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,18 @@ Thank you for your interest in contributing to Mothertree! This document provide
    make setup  # Initialize submodules if you have access
    ```
 
-2. **Install prerequisites**
+2. **Install prerequisites** (see [tool installation guide](#installing-cli-tools) below)
    - `terraform` >= 1.0
-   - `kubectl`
+   - `kubectl` >= 1.27
    - `helm` >= 3.0
-   - `helmfile`
+   - `helmfile` >= 1.0
+   - `kustomize` >= 5.0
    - `yq` >= 4.0
-   - `node` >= 18 (for admin-portal and account-portal)
+   - `jq`
+   - `envsubst` (from `gettext`)
+   - `openssl`
+   - `curl`
+   - `node` >= 22 LTS (for admin-portal and account-portal)
 
 3. **Set up tenant configuration**
    ```bash
@@ -52,6 +57,158 @@ npm install
 cp .env.example .env  # Edit with your settings
 npm start
 ```
+
+## Installing CLI Tools
+
+### macOS (Homebrew)
+
+```bash
+# Core tools — all available via Homebrew
+brew install terraform kubectl helm helmfile kustomize yq jq gettext openssl curl node@22
+
+# gettext (provides envsubst) needs to be linked since it's keg-only
+brew link --force gettext
+
+# Verify
+terraform version && kubectl version --client && helm version && helmfile version && \
+kustomize version && yq --version && jq --version && envsubst --version && node --version
+```
+
+Optional tools:
+```bash
+brew install ansible gh dig swaks postgresql linode-cli docker
+```
+
+### Linux (Fedora / RHEL / CentOS)
+
+Most tools are **not available** via `dnf` in compatible versions. Install from upstream releases.
+
+> **Warning**: On Fedora, running an uninstalled command may create a PackageKit stub script instead of reporting "command not found". Always verify tools work correctly after installing — run `<tool> version` and check the output makes sense.
+
+```bash
+# System packages (available via dnf)
+sudo dnf install -y jq gettext openssl curl git
+
+# Node.js 22 LTS (via NodeSource)
+curl -fsSL https://rpm.nodesource.com/setup_22.x | sudo bash -
+sudo dnf install -y nodejs
+
+# kubectl
+curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && rm kubectl
+
+# Terraform
+sudo dnf install -y dnf-plugins-core
+sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
+sudo dnf install -y terraform
+
+# Helm
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# Helmfile — must be v1.x, not v0.x (check latest: https://github.com/helmfile/helmfile/releases)
+curl -fsSL -o /tmp/helmfile.tar.gz https://github.com/helmfile/helmfile/releases/download/v1.4.2/helmfile_1.4.2_linux_amd64.tar.gz
+tar xzf /tmp/helmfile.tar.gz -C /tmp helmfile
+sudo mv /tmp/helmfile /usr/local/bin/helmfile && rm /tmp/helmfile.tar.gz
+
+# Kustomize (check latest: https://github.com/kubernetes-sigs/kustomize/releases)
+curl -fsSL -o /tmp/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.6.0/kustomize_v5.6.0_linux_amd64.tar.gz
+tar xzf /tmp/kustomize.tar.gz -C /tmp
+sudo mv /tmp/kustomize /usr/local/bin/kustomize && rm /tmp/kustomize.tar.gz
+
+# yq (check latest: https://github.com/mikefarah/yq/releases)
+curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64
+sudo install -o root -g root -m 0755 /tmp/yq /usr/local/bin/yq && rm /tmp/yq
+
+# Verify all tools
+terraform version && kubectl version --client && helm version && helmfile version && \
+kustomize version && yq --version && jq --version && envsubst --version && node --version
+```
+
+Optional tools:
+```bash
+# Ansible (for VPN/Postfix relay setup)
+sudo dnf install -y ansible-core
+
+# GitHub CLI
+sudo dnf install -y 'dnf-command(config-manager)'
+sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf install -y gh
+
+# Other optional tools
+sudo dnf install -y bind-utils swaks postgresql docker-ce
+```
+
+### Linux (Ubuntu / Debian)
+
+```bash
+# System packages
+sudo apt-get update && sudo apt-get install -y jq gettext-base openssl curl git
+
+# Node.js 22 LTS (via NodeSource)
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
+sudo apt-get install -y nodejs
+
+# kubectl
+curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && rm kubectl
+
+# Terraform
+wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt-get update && sudo apt-get install -y terraform
+
+# Helm
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# Helmfile — must be v1.x, not v0.x (check latest: https://github.com/helmfile/helmfile/releases)
+curl -fsSL -o /tmp/helmfile.tar.gz https://github.com/helmfile/helmfile/releases/download/v1.4.2/helmfile_1.4.2_linux_amd64.tar.gz
+tar xzf /tmp/helmfile.tar.gz -C /tmp helmfile
+sudo mv /tmp/helmfile /usr/local/bin/helmfile && rm /tmp/helmfile.tar.gz
+
+# Kustomize (check latest: https://github.com/kubernetes-sigs/kustomize/releases)
+curl -fsSL -o /tmp/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.6.0/kustomize_v5.6.0_linux_amd64.tar.gz
+tar xzf /tmp/kustomize.tar.gz -C /tmp
+sudo mv /tmp/kustomize /usr/local/bin/kustomize && rm /tmp/kustomize.tar.gz
+
+# yq (check latest: https://github.com/mikefarah/yq/releases)
+curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64
+sudo install -o root -g root -m 0755 /tmp/yq /usr/local/bin/yq && rm /tmp/yq
+
+# Verify all tools
+terraform version && kubectl version --client && helm version && helmfile version && \
+kustomize version && yq --version && jq --version && envsubst --version && node --version
+```
+
+Optional tools:
+```bash
+# Ansible (for VPN/Postfix relay setup)
+sudo apt-get install -y ansible
+
+# GitHub CLI (https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
+(type -p wget >/dev/null || sudo apt-get install wget -y) \
+  && sudo mkdir -p -m 755 /etc/apt/keyrings \
+  && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+  && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && sudo apt-get update && sudo apt-get install gh -y
+
+# Other optional tools
+sudo apt-get install -y dnsutils swaks postgresql-client docker.io
+```
+
+### Verifying Your Setup
+
+After installing all tools, run the verification one-liner:
+
+```bash
+echo "--- Tool Versions ---" && \
+for cmd in terraform kubectl helm helmfile kustomize yq jq envsubst openssl curl node; do
+  printf "%-12s " "$cmd:" && ($cmd --version 2>/dev/null || $cmd version 2>/dev/null) | head -1
+done
+```
+
+All commands should print a version. If any command prints package metadata, help text, or errors instead of a version, the binary is likely a stub or the wrong tool — reinstall it from the upstream source.
 
 ## Making Changes
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,42 @@ Multi-tenant collaboration platform on Kubernetes. Provides Matrix (chat), Eleme
 
 ### Prerequisites
 
+**Accounts:**
 - Linode account with API token
 - Cloudflare account with API token and zone ID
 - A domain with DNS managed by Cloudflare
-- `terraform`, `kubectl`, `helm`, `helmfile`, `yq` installed
+
+**Required CLI tools:**
+
+| Tool | Min Version | Purpose |
+|------|-------------|---------|
+| `terraform` | >= 1.0 | Infrastructure provisioning (LKE, DNS, VPN) |
+| `kubectl` | >= 1.27 | Kubernetes cluster management |
+| `helm` | >= 3.0 | Kubernetes package management |
+| `helmfile` | >= 1.0 | Multi-chart Helm orchestration (v0.x will **not** work) |
+| `kustomize` | >= 5.0 | Kubernetes manifest customization (helmfile exec dependency) |
+| `yq` | >= 4.0 | YAML parsing (tenant config files) |
+| `jq` | any | JSON parsing (API responses, secrets) |
+| `envsubst` | any | Template variable substitution (from `gettext` package) |
+| `openssl` | any | TLS cert and secret generation |
+| `curl` | any | HTTP API calls |
+| `node` | >= 22 LTS | Admin and account portal development |
+
+> **Note**: `kustomize` is not called directly by any deploy script, but helmfile invokes it internally. If missing, helmfile will fail with `exec: "kustomize": executable file not found in $PATH`.
+
+**Optional tools** (auto-detected; scripts degrade gracefully if absent):
+
+| Tool | When needed |
+|------|-------------|
+| `ansible-playbook` | VPN/Postfix relay setup (required by `deploy_infra` VPN section) |
+| `docker` | Building container images |
+| `gh` | GitHub CLI (PR workflows) |
+| `dig` | DNS verification in `deploy_infra` and `verify-endpoints` (skipped if missing) |
+| `swaks` | Email delivery testing in `test-email-system` (skipped if missing) |
+| `psql` | Direct PostgreSQL administration |
+| `linode-cli` | Linode resource management, S3 buckets, teardown (skipped if missing) |
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed installation instructions on macOS and Linux.
 
 ### 1. Configure
 


### PR DESCRIPTION
## Summary

- Expand README prerequisites from a one-liner into full tables covering 11 required tools (with min versions) and 7 optional tools
- Add "Installing CLI Tools" section to CONTRIBUTING.md with platform-specific instructions for macOS (Homebrew), Fedora/RHEL (upstream binaries), and Ubuntu/Debian
- Include a verification one-liner to catch stub binaries (like the Fedora PackageKit issue we hit)

Motivated by a new Linux developer hitting missing `helmfile` and `kustomize` errors during their first deploy — each tool was only discovered at the point of failure mid-deploy.

Closes #225

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues. All content is generic installation instructions with upstream URLs.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 3 | **LOW**: 0

Three MEDIUM findings — all standard patterns from official upstream install docs:
- `curl | bash` patterns for NodeSource and Helm (upstream-documented method)
- `wget | gpg` for HashiCorp APT key (upstream-documented method)
- No SHA256 checksum verification on binary downloads (HTTPS provides transport integrity)

All URLs verified to point to legitimate first-party sources. No code changes — documentation only.

## Test plan

- [ ] Verify README prerequisites table renders correctly on GitHub
- [ ] Verify CONTRIBUTING.md anchor link to "Installing CLI Tools" works
- [ ] Spot-check one Linux install command (e.g., helmfile download URL returns 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)