### PR TITLE
Fix Roundcube compose button race condition in E2E tests

### DIFF
--- a/e2e/tests/email/email-roundtrip.spec.ts
+++ b/e2e/tests/email/email-roundtrip.spec.ts
@@ -55,6 +55,12 @@ test.describe('Email — Round-Trip via Echo Group', () => {
     // ── Step 1: Sender logs into Roundcube and sends email to the echo group ──
     await roundcubeLogin(senderPage, sender.username, sender.password);
 
+    // Wait for Roundcube JS app to finish initializing (rcmail.busy clears
+    // after IMAP inbox load completes — large inboxes delay this)
+    await senderPage.waitForFunction(
+      () => window.rcmail && window.rcmail.task === 'mail' && !window.rcmail.busy,
+      { timeout: 30_000 },
+    );
     await senderPage.getByRole('button', { name: 'Compose' }).click();
     const subjectInput = senderPage.getByRole('textbox', { name: 'Subject' });
     await subjectInput.waitFor({ timeout: 15_000 });

--- a/e2e/tests/email/inbound-email-new-user.spec.ts
+++ b/e2e/tests/email/inbound-email-new-user.spec.ts
@@ -75,6 +75,12 @@ test.describe('Email — Inbound Delivery to New User (#189)', () => {
       const sender = TEST_USERS.emailTest;
       await roundcubeLogin(senderPage, sender.username, sender.password);
 
+      // Wait for Roundcube JS app to finish initializing (rcmail.busy clears
+      // after IMAP inbox load completes — large inboxes delay this)
+      await senderPage.waitForFunction(
+        () => window.rcmail && window.rcmail.task === 'mail' && !window.rcmail.busy,
+        { timeout: 30_000 },
+      );
       await senderPage.getByRole('button', { name: 'Compose' }).click();
       const subjectInput = senderPage.getByRole('textbox', { name: 'Subject' });
       await subjectInput.waitFor({ timeout: 15_000 });

--- a/e2e/tests/email/roundcube-basic.spec.ts
+++ b/e2e/tests/email/roundcube-basic.spec.ts
@@ -102,6 +102,15 @@ test.describe('Email — Roundcube Basic', () => {
   test('can open compose form', async ({ emailTestPage: page }) => {
     await navigateToRoundcube(page, TEST_USERS.emailTest.username, TEST_USERS.emailTest.password);
 
+    // Wait for Roundcube JS app to finish initializing before clicking.
+    // The Compose button element appears in the DOM before rcmail.init() binds
+    // the click handler. With large inboxes, IMAP init takes longer and clicks
+    // during this window silently do nothing.
+    await page.waitForFunction(
+      () => window.rcmail && window.rcmail.task === 'mail' && !window.rcmail.busy,
+      { timeout: 30_000 },
+    );
+
     // Click compose button
     await page.locator('button:has-text("Compose"), a.compose, [data-command="compose"]').first().click();
 


### PR DESCRIPTION
## Summary

- Fix consistent shard-5 E2E failure: `can open compose form` test
- Root cause: the Compose button DOM element appears before Roundcube's `rcmail.init()` binds the click handler. With 360-852 accumulated emails in the `e2e-mailrt` inbox, IMAP initialization takes longer, widening the race window where clicks silently do nothing.
- Fix: add `waitForFunction(() => window.rcmail && rcmail.task === 'mail' && !rcmail.busy)` before clicking Compose in all 3 affected test files

## Diagnosis

- SSH'd into CI box, examined Playwright screenshots from failed runs
- Screenshots show inbox fully loaded (360 messages) but page stays on inbox after clicking Compose — compose view never loads
- The `navigateToRoundcube` helper returns as soon as `button:has-text("Compose")` appears (part of `ROUNDCUBE_INBOX` selector), but `rcmail` JS may still be initializing

## Test plan

- [x] CI pipeline will validate the fix (shard-5 should pass)
- Same fix applied to `inbound-email-new-user.spec.ts` (was flaky) and `email-roundtrip.spec.ts` (preventive)

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — Clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)