### PR TITLE
fix: correct Unbound Ansible tasks for Docker volume mount

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -311,6 +311,8 @@
     # --- Unbound DNS for internal service resolution ---
     # Monitoring services resolve to NODE_IP (NodePort access).
     # Web services resolve to CLUSTER_IP (NodeBalancer, bypasses Cloudflare for VPN debugging).
+    # Unbound runs in Docker with unbound.conf mounted. We add a conf.d volume
+    # for DNS overrides so the base config stays untouched.
     - name: Ensure Unbound conf.d directory exists
       file:
         path: /opt/unbound/conf.d
@@ -320,11 +322,20 @@
         mode: '0755'
       when: cluster_node_ip is defined
 
-    - name: Ensure Unbound includes conf.d
+    - name: Add conf.d volume mount to Unbound docker-compose
+      lineinfile:
+        path: /opt/unbound/docker-compose.yml
+        regexp: 'conf\.d:/opt/unbound/etc/unbound/conf\.d'
+        line: '      - ./conf.d:/opt/unbound/etc/unbound/conf.d:ro'
+        insertafter: 'unbound\.conf:/opt/unbound/etc/unbound/unbound\.conf'
+      notify: recreate unbound
+      when: cluster_node_ip is defined
+
+    - name: Ensure Unbound includes conf.d (container path)
       lineinfile:
         path: /opt/unbound/unbound.conf
-        regexp: '^include: "/opt/unbound/conf.d/\*\.conf"'
-        line: 'include: "/opt/unbound/conf.d/*.conf"'
+        regexp: 'include:.*conf\.d/\*\.conf'
+        line: 'include: "/opt/unbound/etc/unbound/conf.d/*.conf"'
         insertbefore: '^stub-zone:'
       notify: restart unbound
       when: cluster_node_ip is defined
@@ -340,6 +351,11 @@
       when: cluster_node_ip is defined and cluster_lb_ip is defined and internal_dns_domain is defined
 
   handlers:
+    - name: recreate unbound
+      shell: cd /opt/unbound && docker-compose down && docker-compose up -d
+      retries: 3
+      delay: 2
+
     - name: restart unbound
       shell: cd /opt/unbound && docker-compose restart
       retries: 3

--- a/ansible/templates/unbound-local-data.conf.j2
+++ b/ansible/templates/unbound-local-data.conf.j2
@@ -5,8 +5,6 @@
 # Web services → cluster LB IP (NodeBalancer, bypasses Cloudflare)
 
 server:
-    local-zone: "{{ internal_dns_domain }}." transparent
-
     # Monitoring services (NodePort access via node IP)
     local-data: "grafana.{{ internal_dns_domain }}. IN A {{ cluster_node_ip }}"
     local-data: "prometheus.{{ internal_dns_domain }}. IN A {{ cluster_node_ip }}"


### PR DESCRIPTION
## Summary

Fixes the Unbound DNS Ansible tasks from #249 which broke Unbound on dev because the conf.d include path was a host path, not a container path.

### What was broken

Unbound runs in Docker with only `unbound.conf` mounted. The `include: "/opt/unbound/conf.d/*.conf"` directive used a host path — inside the container, the config lives at `/opt/unbound/etc/unbound/`. Unbound crashed with:
```
error: cannot open include file '/opt/unbound/conf.d/*.conf': No such file or directory
```

### Fixes

1. **New task**: Adds `./conf.d:/opt/unbound/etc/unbound/conf.d:ro` volume mount to `docker-compose.yml`
2. **Fixed include path**: `include: "/opt/unbound/etc/unbound/conf.d/*.conf"` (container path)
3. **New handler**: `recreate unbound` uses `docker-compose down && up` (needed for volume changes; `force-recreate` fails on docker-compose v1 with `ContainerConfig` bug)
4. **Template fix**: Removed duplicate `local-zone` directive (already in base `unbound.conf`)

### Already tested on dev

Manually applied these fixes during debugging. Unbound is healthy and resolving:
- `grafana.internal.dev.*` → node IP (NodePort)
- `matrix.internal.dev.*` → LB IP (NodeBalancer)
- Upstream forwarding works (google.com)

## Test plan

- [ ] `./scripts/deploy_infra -e dev` completes with Ansible play succeeding
- [ ] `dig @10.9.0.1 grafana.internal.dev.<domain>` resolves
- [ ] Unbound container is healthy (`docker-compose ps`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)