### PR TITLE
test(e2e): tolerate Stalwart queue stalls in inbound-email test

### DIFF
--- a/e2e/helpers/imap.ts
+++ b/e2e/helpers/imap.ts
@@ -275,6 +275,19 @@ export async function waitForEmailBody(opts: {
   let pollCount = 0;
   let matchedUids: number[] = [];
 
+  // Print a single grep-friendly summary line when delivery succeeds.
+  // Prefix with "SLOW" when above threshold so CI log scans surface recurrences
+  // of the Stalwart queue-stall pattern (see inbound-email-new-user flake 2026-04-18).
+  const SLOW_THRESHOLD_MS = 30_000;
+  const logDelivery = () => {
+    const elapsedMs = Date.now() - start;
+    const tag = elapsedMs >= SLOW_THRESHOLD_MS ? 'SLOW' : 'ok';
+    console.log(
+      `  [imap] Delivery ${tag}: ${Math.round(elapsedMs / 1000)}s after ${pollCount} poll(s) ` +
+      `(user=${opts.userEmail}${opts.subjectContains ? `, subject~="${opts.subjectContains}"` : ''})`,
+    );
+  };
+
   while (Date.now() - start < timeoutMs) {
     pollCount++;
     let client: typeof ImapFlow | null = null;
@@ -350,7 +363,10 @@ export async function waitForEmailBody(opts: {
               chunks.push(chunk as Buffer);
             }
             const raw = Buffer.concat(chunks).toString();
-            if (raw) return raw;
+            if (raw) {
+              logDelivery();
+              return raw;
+            }
             console.log(`  [imap] Source download attempt ${attempt}: empty result for uid=${uid}`);
           } catch (err) {
             console.log(`  [imap] Source download attempt ${attempt} error: ${(err as Error).message}`);
@@ -379,6 +395,7 @@ export async function waitForEmailBody(opts: {
                 console.log(`  [imap] uid=${uid}: skipped (contains skipContaining pattern)`);
                 skippedUids.add(uid);
               } else {
+                logDelivery();
                 return raw;
               }
               break;

--- a/e2e/tests/email/inbound-email-new-user.spec.ts
+++ b/e2e/tests/email/inbound-email-new-user.spec.ts
@@ -104,8 +104,8 @@ test.describe('Email — Inbound Delivery to New User (#189)', () => {
       const rawMime = await waitForEmailBody({
         userEmail: newUserEmail,
         subjectContains: subject,
-        timeoutMs: 90_000,
-        pollIntervalMs: 5_000,
+        timeoutMs: 150_000,
+        pollIntervalMs: 3_000,
       });
 
       expect(rawMime).toContain(subject);


### PR DESCRIPTION
## Summary

- Pipeline #1068 (main merge) failed on e2e-shard-5's `inbound-email-new-user` test. Dev Stalwart logs show the local-queue delivery took **92s** (log: `elapsed=92000ms`) vs typical ~0ms median. The test's 90s IMAP poll timeout just missed it.
- Not a regression from PR #347 (pure portal CSS change) and not a regular scheduler tick — Stalwart's fallback is 5 min, deliveries are normally event-driven via an MPSC `QueueEvent::Refresh` from `spool.rs:517`. A one-off stall in the queue→manager handoff (probably a PG write or pool stall, since both stuck messages released together at the same instant with elapsed values differing by the exact time between their submissions).

## Changes

- `e2e/tests/email/inbound-email-new-user.spec.ts`: `timeoutMs` 90_000 → 150_000, `pollIntervalMs` 5_000 → 3_000.
- `e2e/helpers/imap.ts`: new `logDelivery()` helper prints a one-line summary on every `waitForEmailBody` success — prefixed `SLOW` when elapsed ≥ 30s. Grep-friendly so future CI log scans surface recurrences of the Stalwart stall pattern.

## Test plan

- [ ] CI runs pass (all 10 e2e shards)
- [ ] Confirm `[imap] Delivery ok: Xs after N poll(s)` lines appear in e2e shard logs for successful runs
- [ ] If a future run stalls again, `grep 'Delivery SLOW' ci-logs` surfaces it without failing the test

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — clean.

Logged fields are synthetic `e2e-*` test identities and test-generated subjects; no tenant data, credentials, or personal info.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — clean.

`logDelivery()` is a pure `console.log` of timing + caller-supplied test metadata (`userEmail`, `subjectContains`) — no passwords/tokens/cookies/bodies. No new network endpoints. Timeout tuning does not weaken assertions.

## Version Bump

Not required — changes confined to `e2e/` test code; no portal code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)