### PR TITLE
Randomize CI pool slot iteration order

### DIFF
--- a/ci/scripts/ci-lease-tenant.sh
+++ b/ci/scripts/ci-lease-tenant.sh
@@ -36,7 +36,9 @@ LEASED_POOL=""
 ELAPSED=0
 
 while [[ -z "$LEASED_POOL" ]]; do
-  for pool in "${POOLS[@]}"; do
+  # Shuffle pool order so concurrent pipelines don't all contend on slot 1
+  mapfile -t SHUFFLED < <(printf '%s\n' "${POOLS[@]}" | sort -R)
+  for pool in "${SHUFFLED[@]}"; do
     KEY="ci-lease-${pool}"
     # SET NX EX: atomic "create if not exists" with TTL
     RESULT=$(vcli SET "$KEY" "$CI_PIPELINE_NUMBER" NX EX "$LEASE_TTL" 2>/dev/null || true)


### PR DESCRIPTION
## Summary
- Shuffles the CI tenant lease pool slots randomly on each attempt instead of always iterating from pool1
- Reduces contention when concurrent pipelines start simultaneously
- Uses `mapfile` + `sort -R` for safe array population (no word-splitting risks)

## OSS Compliance Review
**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0
No issues found. All domains use env vars, no credentials or tenant names hardcoded.

## Security Review
**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 1
- **LOW**: `sort -R` is GNU-only (not available on macOS BSD sort), but this script only runs on the Linux CI server.

No TOCTOU or command injection risks — the `SET NX EX` Valkey command remains the atomicity boundary.

## Test plan
- [ ] Verify CI lease acquisition still works on next pipeline run
- [ ] Confirm pool slot is logged correctly in lease output

🤖 Generated with [Claude Code](https://claude.com/claude-code)