### PR TITLE
fix: key-rotator jq operator precedence crash on untagged keys

### DIFF
--- a/apps/manifests/tailscale-key-rotator/configmap.yaml.tpl
+++ b/apps/manifests/tailscale-key-rotator/configmap.yaml.tpl
@@ -73,7 +73,7 @@ data:
       # Find the best (longest-lived) valid key for this tag
       BEST_EXPIRY=$(echo "$KEYS" | jq -r --arg tag "$tag" '
         [.preAuthKeys[]
-         | select(.reusable == true and (.aclTags // []) | index($tag))
+         | select(.reusable == true and ((.aclTags // []) | index($tag)))
          | .expiration
         ] | map(sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) | max // 0
       ')


### PR DESCRIPTION
## Summary

- Fix jq operator precedence bug in Tailscale key-rotator CronJob that caused crashes when processing pre-auth keys without ACL tags
- `select(.reusable == true and (.aclTags // []) | index($tag))` parsed incorrectly due to jq pipe precedence — `true | index("tag:...")` crashes with "Cannot index boolean with string"
- Fix: add parens `((.aclTags // []) | index($tag))` so the pipe binds to `index()` not to the whole `select`

## Root cause

Pre-auth keys created without explicit ACL tags have `"aclTags": []`. The `and` operator with an empty array evaluates to `true` (arrays are truthy in jq), which then gets piped to `index()` — a boolean can't be indexed.

## OSS Compliance Review

No domains, credentials, or sensitive data — single character change in a jq expression.

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

## Security Review

No security impact — fixes a parsing crash, no change to auth flow or secret handling.

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

## Test plan

- [x] Fix already deployed and verified on prod-eu (manual job ran successfully — all 4 components processed)
- [x] Fix deployed to prod and dev
- [x] Deleted stale 2-day-old failed job in prod that was causing alerts
- [ ] Verify next scheduled Sunday rotation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)