### PR TITLE
feat(mail): step 2 PR-3 — Alertmanager direct SES; drop prod-eu email_configs

### DIFF
--- a/apps/environments/prod-eu/prometheus.yaml.gotmpl
+++ b/apps/environments/prod-eu/prometheus.yaml.gotmpl
@@ -25,14 +25,13 @@ alertmanager:
       - secretName: alertmanager-tls
         hosts:
           - 'alertmanager.prod-eu.{{ env "INFRA_DOMAIN" }}'
-  # AlertManager configuration for production alerting
+  # AlertManager configuration for prod-eu: Matrix + Healthchecks.io only.
+  # No SMTP configured — prod-eu has no SES credentials and no K8s Postfix
+  # (no tenant has features.mail_enabled=true), so email notifications are not
+  # available here. Alerts flow to Matrix; the Watchdog pings Healthchecks.io.
   config:
-    global:
-      smtp_smarthost: 'postfix-internal.infra-mail.svc.cluster.local:587'
-      smtp_from: 'alertmanager@{{ env "INFRA_DOMAIN" }}'
-      smtp_require_tls: false
     route:
-      receiver: 'default'
+      receiver: 'matrix-alerts'
       group_by: ['alertname', 'severity', 'namespace']
       group_wait: 30s
       group_interval: 5m
@@ -48,30 +47,18 @@ alertmanager:
           receiver: 'deadman'
           group_interval: 1m
           repeat_interval: 1m
-        # Critical alerts: email + Matrix, notify immediately and more frequently
+        # Critical alerts: notify Matrix immediately and more frequently
         - match:
             severity: critical
           receiver: 'critical-alerts'
           repeat_interval: 1h
-        # Non-critical alerts go to Matrix only (criticals already sent above)
+        # Non-critical alerts: Matrix at default cadence
         - match_re:
             severity: warning|info
           receiver: 'matrix-alerts'
     receivers:
       - name: 'null'
-      - name: 'default'
-        email_configs:
-          - to: '{{ requiredEnv "ALERTMANAGER_EMAIL_TO" }}'
-            send_resolved: true
-            headers:
-              # Note: These are AlertManager Go templates, escaped with raw string blocks
-              Subject: '{{ "{{" }} printf "[%s] %s: %s" "{{ env "INFRA_NAME" | default "MotherTree" }}" (.Status | toUpper) .CommonLabels.alertname {{ "}}" }}'
       - name: 'critical-alerts'
-        email_configs:
-          - to: '{{ requiredEnv "ALERTMANAGER_EMAIL_TO" }}'
-            send_resolved: true
-            headers:
-              Subject: '{{ "{{" }} printf "[%s CRITICAL] %s: %s" "{{ env "INFRA_NAME" | default "MotherTree" }}" (.Status | toUpper) .CommonLabels.alertname {{ "}}" }}'
         webhook_configs:
           # TODO: Matrix room ID should come from tenant config
           # Room ID: #alerts on Matrix server

--- a/apps/environments/prod/prometheus.yaml.gotmpl
+++ b/apps/environments/prod/prometheus.yaml.gotmpl
@@ -31,12 +31,25 @@ alertmanager:
         hosts:
           - 'alertmanager.internal.{{ env "INFRA_DOMAIN" }}'
           - 'alertmanager.prod.{{ env "INFRA_DOMAIN" }}'
+  alertmanagerSpec:
+    # SES password is mounted as a file — Alertmanager reads smtp_auth_password_file.
+    # Created by deploy_infra before the helmfile sync.
+    volumes:
+      - name: ses-credentials
+        secret:
+          secretName: ses-credentials
+    volumeMounts:
+      - name: ses-credentials
+        mountPath: /etc/alertmanager/ses
+        readOnly: true
   # AlertManager configuration for production alerting
   config:
     global:
-      smtp_smarthost: 'postfix-internal.infra-mail.svc.cluster.local:587'
+      smtp_smarthost: '{{ requiredEnv "SES_SMTP_ENDPOINT" }}:587'
       smtp_from: 'alertmanager@{{ env "INFRA_DOMAIN" }}'
-      smtp_require_tls: false
+      smtp_auth_username: '{{ requiredEnv "SES_SMTP_USERNAME" }}'
+      smtp_auth_password_file: '/etc/alertmanager/ses/password'
+      smtp_require_tls: true
     route:
       receiver: 'default'
       group_by: ['alertname', 'severity', 'namespace']

--- a/e2e/tests/mail/sasl-auth-failure.spec.ts
+++ b/e2e/tests/mail/sasl-auth-failure.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * E2E test: SASL auth failure against Stalwart's submission listener.
+ *
+ * Regression guard for the caller-side SASL wiring shipped in PR-2b
+ * (Synapse, Docs, Nextcloud, Keycloak realm SMTP → Stalwart:588). Verifies
+ * Stalwart returns a clean `535` on invalid credentials rather than hanging,
+ * closing the socket, or returning a generic `500`. A hang here would cascade
+ * into caller timeouts and breaks notification email delivery silently.
+ *
+ * Requires `E2E_STALWART_SMTP_SUBMISSION_PORT` — the external tenant-unique
+ * submission port (e.g. `58700`) that forwards to stalwart:587 with STARTTLS.
+ * Skips when unset so the spec can land ahead of the CI secret being added.
+ */
+import { test, expect } from '@playwright/test';
+import * as net from 'net';
+import * as tls from 'tls';
+
+const baseDomain = process.env.E2E_BASE_DOMAIN || 'dev.example.com';
+const smtpHost = process.env.E2E_STALWART_IMAP_HOST || `lb1.${baseDomain}`;
+const smtpPortStr = process.env.E2E_STALWART_SMTP_SUBMISSION_PORT;
+
+interface SmtpExchange {
+  /** Multi-line 3-digit status code sequence for each reply received. */
+  codes: number[];
+  /** Concatenated raw server output (for diagnostics on failure). */
+  transcript: string;
+}
+
+/**
+ * Run a minimal SMTP dialogue: EHLO → STARTTLS → EHLO → AUTH PLAIN → QUIT.
+ *
+ * Returns the status code of the AUTH PLAIN response. Each reply is read with
+ * a per-step timeout so a Stalwart hang surfaces as a failed test (the whole
+ * point of this spec) rather than a wall-clock timeout in Playwright.
+ */
+async function sendSmtpAuthPlain(opts: {
+  host: string;
+  port: number;
+  authBlob: string;
+  replyTimeoutMs: number;
+}): Promise<SmtpExchange> {
+  const { host, port, authBlob, replyTimeoutMs } = opts;
+  const codes: number[] = [];
+  let transcript = '';
+
+  const readReply = (stream: net.Socket | tls.TLSSocket) =>
+    new Promise<number>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        stream.removeListener('data', onData);
+        reject(new Error(`SMTP reply timeout after ${replyTimeoutMs}ms — Stalwart stopped responding mid-dialogue`));
+      }, replyTimeoutMs);
+      let buf = '';
+      const onData = (chunk: Buffer) => {
+        buf += chunk.toString('utf8');
+        transcript += chunk.toString('utf8');
+        // SMTP reply line ends when we see "NNN " (space) vs "NNN-" (continuation).
+        const lines = buf.split(/\r?\n/).filter(Boolean);
+        const last = lines[lines.length - 1] || '';
+        const m = /^(\d{3}) /.exec(last);
+        if (m) {
+          clearTimeout(timer);
+          stream.removeListener('data', onData);
+          resolve(parseInt(m[1], 10));
+        }
+      };
+      stream.on('data', onData);
+    });
+
+  const plain = await new Promise<net.Socket>((resolve, reject) => {
+    const s = net.connect({ host, port, timeout: replyTimeoutMs }, () => resolve(s));
+    s.once('error', reject);
+    s.once('timeout', () => reject(new Error(`TCP connect timeout to ${host}:${port}`)));
+  });
+
+  try {
+    codes.push(await readReply(plain)); // 220 banner
+    plain.write('EHLO e2e-sasl-test.local\r\n');
+    codes.push(await readReply(plain)); // 250 EHLO
+    plain.write('STARTTLS\r\n');
+    codes.push(await readReply(plain)); // 220 ready to start TLS
+  } catch (err) {
+    plain.destroy();
+    throw err;
+  }
+
+  // Upgrade to TLS. Self-signed certs are acceptable here — we only care about
+  // protocol-level behaviour, not certificate validity.
+  const secure = await new Promise<tls.TLSSocket>((resolve, reject) => {
+    const t = tls.connect({ socket: plain, servername: host, rejectUnauthorized: false }, () => resolve(t));
+    t.once('error', reject);
+  });
+
+  try {
+    secure.write('EHLO e2e-sasl-test.local\r\n');
+    codes.push(await readReply(secure)); // 250 EHLO (post-TLS)
+    secure.write(`AUTH PLAIN ${authBlob}\r\n`);
+    codes.push(await readReply(secure)); // THIS is the code under test
+    secure.write('QUIT\r\n');
+    // Best-effort QUIT; we don't care if the server has already closed.
+    await readReply(secure).catch(() => 221);
+  } finally {
+    secure.destroy();
+  }
+
+  return { codes, transcript };
+}
+
+test.describe('Mail — SASL Auth Failure (PR-2b regression guard)', () => {
+  test.skip(
+    !smtpPortStr,
+    'E2E_STALWART_SMTP_SUBMISSION_PORT not set — skipping SASL auth-failure test',
+  );
+
+  test('invalid SASL password returns 535, does not hang', async () => {
+    test.setTimeout(30_000);
+
+    const port = parseInt(smtpPortStr!, 10);
+    expect(Number.isFinite(port) && port > 0, `Expected numeric port, got: ${smtpPortStr}`).toBe(true);
+
+    // RFC 4616 PLAIN: \0<user>\0<pass>. The user/pass here are deliberately
+    // garbage so Stalwart's OIDC directory short-circuits to a reject.
+    const authBlob = Buffer.from('\0e2e-sasl-bogus@invalid.example\0not-a-real-password')
+      .toString('base64');
+
+    const result = await sendSmtpAuthPlain({
+      host: smtpHost,
+      port,
+      authBlob,
+      replyTimeoutMs: 10_000,
+    });
+
+    const authCode = result.codes[result.codes.length - 2]; // second-to-last (last is QUIT)
+    expect(
+      authCode,
+      `Expected 535 (auth failure) from Stalwart, got ${authCode}. Transcript:\n${result.transcript}`,
+    ).toBe(535);
+  });
+});

--- a/e2e/tests/onboarding/synapse-room-invite.spec.ts
+++ b/e2e/tests/onboarding/synapse-room-invite.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * E2E test: Synapse room invite exercises the Stalwart:588 SMTP relay.
+ *
+ * Verifies the Synapse → Stalwart:588 SASL wiring installed in PR-2b end-to-end.
+ * When a user is invited to a Matrix room while offline, Synapse's email
+ * notifier sends them a notification email via the configured SMTP submission
+ * endpoint. The test confirms the email lands in the invitee's mailbox.
+ *
+ * Currently skipped by default because Synapse's `email_notifier_plaintext_interval`
+ * defaults to 10 minutes (much longer than a CI budget can tolerate). Two
+ * preconditions must hold to enable it:
+ *   1. Dev's Synapse config must set `email_notifier_plaintext_interval` low
+ *      enough (e.g. 30s) so the notifier fires within the test timeout.
+ *   2. Set `E2E_SYNAPSE_ROOM_INVITE_ENABLED=1` to opt in.
+ *
+ * The spec is structured so the room creation + invite path can be exercised
+ * independently of the email assertion — once the config is tuned, flip the
+ * gate and the SMTP path becomes the actual assertion.
+ */
+
+import { test, expect } from '../../fixtures/authenticated';
+import { urls } from '../../helpers/urls';
+import { TEST_USERS } from '../../helpers/test-users';
+import { keycloakLogin } from '../../helpers/auth';
+import {
+  isImapConfigured,
+  waitForEmailBody,
+  deleteEmailsBySubject,
+} from '../../helpers/imap';
+
+const MATRIX_BASE = urls.element.replace(/\/$/, '');
+
+/**
+ * Login to Element once via OIDC and return the Matrix access token from
+ * Element's localStorage. The token is needed for server-to-server Client-
+ * Server API calls that create rooms and issue invites.
+ */
+async function getMatrixAccessToken(
+  page: import('@playwright/test').Page,
+  user: { username: string; password: string },
+): Promise<string> {
+  await page.goto(MATRIX_BASE);
+  if (new URL(page.url()).hostname.startsWith('auth.')) {
+    const continueLink = page.getByRole('link', { name: 'Continue' });
+    if (await continueLink.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await continueLink.click();
+    } else {
+      await keycloakLogin(page, user.username, user.password);
+    }
+  }
+  // Element persists the access token in localStorage once the SPA initialises.
+  await page.waitForFunction(
+    () => !!window.localStorage.getItem('mx_access_token'),
+    { timeout: 60_000 },
+  );
+  const token = await page.evaluate(() => window.localStorage.getItem('mx_access_token'));
+  expect(token, 'Matrix access token should be present in Element localStorage').toBeTruthy();
+  return token as string;
+}
+
+/**
+ * Resolve a user's canonical Matrix ID via the /whoami endpoint.
+ *
+ * Synapse's OIDC user_mapping_provider uses the email address as the
+ * localpart template, which Synapse then percent-escapes (e.g. `@` → `=40`)
+ * to stay within the Matrix localpart grammar. Rather than replicating the
+ * escape rules here, we ask Synapse what MXID was actually assigned.
+ */
+async function whoami(
+  page: import('@playwright/test').Page,
+  accessToken: string,
+): Promise<string> {
+  const res = await page.request.get(`${MATRIX_BASE}/_matrix/client/v3/account/whoami`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  expect(res.ok(), `whoami failed: ${res.status()}`).toBe(true);
+  const { user_id } = await res.json();
+  expect(user_id, 'whoami should return user_id').toBeTruthy();
+  return user_id as string;
+}
+
+const enabled = process.env.E2E_SYNAPSE_ROOM_INVITE_ENABLED === '1';
+
+test.describe('Onboarding — Synapse Room Invite (SMTP via Stalwart:588)', () => {
+  test.skip(
+    !enabled,
+    'E2E_SYNAPSE_ROOM_INVITE_ENABLED != 1 — needs Synapse email notifier interval reduced in dev before enabling',
+  );
+  test.skip(!isImapConfigured(), 'IMAP not configured (E2E_STALWART_ADMIN_PASSWORD not set)');
+
+  test('invited offline user receives Synapse notification email', async ({
+    emailTestPage: senderPage,
+    emailRecvPage: receiverPage,
+  }) => {
+    test.setTimeout(300_000); // 5 min: email notifier must fire after throttle window
+
+    const sender = TEST_USERS.emailTest;
+    const receiver = TEST_USERS.emailRecv;
+    const roomAlias = `E2E Invite ${Date.now()}`;
+
+    let roomId: string | null = null;
+    try {
+      // Warm receiver session so Synapse has a mapped user to invite, then
+      // query /whoami to get the authoritative MXID, then close the page to
+      // simulate "offline" for the email notifier.
+      const receiverToken = await getMatrixAccessToken(receiverPage, receiver);
+      const receiverMxid = await whoami(receiverPage, receiverToken);
+      await receiverPage.close();
+
+      const senderToken = await getMatrixAccessToken(senderPage, sender);
+
+      // Create a room and invite the receiver via the Matrix Client-Server API.
+      const headers = {
+        Authorization: `Bearer ${senderToken}`,
+        'Content-Type': 'application/json',
+      };
+      const createRes = await senderPage.request.post(`${MATRIX_BASE}/_matrix/client/v3/createRoom`, {
+        headers,
+        data: {
+          name: roomAlias,
+          preset: 'private_chat',
+          invite: [receiverMxid],
+        },
+      });
+      expect(createRes.ok(), `createRoom failed: ${createRes.status()} ${await createRes.text()}`).toBe(true);
+      const created = await createRes.json();
+      roomId = created.room_id;
+      expect(roomId, 'room_id should be returned').toBeTruthy();
+
+      // Send a message that mentions the invitee — a common trigger for the
+      // email notifier's unread-mention path.
+      const txnId = `e2e-${Date.now()}`;
+      const sendRes = await senderPage.request.put(
+        `${MATRIX_BASE}/_matrix/client/v3/rooms/${encodeURIComponent(roomId!)}/send/m.room.message/${txnId}`,
+        {
+          headers,
+          data: {
+            msgtype: 'm.text',
+            body: `${receiver.username}: you've been invited (E2E ${Date.now()})`,
+          },
+        },
+      );
+      expect(sendRes.ok(), `send message failed: ${sendRes.status()}`).toBe(true);
+
+      // Poll the receiver's inbox. The email subject is Synapse-controlled;
+      // match the notif_from display name from apps/environments/*/synapse.yaml.gotmpl.
+      const body = await waitForEmailBody({
+        userEmail: receiver.email,
+        bodyContains: roomAlias,
+        timeoutMs: 240_000,
+        pollIntervalMs: 10_000,
+      });
+      expect(body, 'expected Matrix notification email body').toContain(roomAlias);
+    } finally {
+      if (isImapConfigured()) {
+        await deleteEmailsBySubject({ userEmail: receiver.email, subjectContains: roomAlias });
+      }
+    }
+  });
+});

--- a/scripts/deploy_infra
+++ b/scripts/deploy_infra
@@ -275,16 +275,22 @@ fi
 # can mount the Secret on first install.
 if [ -n "${SES_SMTP_ENDPOINT:-}" ] && [ -n "${SES_SMTP_USERNAME:-}" ] && [ -n "${SES_SMTP_PASSWORD:-}" ]; then
   print_status "Applying SES credentials Secret to $NS_MONITORING (for Alertmanager)..."
+  # Save + restore umask so the rest of the script keeps its default perms.
+  # Don't use `trap EXIT` for cleanup here — mt_deploy_start already installed
+  # a completion-notification trap on EXIT that we must not clobber.
   AM_SES_SECRET_DIR=$(mktemp -d)
-  trap 'rm -rf "$AM_SES_SECRET_DIR"' EXIT
+  _AM_SES_PREV_UMASK=$(umask)
   umask 077
   printf '%s' "$SES_SMTP_USERNAME" > "$AM_SES_SECRET_DIR/username"
   printf '%s' "$SES_SMTP_PASSWORD" > "$AM_SES_SECRET_DIR/password"
+  umask "$_AM_SES_PREV_UMASK"
+  unset _AM_SES_PREV_UMASK
   kubectl create secret generic ses-credentials -n "$NS_MONITORING" \
     --from-file=username="$AM_SES_SECRET_DIR/username" \
     --from-file=password="$AM_SES_SECRET_DIR/password" \
     --dry-run=client -o yaml | mt_apply kubectl apply -f -
   rm -rf "$AM_SES_SECRET_DIR"
+  unset AM_SES_SECRET_DIR
 else
   # Remove stale Secret if SES was previously configured but isn't now.
   kubectl delete secret ses-credentials -n "$NS_MONITORING" --ignore-not-found=true >/dev/null 2>&1 || true

--- a/scripts/deploy_infra
+++ b/scripts/deploy_infra
@@ -262,6 +262,34 @@ else
   print_status "tcp-services ConfigMap does not exist yet, will be created by helmfile"
 fi
 
+# =============================================================================
+# SES credentials Secret for Alertmanager (infra-monitoring)
+# =============================================================================
+# Alertmanager submits operator alerts directly to AWS SES via SASL-authenticated
+# submission on port 587. The password lands in a Secret (mounted at
+# /etc/alertmanager/ses/password) so it's not embedded in Helm values. The
+# username is inline via requiredEnv in prometheus.yaml.gotmpl because
+# Alertmanager v0.27 has no smtp_auth_username_file.
+#
+# Must be applied before the tier=system helmfile sync so the Alertmanager pod
+# can mount the Secret on first install.
+if [ -n "${SES_SMTP_ENDPOINT:-}" ] && [ -n "${SES_SMTP_USERNAME:-}" ] && [ -n "${SES_SMTP_PASSWORD:-}" ]; then
+  print_status "Applying SES credentials Secret to $NS_MONITORING (for Alertmanager)..."
+  AM_SES_SECRET_DIR=$(mktemp -d)
+  trap 'rm -rf "$AM_SES_SECRET_DIR"' EXIT
+  umask 077
+  printf '%s' "$SES_SMTP_USERNAME" > "$AM_SES_SECRET_DIR/username"
+  printf '%s' "$SES_SMTP_PASSWORD" > "$AM_SES_SECRET_DIR/password"
+  kubectl create secret generic ses-credentials -n "$NS_MONITORING" \
+    --from-file=username="$AM_SES_SECRET_DIR/username" \
+    --from-file=password="$AM_SES_SECRET_DIR/password" \
+    --dry-run=client -o yaml | mt_apply kubectl apply -f -
+  rm -rf "$AM_SES_SECRET_DIR"
+else
+  # Remove stale Secret if SES was previously configured but isn't now.
+  kubectl delete secret ses-credentials -n "$NS_MONITORING" --ignore-not-found=true >/dev/null 2>&1 || true
+fi
+
 # Deploy system components via helmfile
 # Uses 'sync' instead of 'apply' to skip the slow diff operation —
 # for large charts like kube-prometheus-stack, diff can take 10+ minutes.


### PR DESCRIPTION
## Summary

- **Alertmanager → direct SES.** prod (and future SES-configured envs) submit operator alerts via authenticated SASL to `email-smtp.<region>.amazonaws.com:587` with STARTTLS. Password is file-mounted from a new `ses-credentials` Secret in `infra-monitoring`; username is `requiredEnv`-inlined (Alertmanager v0.27 has no `smtp_auth_username_file`). Dev stays on `postfix-internal:587` (no SES creds available).
- **prod-eu: drop `email_configs` entirely.** prod-eu has no SES creds AND no K8s Postfix (no tenant has `features.mail_enabled=true`), so its SMTP receiver was silently broken. Matrix + Healthchecks.io receivers are unaffected.
- **Bundled e2e specs from PR-2b carry-over** (both skipped-by-default pending CI plumbing): `sasl-auth-failure` (negative-path 535 guard) and `synapse-room-invite` (notification email via Stalwart:588, resolves MXID via `/whoami` instead of guessing OIDC escape rules).

## OSS Compliance Review

**Files reviewed**: 5 (`apps/environments/prod/prometheus.yaml.gotmpl`, `apps/environments/prod-eu/prometheus.yaml.gotmpl`, `e2e/tests/mail/sasl-auth-failure.spec.ts`, `e2e/tests/onboarding/synapse-room-invite.spec.ts`, `scripts/deploy_infra`)
**Changes analyzed**: +354 / -22 lines

No OSS compliance issues found. Changes are safe to commit.

- No real domains: only sanctioned placeholders (`dev.example.com`, `invalid.example`)
- No personal info, hardcoded credentials, or private registry references
- SES endpoint/username/password all flow via `requiredEnv` / env vars; the Secret is assembled from `$SES_SMTP_*` at deploy time with `umask 077` and cleaned up after `kubectl apply`
- No gitignored file patterns staged; config-boundary (`config/` submodule) intact
- `scripts/deploy_infra` correctly does **not** install an `EXIT` trap — it uses scoped save/restore of `umask` and explicit `rm -rf`/`unset` for cleanup so the pre-existing `mt_deploy_start` completion-notification trap is preserved

## Security Review

**Files reviewed**: 5
**Changes analyzed**: +354 / -22 lines

### Findings

**LOW** — Tempdir leak on `kubectl apply` failure (`scripts/deploy_infra:281-293`). With `set -euo pipefail`, if the `kubectl create ... | mt_apply kubectl apply -f -` pipeline fails, the script exits before `rm -rf "$AM_SES_SECRET_DIR"` runs, leaving the tempdir in `/tmp` (mktemp 0700, files 0600) until the OS tmpreaper sweeps it. Files are owner-only-readable and the SES password isn't lost (still in-env), so impact is minor.

### Summary

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 1

The prior HIGH finding (new EXIT trap clobbering `_mt_deploy_exit_handler` from `mt_deploy_start`) was resolved in commit `99e4d22` by dropping the trap and using inline cleanup + umask save/restore. A prior MEDIUM (`smtp_auth_username` landing in the Helm release Secret via `requiredEnv`) remains informational — it's a documented Alertmanager v0.27 constraint; the password (the sensitive piece) stays only in `ses-credentials`.

## Version Bump

No portal code changes — no VERSION / `image-versions.env` bump required.

## Test plan

- [ ] `helmfile -e prod template -l name=kube-prometheus-stack` renders `alertmanager.yaml` Secret with `smtp_smarthost: email-smtp...:587`, `smtp_auth_password_file: /etc/alertmanager/ses/password`, `smtp_require_tls: true` (already verified locally).
- [ ] `helmfile -e prod-eu template -l name=kube-prometheus-stack` renders `alertmanager.yaml` with **no** `smtp_*` keys (already verified locally).
- [ ] `helmfile -e dev template -l name=kube-prometheus-stack` still renders `postfix-internal.infra-mail.svc.cluster.local:587` (already verified locally).
- [ ] After deploy to prod: `kubectl get secret ses-credentials -n infra-monitoring` exists; `kubectl exec alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager -- ls -la /etc/alertmanager/ses/` shows `username` + `password`.
- [ ] Trigger a test alert (`amtool alert add` or disable/re-enable a dummy probe) and confirm arrival at `oncall@mother-tree.org`; check Alertmanager logs for SMTP success.
- [ ] Confirm Postfix no longer sees Alertmanager traffic: `kubectl logs -n infra-mail deploy/postfix -c postfix | grep alertmanager-kube-prometheus-stack` returns nothing after rollout.
- [ ] Dev alerts still fire via direct-send through cluster Postfix (existing behaviour).
- [ ] prod-eu alerts fire only to Matrix + Healthchecks.io (email path intentionally removed).

Refs: `step2-pr3-alertmanager.md`, mothertree-labs/mothertree-oss#349

🤖 Generated with [Claude Code](https://claude.com/claude-code)