### PR TITLE
feat(dns): rename prod LB record from lb1.prod to lb2.prod

### DIFF
--- a/.claude/agents/terraform-researcher.md
+++ b/.claude/agents/terraform-researcher.md
@@ -57,7 +57,7 @@ data "terraform_remote_state" "phase1" {
 - cert-manager ClusterIssuers (HTTP-01 and DNS-01)
 - Postfix Deployment + Service (with OpenDKIM sidecar)
 - ConfigMaps: postfix-config, opendkim-config, postfix-init-scripts
-- DNS records via `modules/dns/` (lb1, mail, turn A records; tenant CNAMEs)
+- DNS records via `modules/dns/` (LB A record: `lb2.prod`/`lb1.<label>`, mail, turn A records; tenant CNAMEs)
 
 **Templates** (in `infra/templates/`):
 - `postfix-main.cf.tpl` — Postfix configuration

--- a/.claude/commands/ops.md
+++ b/.claude/commands/ops.md
@@ -121,7 +121,7 @@ without running the full `create_env`.
 | `env_dns_label` | `"dev"` | `""` (empty string) |
 | External hosts | `matrix.dev.example.com` | `matrix.example.com` |
 | Internal hosts | `grafana.internal.dev.example.com` | `grafana.prod.example.com` |
-| LB hostname | `lb1.dev.example.com` | `lb1.prod.example.com` |
+| LB hostname | `lb1.dev.example.com` | `lb2.prod.example.com` |
 | Cloudflare proxy | `false` (DNS-only) | `true` (proxied, DDoS/WAF) |
 | Wildcard cert | `*.dev.example.com` + `*.internal.dev.example.com` | `*.example.com` + `*.prod.example.com` |
 | Cookie domain | `.dev.example.com` | `.example.com` |
@@ -252,7 +252,7 @@ Per-tenant namespace policies (`apps/manifests/network-policies/`):
 
 **Terraform-managed** (modules/dns/ and infra/main.tf) — DO NOT create in scripts:
 - Base domain CNAME (`example.com` → `www.example.com`) — NEVER modify
-- `lb1` A record → cluster ingress IP
+- LB A record (`lb2.prod` for prod, `lb1.<label>` for dev/prod-eu) → cluster ingress IP
 - `mail` A record → Postfix relay VM IP
 - `turn` A record → TURN server IP
 - Matrix federation SRV records
@@ -266,7 +266,7 @@ Per-tenant namespace policies (`apps/manifests/network-policies/`):
 ### CNAME Chain
 
 ```
-matrix.example.com  →  CNAME  →  lb1.prod.example.com  →  A  →  <ingress-IP>
+matrix.example.com  →  CNAME  →  lb2.prod.example.com  →  A  →  <ingress-IP>
 matrix.dev.example.com  →  CNAME  →  lb1.dev.example.com  →  A  →  <ingress-IP>
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,11 +110,11 @@ deploy-prod → deploy_infra -e prod + create_env -e prod -t <all tenants>
 
 ## DNS Patterns
 
-- **Prod**: `matrix.example.com`, `mail.example.com`, `lb1.prod.example.com`
+- **Prod**: `matrix.example.com`, `mail.example.com`, `lb2.prod.example.com`
 - **Dev**: `matrix.dev.example.com`, `mail.dev.example.com`, `lb1.dev.example.com`
 - **Prod internal**: `grafana.prod.example.com`, `prometheus.prod.example.com` (prefix is `prod`, NOT `internal`)
 - **Dev internal**: `grafana.internal.dev.example.com`, `prometheus.internal.dev.example.com` (prefix is `internal.dev`)
-- Tenant subdomains CNAME to `lb1.{env_label}.example.com`
+- Tenant subdomains CNAME to `lb2.prod.example.com` (prod) or `lb1.{env_label}.example.com` (dev/prod-eu)
 - `env_dns_label`: empty string for prod, `"dev"` for dev
 
 ## Tenant Config Structure
@@ -230,7 +230,7 @@ Never skip this step, even if the changes seem trivial.
 ## DNS Safety Rules
 
 - **NEVER modify the base domain DNS record.** The base domain is a CNAME pointing to an external website. The `create_env` script must not create A/CNAME records for the bare domain.
-- Records managed by `manage_infra --dns` (via `scripts/manage-dns.sh`) should not be duplicated or overridden by `create_env`. Managed records include: base domain CNAME, `lb1` A record, `mail` A record, MX, SPF, DKIM, DMARC, TURN SRV.
+- Records managed by `manage_infra --dns` (via `scripts/manage-dns.sh`) should not be duplicated or overridden by `create_env`. Managed records include: base domain CNAME, LB A record (`lb2.prod` / `lb1.<label>`), `mail` A record, MX, SPF, DKIM, DMARC, TURN SRV.
 - The `create_env` script manages per-tenant CNAME records (subdomains like `matrix`, `element`, `docs`, etc.) and tenant-specific email DNS records only.
 
 ## Troubleshooting

--- a/ansible/templates/unbound-local-data.conf.j2
+++ b/ansible/templates/unbound-local-data.conf.j2
@@ -11,6 +11,6 @@ server:
     local-data: "alertmanager.{{ internal_dns_domain }}. IN A {{ cluster_node_ip }}"
 
     # Web services (NodeBalancer access via cluster LB IP)
-{% for subdomain in ['matrix', 'synapse', 'docs', 'files', 'auth', 'home', 'admin', 'account', 'element', 'webmail', 'calendar', 'jitsi', 'lb1'] %}
+{% for subdomain in ['matrix', 'synapse', 'docs', 'files', 'auth', 'home', 'admin', 'account', 'element', 'webmail', 'calendar', 'jitsi', 'lb1', 'lb2'] %}
     local-data: "{{ subdomain }}.{{ internal_dns_domain }}. IN A {{ cluster_lb_ip }}"
 {% endfor %}

--- a/scripts/cleanup-lb1-prod-dns.sh
+++ b/scripts/cleanup-lb1-prod-dns.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# One-shot cleanup: delete orphaned `lb1.prod.<domain>` A records after
+# migrating prod to `lb2.prod`. Idempotent — safe to re-run.
+#
+# Deletes:
+#   - lb1.prod.<INFRA_DOMAIN>            (the shared infra record)
+#   - lb1.prod.<tenant_domain>           (per prod tenant)
+#
+# Usage:
+#   ./scripts/cleanup-lb1-prod-dns.sh -e prod [--dry-run]
+#
+# Only operates on MT_ENV=prod. Run AFTER:
+#   1. `manage_infra --dns -e prod` has created the new lb2.prod record
+#   2. `create_env -e prod -t <tenant>` has been re-run for every prod tenant
+#   3. Enough time (≥ 2x TTL) has passed for caches to drain
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "${REPO_ROOT}/scripts/lib/common.sh"
+source "${REPO_ROOT}/scripts/lib/args.sh"
+
+mt_usage() {
+  echo "Usage: $0 -e prod [--dry-run]"
+  echo ""
+  echo "One-shot cleanup of orphaned lb1.prod.* A records after lb2 migration."
+  echo "Idempotent. Only operates on MT_ENV=prod."
+}
+
+DRY_RUN="false"
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN="true" ;;
+  esac
+done
+
+mt_parse_args "$@"
+mt_require_env
+
+if [ "$MT_ENV" != "prod" ]; then
+  print_error "This cleanup script only runs against prod (MT_ENV=$MT_ENV)"
+  exit 1
+fi
+
+mt_require_commands curl jq yq
+
+if [ -f "$REPO_ROOT/secrets.tfvars.env" ]; then
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/secrets.tfvars.env"
+elif [ -f "$REPO_ROOT/secrets.${MT_ENV}.tfvars.env" ]; then
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/secrets.${MT_ENV}.tfvars.env"
+fi
+
+if [ -z "${TF_VAR_cloudflare_api_token:-}" ]; then
+  print_error "TF_VAR_cloudflare_api_token not set"
+  exit 1
+fi
+
+source "${REPO_ROOT}/scripts/lib/dns.sh"
+
+# Wrapper to honour --dry-run
+_delete_or_log() {
+  local name="$1" type="$2"
+  if [ "$DRY_RUN" = "true" ]; then
+    print_status "[dry-run] Would delete: $name ($type)"
+    return 0
+  fi
+  delete_dns_record "$name" "$type"
+}
+
+# =============================================================================
+# Step 1: delete lb1.prod.<INFRA_DOMAIN> from the infra zone
+# =============================================================================
+(
+  source "${REPO_ROOT}/scripts/lib/infra-config.sh"
+  mt_load_infra_config
+
+  if [ -z "${INFRA_DOMAIN:-}" ]; then
+    print_error "INFRA_DOMAIN not set after loading infra config"
+    exit 1
+  fi
+  if [ -z "${TF_VAR_cloudflare_zone_id:-}" ]; then
+    print_error "TF_VAR_cloudflare_zone_id not set from infra config"
+    exit 1
+  fi
+
+  print_status "=== Infra record: lb1.prod.${INFRA_DOMAIN} (zone=${TF_VAR_cloudflare_zone_id}) ==="
+  _delete_or_log "lb1.prod.${INFRA_DOMAIN}" "A"
+)
+
+# =============================================================================
+# Step 2: delete lb1.prod.<tenant_domain> for every prod tenant (in subshells
+# so each tenant's config/zone_id is loaded cleanly)
+# =============================================================================
+for tenant_dir in "$MT_TENANTS_DIR"/*/; do
+  [ -d "$tenant_dir" ] || continue
+  tenant_name=$(basename "$tenant_dir")
+  config_file="$tenant_dir/${MT_ENV}.config.yaml"
+  [ -f "$config_file" ] || continue
+
+  # Prod tenants have empty/null env_dns_label
+  env_label=$(yq '.dns.env_dns_label // ""' "$config_file")
+  if [ -n "$env_label" ] && [ "$env_label" != "null" ]; then
+    continue
+  fi
+
+  (
+    export MT_TENANT="$tenant_name"
+    source "${REPO_ROOT}/scripts/lib/config.sh"
+    mt_load_tenant_config >/dev/null
+
+    if [ -z "${TENANT_DOMAIN:-}" ]; then
+      print_warning "Skipping tenant $tenant_name — TENANT_DOMAIN empty"
+      exit 0
+    fi
+    if [ -z "${TF_VAR_cloudflare_zone_id:-}" ]; then
+      print_warning "Skipping tenant $tenant_name — no cloudflare zone_id"
+      exit 0
+    fi
+
+    print_status "=== Tenant $tenant_name: lb1.prod.${TENANT_DOMAIN} (zone=${TF_VAR_cloudflare_zone_id}) ==="
+    _delete_or_log "lb1.prod.${TENANT_DOMAIN}" "A"
+  )
+done
+
+print_success "Cleanup complete"

--- a/scripts/create_env
+++ b/scripts/create_env
@@ -287,11 +287,11 @@ else
   # Load shared DNS functions (create_dns_record, create_srv_record, create_mx_record)
   source "${REPO_ROOT}/scripts/lib/dns.sh"
 
-  # Create lb1 A record for this tenant's domain
+  # Create LB A record for this tenant's domain (lb2.prod for prod, lb1.<label> for dev/prod-eu)
   if [ -n "$TENANT_ENV_DNS_LABEL" ] && [ "$TENANT_ENV_DNS_LABEL" != "null" ]; then
     LB1_RECORD="lb1.${TENANT_ENV_DNS_LABEL}.${TENANT_DOMAIN}"
   else
-    LB1_RECORD="lb1.prod.${TENANT_DOMAIN}"
+    LB1_RECORD="lb2.prod.${TENANT_DOMAIN}"
   fi
   # Cloudflare proxy: prod only (Universal SSL covers *.domain but not *.dev.domain)
   if [ -z "$TENANT_ENV_DNS_LABEL" ] || [ "$TENANT_ENV_DNS_LABEL" = "null" ]; then
@@ -301,9 +301,9 @@ else
   fi
 
   create_dns_record "$LB1_RECORD" "A" "$INGRESS_IP" "$CF_PROXIED"
-  print_status "Created lb1 A record: $LB1_RECORD -> $INGRESS_IP (proxied=$CF_PROXIED)"
+  print_status "Created LB A record: $LB1_RECORD -> $INGRESS_IP (proxied=$CF_PROXIED)"
 
-  # Create CNAME records for all tenant subdomains pointing to lb1
+  # Create CNAME records for all tenant subdomains pointing to the tenant LB record
   # Note: 'mail' is excluded — its A record is created above alongside the MX record
   PROXIED_SUBDOMAINS="matrix synapse docs files auth home admin account webmail calendar jitsi office"
   DNS_ONLY_SUBDOMAINS="imap smtp"

--- a/scripts/lib/dns.sh
+++ b/scripts/lib/dns.sh
@@ -164,6 +164,35 @@ create_mx_record() {
   fi
 }
 
+# Delete a Cloudflare DNS record (idempotent — no-op if record doesn't exist)
+# Args: record_name record_type
+delete_dns_record() {
+  local record_name="$1"
+  local record_type="$2"
+
+  EXISTING=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/${TF_VAR_cloudflare_zone_id}/dns_records?name=${record_name}&type=${record_type}" \
+    -H "Authorization: Bearer ${TF_VAR_cloudflare_api_token}" \
+    -H "Content-Type: application/json")
+
+  RECORD_ID=$(echo "$EXISTING" | jq -r '.result[0].id // empty')
+
+  if [ -z "$RECORD_ID" ]; then
+    print_status "DNS record absent (already deleted): $record_name ($record_type)"
+    return 0
+  fi
+
+  RESULT=$(curl -s -X DELETE "https://api.cloudflare.com/client/v4/zones/${TF_VAR_cloudflare_zone_id}/dns_records/${RECORD_ID}" \
+    -H "Authorization: Bearer ${TF_VAR_cloudflare_api_token}" \
+    -H "Content-Type: application/json")
+
+  if echo "$RESULT" | jq -e '.success' >/dev/null 2>&1; then
+    print_status "Deleted DNS: $record_name ($record_type)"
+  else
+    print_error "Failed to delete DNS: $record_name — $(echo "$RESULT" | jq -r '.errors[0].message // "unknown error"')"
+    return 1
+  fi
+}
+
 # Set Linode reverse DNS (PTR) for an IP address
 # Args: ip_address rdns_hostname
 # Linode requires forward DNS to resolve first

--- a/scripts/manage-dns.sh
+++ b/scripts/manage-dns.sh
@@ -5,7 +5,8 @@
 #          for shared infrastructure (not per-tenant records).
 #
 # Records managed:
-#   - lb1.{prod|dev|prod-eu}.<domain> A  → Ingress LB IP (proxied in prod)
+#   - lb2.prod.<domain> A  → Ingress LB IP (prod, proxied)
+#   - lb1.{dev|prod-eu}.<domain> A  → Ingress LB IP (dev/prod-eu, not proxied)
 #   - turn[.dev].<domain> A              → TURN server IP
 #   - hs-{prod|dev|prod-eu}.<domain> A   → Headscale server IP
 #   - @ CNAME → www.<domain>             (prod only)
@@ -87,9 +88,9 @@ fi
 # Subdomain defaults (match previous Terraform defaults)
 SYNAPSE_CNAME="${SYNAPSE_CNAME:-synapse}"
 
-# LB1 subdomain: lb1.prod for prod, lb1.dev for dev
+# LB subdomain: lb2.prod for prod, lb1.<label> for dev/prod-eu
 if [ -z "$INFRA_ENV_DNS_LABEL" ]; then
-  LB1_SUBDOMAIN="lb1.prod"
+  LB1_SUBDOMAIN="lb2.prod"
   CF_PROXIED="true"
 else
   LB1_SUBDOMAIN="lb1.${INFRA_ENV_DNS_LABEL}"

--- a/scripts/manage_infra
+++ b/scripts/manage_infra
@@ -479,14 +479,21 @@ EOF
         source "$REPO_ROOT/secrets.$MT_ENV.tfvars.env"
       fi
 
+      # LB FQDN: lb2.prod for prod, lb1.<env> for dev/prod-eu
+      if [ "$MT_ENV" = "prod" ]; then
+        LB_FQDN="lb2.prod.${INFRA_DOMAIN}"
+      else
+        LB_FQDN="lb1.${MT_ENV}.${INFRA_DOMAIN}"
+      fi
+
       # Resolve NodeBalancer's real hostname for mail routing.
-      # Cloudflare-proxied lb1.* FQDNs block SMTP (port 30025) — must use the
+      # Cloudflare-proxied LB FQDNs block SMTP (port 30025) — must use the
       # NodeBalancer's direct IP/hostname from the LoadBalancer service.
       K8S_LB_DIRECT_HOST=$(kubectl --kubeconfig="$KUBECONFIG" -n infra-ingress \
         get svc ingress-nginx-controller \
         -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "")
       if [ -z "$K8S_LB_DIRECT_HOST" ]; then
-        K8S_LB_DIRECT_HOST="lb1.${MT_ENV}.${INFRA_DOMAIN}"
+        K8S_LB_DIRECT_HOST="$LB_FQDN"
         print_warning "Could not resolve NodeBalancer IP — using $K8S_LB_DIRECT_HOST (may fail if Cloudflare-proxied)"
       fi
 
@@ -503,7 +510,7 @@ EOF
       cat >> "$TEMP_EXTRA_VARS" <<EOF
 
 # K8s Postfix inbound mail routing via NodeBalancer TCP proxy
-# Use the NodeBalancer's real IP (not Cloudflare-proxied lb1.* FQDN)
+# Use the NodeBalancer's real IP (not Cloudflare-proxied LB FQDN)
 # because Cloudflare only proxies HTTP/HTTPS — SMTP port 30025 is blocked.
 k8s_postfix_nodeport: 30025
 k8s_lb_host: "${K8S_LB_DIRECT_HOST}"
@@ -641,7 +648,7 @@ EOF
       print_status "Environment:        $MT_ENV"
       print_status "TLS email:          ${TF_VAR_tls_email:-<not set, Certbot/TLS skipped>}"
       print_status "Tenant Domains:     ${TENANT_DOMAINS:-<none>}"
-      print_status "K8s LB Host:        lb1.${MT_ENV}.${INFRA_DOMAIN}"
+      print_status "K8s LB Host:        $LB_FQDN"
       print_status "TURN IP:            ${TURN_SERVER_IP:-<not deployed>}"
       print_status "Headscale IP:       ${HEADSCALE_SERVER_IP:-<not deployed>}"
       print_status "PostgreSQL IP:      ${POSTGRES_SERVER_IP:-<not deployed>}"


### PR DESCRIPTION
## Summary

- Rename the prod ingress load balancer subdomain from `lb1.prod` to `lb2.prod` across scripts, Ansible templates, and docs
- Dev and prod-eu environments are unchanged — they continue using `lb1.<env_dns_label>`
- Adds idempotent `delete_dns_record()` helper in `scripts/lib/dns.sh` and a one-shot cleanup script `scripts/cleanup-lb1-prod-dns.sh` for orphaned `lb1.prod.*` records

## Files touched

- `scripts/manage-dns.sh` — prod branch sets `LB1_SUBDOMAIN="lb2.prod"`
- `scripts/create_env` — prod branch sets `LB1_RECORD="lb2.prod.${TENANT_DOMAIN}"`
- `scripts/manage_infra` — new `LB_FQDN` local var with prod/dev conditional, used for the ansible extra-vars fallback and the diagnostic print
- `scripts/lib/dns.sh` — new `delete_dns_record()` helper (idempotent, no-op when absent)
- `scripts/cleanup-lb1-prod-dns.sh` — new one-shot cleanup, supports `--dry-run`, iterates prod tenants in subshells to load per-tenant Cloudflare zone IDs cleanly, refuses to run against any env other than prod
- `ansible/templates/unbound-local-data.conf.j2` — add `'lb2'` to the Jinja2 subdomain list; `'lb1'` stays for dev internal DNS
- Docs: `CLAUDE.md`, `.claude/commands/ops.md`, `.claude/agents/terraform-researcher.md`, and the `config/platform` submodule equivalents

## Zero-downtime rollout (operator steps, post-merge)

```bash
# 1. Create lb2.prod alongside lb1.prod
./scripts/manage_infra --dns -e prod

# 2. Repoint each prod tenant's subdomain CNAMEs
./scripts/create_env -e prod -t <tenant>

# 3. Verify
dig lb2.prod.<domain> A
dig matrix.<tenant>.<domain> CNAME

# 4. Wait ≥ 2× TTL (~10 min for proxied records)

# 5. Dry-run + apply cleanup
./scripts/cleanup-lb1-prod-dns.sh -e prod --dry-run
./scripts/cleanup-lb1-prod-dns.sh -e prod

# 6. Re-run VPN ansible so unbound serves lb2 internally
./scripts/manage_infra -e prod --ansible
```

After cleanup, `manage_infra --dns -e prod` and `create_env -e prod -t <tenant>` re-runs are no-ops for the LB records — the scripts no longer reference `lb1.prod` at all, so deleted records stay deleted.

## Test plan

- [ ] `bash -n` passes on all edited shell scripts (verified locally)
- [ ] Dry-run `cleanup-lb1-prod-dns.sh` against prod and confirm the expected records are listed
- [ ] Run step 1, verify `lb2.prod.<domain>` A record is created in Cloudflare with the correct ingress LB IP and `proxied=true`
- [ ] Run step 2 for one prod tenant, verify subdomain CNAMEs repoint to `lb2.prod.<tenant-domain>`
- [ ] Verify tenant URL loads (browser check on e.g. `matrix.<tenant>.<domain>`)
- [ ] Repeat step 2 for remaining prod tenants
- [ ] After TTL wait, run cleanup with `--dry-run` then for real
- [ ] Verify `dig lb1.prod.<infra-domain>` returns `NXDOMAIN`
- [ ] Re-run `manage_infra --dns -e prod` and confirm it's a no-op (idempotency check)

## OSS Compliance Review

**Files reviewed**: 10 (excluding `config/platform` submodule pointer)

All diffs use `example.com` placeholders, `$INFRA_DOMAIN`/`$TENANT_DOMAIN` variables, or `{{ }}` Ansible/template expressions. No real tenant domains, personal info, hardcoded credentials, or private registry references leaked. The `config/platform` submodule pointer bump is an opaque SHA reference — the private content stays in the private repo.

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — clean.

## Security Review

**Focus areas checked**:

1. **`cleanup-lb1-prod-dns.sh` prod gating**: Explicit hard fail when `MT_ENV != "prod"` (line 41), `mt_require_env` runs first. Tenant iteration filters out records with non-empty `env_dns_label`, so dev/prod-eu tenants are skipped even if colocated.
2. **Injection surface**: Tenant names come from directory listing; domains come from the trusted config submodule. Passed as quoted positional args into helpers. Acceptable for this trust model.
3. **`delete_dns_record()` helper**: Mirrors existing sibling helpers in `scripts/lib/dns.sh` — same auth header pattern, same `jq -e '.success'` verification (correct for Cloudflare's 200-with-error-body response shape), same idempotency. Returns non-zero on API failure so `set -e` propagates.
4. **`manage_infra` prod branch** (L482–486): Simple string equality on `MT_ENV`; `mt_require_env` validates earlier. No fallthrough writes the wrong FQDN.
5. **Secrets/curl**: Tokens passed via `Authorization: Bearer` header, never URL. No `--insecure`, no token echoing, no new secret files.

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — clean.

## Version Bump

No portal code changes detected. No version bump needed.

Co-Authored-By: Claude, for mothertree <info@mothertree.org>