### PR TITLE
feat: brand Woodpecker CI with Mothertree theme

### DIFF
--- a/ci/ansible/files/woodpecker-custom.css
+++ b/ci/ansible/files/woodpecker-custom.css
@@ -1,0 +1,129 @@
+/*
+ * Mothertree CI — Custom Woodpecker theme
+ * Overrides default green palette with Mothertree brand colors:
+ *   Ash (#F3E8D6)        — warm cream background
+ *   Coal (#141511)       — near-black text/dark theme base
+ *   Ghost Fern (#A7AE8D) — sage green primary accent
+ *   Cinder (#A64330)     — warm red secondary accent
+ */
+
+/* ── Light theme ──────────────────────────────────────────────── */
+
+:root,
+:root[data-theme='light'] {
+  /* Backgrounds: warm cream tones instead of cold gray */
+  --wp-background-100: #FEFCF8;
+  --wp-background-200: #F9F3EA;
+  --wp-background-300: #EDE4D5;
+  --wp-background-400: #DDD3C2;
+  --wp-background-500: #C9BEAE;
+
+  /* Text: coal-based */
+  --wp-text-100: #4A4A42;
+  --wp-text-200: #2A2A24;
+  --wp-text-alt-100: #6B6B5E;
+
+  /* Primary: ghost fern sage green */
+  --wp-primary-100: #A7AE8D;
+  --wp-primary-200: #8A9475;
+  --wp-primary-300: #6E7A5A;
+  --wp-primary-text-100: #FEFCF8;
+
+  /* Links */
+  --wp-link-100: #8A9475;
+  --wp-link-200: #6E7A5A;
+
+  /* OK/success states: keep sage green tones */
+  --wp-control-ok-100: #8A9475;
+  --wp-control-ok-200: #6E7A5A;
+  --wp-control-ok-300: #566243;
+  --wp-state-ok-100: #8A9475;
+
+  /* Error states: use cinder red */
+  --wp-error-100: #A64330;
+  --wp-error-200: #8C3828;
+  --wp-error-300: #722D20;
+
+  /* Neutral controls: warm gray tones */
+  --wp-control-neutral-100: #F3E8D6;
+  --wp-control-neutral-200: #E4D8C5;
+  --wp-control-neutral-300: #C9BEAE;
+
+  /* Code blocks: warm tinted */
+  --wp-code-inline-100: #EDE4D5;
+  --wp-code-inline-200: #E4D8C5;
+  --wp-code-inline-text-100: #4A4A42;
+}
+
+/* ── Dark theme ───────────────────────────────────────────────── */
+/* Warm ash-derived palette — like parchment under lamplight.     */
+/* Backgrounds use desaturated warm browns (no green tint),       */
+/* with wide contrast steps so rows are clearly distinct.         */
+
+:root[data-theme='dark'] {
+  /* Backgrounds: Coal page (300 — dark: override), lighter rows (200) */
+  --wp-background-100: #141511;
+  --wp-background-200: #2C2824;
+  --wp-background-300: #141511;
+  --wp-background-400: #52483E;
+  --wp-background-500: #6B6B5E;
+
+  /* Text: Ash cream */
+  --wp-text-100: #D4C8B5;
+  --wp-text-200: #F3E8D6;
+  --wp-text-alt-100: #A89A8A;
+
+  /* Primary: navbar/header — Ghost Fern Dark */
+  --wp-primary-100: #8A9475;
+  --wp-primary-200: #6E7A5A;
+  --wp-primary-300: #566243;
+  --wp-primary-text-100: #F3E8D6;
+
+  /* Links: sage green stands out on brown backgrounds */
+  --wp-link-100: #B5BC9E;
+  --wp-link-200: #A7AE8D;
+
+  /* OK/success: sage green accents (unchanged — run pipeline button) */
+  --wp-control-ok-100: #6E7A5A;
+  --wp-control-ok-200: #566243;
+  --wp-control-ok-300: #3F4C30;
+  --wp-state-ok-100: #8A9475;
+
+  /* Error: cinder red */
+  --wp-error-100: #A64330;
+  --wp-error-200: #8C3828;
+  --wp-error-300: #722D20;
+
+  /* Neutral controls: warm brown steps */
+  --wp-control-neutral-100: #4A3F35;
+  --wp-control-neutral-200: #382F28;
+  --wp-control-neutral-300: #2C2520;
+
+  /* Code blocks: match dark page tone */
+  --wp-code-100: #1A1510;
+  --wp-code-200: #231D18;
+  --wp-code-300: #141210;
+  --wp-code-text-100: #D4C8B5;
+  --wp-code-text-alt-100: #A89A8A;
+  --wp-code-inline-100: #332B24;
+  --wp-code-inline-200: #2C2520;
+  --wp-code-inline-text-100: #D4C8B5;
+}
+
+/* ── Sidebar / navigation accent stripe ───────────────────────── */
+/* The left sidebar "active" indicator uses primary colors;
+   the variables above handle it. This adds a subtle brand touch
+   to the top bar / header area. */
+header nav {
+  border-bottom-color: #A7AE8D !important;
+}
+
+/* Pipeline status badges — use sage for running, cinder for failed */
+.bg-wp-state-ok-100 {
+  background-color: #8A9475 !important;
+}
+
+/* Button hover refinement */
+button:hover {
+  transition: background-color 0.15s ease;
+}

--- a/ci/ansible/files/woodpecker-custom.js
+++ b/ci/ansible/files/woodpecker-custom.js
@@ -1,0 +1,84 @@
+// Mothertree CI — Custom Woodpecker branding
+// Replaces the default Woodpecker logo with the Mothertree tree icon
+// and updates the page title.
+
+(function () {
+  'use strict';
+
+  // Mothertree tree icon SVG (from favicon.svg)
+  // Uses fill="white" to match the original Woodpecker logo behavior —
+  // both the navbar and login page render the logo on colored backgrounds
+  // (bg-wp-primary-200 / bg-wp-primary-300).
+  var MOTHERTREE_SVG =
+    '<svg viewBox="0 -29 217 217" fill="none" xmlns="http://www.w3.org/2000/svg">' +
+    '<path d="M134.619 120.497C134.695 119.603 135.984 119.391 136.386 120.192C143.6 134.563 158.083 144.653 175.011 145.636C175.777 145.68 176.273 146.478 175.905 147.151C171.723 154.788 163.31 159.647 154.079 158.855C141.607 157.785 132.362 146.807 133.432 134.335L134.619 120.497Z" fill="white"/>' +
+    '<path d="M79.1548 121.88C79.5788 121.116 80.803 121.347 80.8794 122.217L81.9361 134.295L81.979 134.879C82.7374 147.107 73.6076 157.776 61.3326 158.851C52.1083 159.657 43.6916 154.82 39.4937 147.199C39.1189 146.518 39.6317 145.712 40.4087 145.684C57.097 145.078 71.5263 135.627 79.1548 121.88Z" fill="white"/>' +
+    '<path d="M113.708 40.4726C114.068 40.4726 114.428 40.4821 114.785 40.499L117.972 40.8779C128.351 42.8706 136.193 51.9979 136.194 62.9579V83.9452C136.194 90.9837 132.959 97.2657 127.896 101.389C126.615 102.431 125.686 103.884 125.534 105.528L121.748 146.6C121.012 153.591 115.116 158.898 108.085 158.898C101.056 158.898 95.1604 153.591 94.4243 146.6L90.6372 105.528C90.4854 103.884 89.5564 102.431 88.2759 101.389C83.2134 97.2656 79.9791 90.9833 79.979 83.9452V62.9579C79.9794 52.1931 87.5445 43.1965 97.648 40.9911L100.835 40.5312C101.373 40.4927 101.917 40.4726 102.464 40.4726H113.708Z" fill="white"/>' +
+    '<path d="M67.646 56.7997C68.4246 56.0212 69.8443 56.8178 69.6783 57.9062C69.4267 59.5533 69.2965 61.2405 69.2964 62.9579V83.9452C69.2964 88.9146 70.3932 93.626 72.3511 97.8534C72.8689 98.9716 73.2021 100.18 73.1363 101.41C72.1331 120.148 56.6221 135.032 37.6343 135.032H7.50931C0.832137 135.032 -2.51116 126.959 2.21048 122.237L67.646 56.7997Z" fill="white"/>' +
+    '<path d="M146.755 57.9062C146.589 56.818 148.009 56.0216 148.788 56.7997L214.224 122.237C218.945 126.959 215.602 135.032 208.924 135.032H178.799C159.812 135.032 144.301 120.148 143.297 101.41C143.232 100.18 143.565 98.9715 144.083 97.8534C146.04 93.6259 147.137 88.9147 147.137 83.9452V62.9579C147.137 61.2405 147.007 59.5533 146.755 57.9062Z" fill="white"/>' +
+    '<path d="M59.0718 0.626885C59.0373 0.0908856 59.9693 -0.21688 60.3306 0.180596C62.3379 2.3892 66.9515 5.78021 76.356 5.78021C94.3314 5.78033 100.999 14.0997 101 25.5312V29.5761C100.999 29.926 100.284 30.0695 100.12 29.7607C98.4153 26.5657 93.8177 20.7831 82.8638 20.7831C74.2455 20.7831 60.1996 18.1158 59.0718 0.626885Z" fill="white"/>' +
+    '<path d="M155.668 0.180596C156.03 -0.216886 156.962 0.0908778 156.927 0.626885C155.799 18.116 141.754 20.7831 133.135 20.7831C122.181 20.7832 117.584 26.5658 115.879 29.7607C115.715 30.0695 115 29.926 115 29.5761V25.5312C115 14.0996 121.668 5.78021 139.644 5.78021C149.048 5.78017 153.661 2.3892 155.668 0.180596Z" fill="white"/>' +
+    '</svg>';
+
+  // Replace page title
+  function updateTitle() {
+    if (document.title.indexOf('Woodpecker') !== -1) {
+      document.title = document.title.replace(/Woodpecker/g, 'Mothertree CI');
+    }
+  }
+  updateTitle();
+
+  // Watch for title changes (Vue router navigation updates the title)
+  new MutationObserver(updateTitle).observe(
+    document.querySelector('title'),
+    { childList: true }
+  );
+
+  // Replace Woodpecker logo SVGs with the Mothertree tree icon.
+  // The Woodpecker logo is rendered as an inline <svg> by Vue (imported
+  // via `logo.svg?component`). It has viewBox="0 0 22 22" and appears in:
+  //   - Navbar: <nav> > <a> > <svg class="h-8 w-8">
+  //   - Login page: <div> > <svg class="h-32 w-32 md:h-48 md:w-48">
+  function replaceLogo() {
+    var logos = document.querySelectorAll('svg[viewBox="0 0 22 22"]');
+    logos.forEach(function (original) {
+      var wrapper = document.createElement('span');
+      wrapper.innerHTML = MOTHERTREE_SVG;
+      var replacement = wrapper.firstChild;
+
+      // Preserve the original's CSS classes (Tailwind sizing)
+      replacement.setAttribute('class', original.getAttribute('class') || '');
+
+      // Copy preserveAspectRatio if present (login page uses it)
+      var par = original.getAttribute('preserveAspectRatio');
+      if (par) {
+        replacement.setAttribute('preserveAspectRatio', par);
+      }
+
+      original.parentNode.replaceChild(replacement, original);
+    });
+  }
+
+  // Run after Vue has mounted the app
+  function init() {
+    replaceLogo();
+
+    // Re-run on SPA route changes. Use a debounced observer to avoid
+    // thrashing on every DOM mutation during Vue rendering.
+    var pending = null;
+    new MutationObserver(function () {
+      if (pending) return;
+      pending = setTimeout(function () {
+        pending = null;
+        replaceLogo();
+        updateTitle();
+      }, 200);
+    }).observe(document.body, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { setTimeout(init, 300); });
+  } else {
+    setTimeout(init, 300);
+  }
+})();

--- a/ci/ansible/playbook.yml
+++ b/ci/ansible/playbook.yml
@@ -164,6 +164,24 @@
         state: directory
         mode: "0755"
 
+    - name: Deploy Mothertree custom CSS for Woodpecker UI
+      ansible.builtin.copy:
+        src: files/woodpecker-custom.css
+        dest: /etc/woodpecker/woodpecker-custom.css
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart Woodpecker server
+
+    - name: Deploy Mothertree custom JS for Woodpecker UI
+      ansible.builtin.copy:
+        src: files/woodpecker-custom.js
+        dest: /etc/woodpecker/woodpecker-custom.js
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart Woodpecker server
+
     - name: Configure Woodpecker server environment
       ansible.builtin.template:
         src: templates/woodpecker-server.env.j2

--- a/ci/ansible/templates/woodpecker-server.env.j2
+++ b/ci/ansible/templates/woodpecker-server.env.j2
@@ -16,3 +16,6 @@ WOODPECKER_GITHUB_SECRET={{ woodpecker_github_secret }}
 # pipeline deploys to prod anyway — cancelling earlier frees pool slots sooner.
 WOODPECKER_DEFAULT_CANCEL_PREVIOUS_PIPELINE_EVENTS=pull_request,push
 WOODPECKER_LOG_LEVEL=info
+# Mothertree brand theming
+WOODPECKER_CUSTOM_CSS_FILE=/etc/woodpecker/woodpecker-custom.css
+WOODPECKER_CUSTOM_JS_FILE=/etc/woodpecker/woodpecker-custom.js


### PR DESCRIPTION
## Summary

- Add custom CSS overriding Woodpecker's `--wp-*` variables with the Mothertree brand palette (Ash, Coal, Ghost Fern, Cinder) for both light and dark themes
- Add custom JS replacing the Woodpecker logo with the Mothertree tree icon and renaming the page title to "Mothertree CI"
- Ansible playbook deploys both files to `/etc/woodpecker/` and restarts the server on changes

## Test plan

- [x] Deployed to CI server via `provision-ci.sh --ansible-only`
- [x] Verified light theme renders with warm cream backgrounds and sage green navbar
- [x] Verified dark theme renders with Coal page background, lighter rows, sage green header
- [x] Verified logo replacement works on repo list page
- [x] Confirmed custom CSS/JS served at `/assets/custom.css` and `/assets/custom.js`

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — No issues found.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 1 (innerHTML with hardcoded constant — no actual XSS vector) | **LOW**: 0 — No blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)