### PR TITLE
feat(infra): on-demand-dev phase 1 — fixed-size dev pool

### DIFF
--- a/terraform.dev.tfvars.example
+++ b/terraform.dev.tfvars.example
@@ -5,21 +5,20 @@
 #
 # This file is loaded AFTER terraform.tfvars (if present), so values here override it.
 #
-# Common use case: dev clusters can be smaller / cheaper and optionally enable autoscaling
-# without changing prod.
+# Dev cluster is sized for an on-demand model: CI brings it up, an idle reaper
+# destroys it after a few hours of inactivity. Pool is fixed-size (no autoscaler)
+# so cold-start provisioning is predictable and cost is bounded.
 
-# Example: a small dev node pool with autoscaling enabled
-# - count is the initial/current node count
-# - autoscaler min/max bounds the pool size
+# Fixed-size pool — autoscaler intentionally omitted.
+# 3× g6-standard-4 matches prod sizing and is cheaper-per-vCPU than 7× standard-2.
 linode_node_pools = [
   {
-    type  = "g6-standard-2"
-    count = 2
-    tags  = ["matrix", "dev"]
-    autoscaler = {
-      min = 1
-      max = 3
-    }
+    type  = "g6-standard-4"
+    count = 3
+    tags  = ["matrix", "dev", "primary"]
   }
 ]
+
+# Note: dev volumes (postgres-dev-data, headscale-dev-data) are at Linode's 10 Gi
+# block-storage minimum already. Don't add volume_size overrides — they'd be no-ops.
 


### PR DESCRIPTION
## Summary

Phase 1 of the on-demand-dev work. Reshapes the dev LKE pool to support a future ephemeral-dev model where CI brings the cluster up on demand and an idle reaper destroys it.

- Pool: **7× g6-standard-2** (autoscaler 1→7, pinned at max) → **3× g6-standard-4** (fixed, no autoscaler)
- Right-sizes the pool for predictable cold-start in Phases 2/3
- ~$24/mo while-up savings vs. the 7-node max state today
- The actual local override lives in the gitignored `terraform.dev.tfvars`; this PR is the example/template only
- Submodule pointer bump captures `terraform-outputs.dev.env` regeneration (postfix-relay output cleanup left from #368)

### Decisions inherited from design docs

- Volume sizing in design doc was wrong: `postgres-dev-data` and `headscale-dev-data` are already at Linode's **10 Gi block-storage minimum** and cannot shrink further. Updated `.example` comment to head off future attempts.
- In-cluster PVCs in dev are minimal (Prometheus + Loki + Lens-IDE artifact); tenant components are emptyDir/S3. No PVC sweep was needed.

### Live execution evidence

- `terraform plan` against live dev: `0 to add, 2 to change, 0 to destroy` (in-place)
- Applied: `manage_infra -e dev --phase1` exit 0 in 1m28s
- Linode treated the pool type change as **delete-then-create** (new pool ID 880411 replaces 811622) despite Terraform's "in-place" framing — workloads were evicted and rescheduled, ~5 min disruption (acceptable for dev)
- Final state: 3× g6-standard-4 Ready, autoscaler off
- One-time pre-step required because of `lifecycle.ignore_changes = [pool[0].count]` in `modules/lke-cluster/main.tf`: had to run `linode-cli lke pool-update 551890 811622 --count 3 --autoscaler.enabled false` before terraform apply, otherwise terraform would have ignored the count change and built a 7-node g6-standard-4 pool ($336/mo, the opposite of the goal)

### What's NOT in this PR (deferred to later phases)

- Clean-destroy script for the LKE cluster (Phase 2)
- CI bring-up + idle reaper (Phase 3)
- Notifications + cost dashboard (Phase 4)
- Loki PVC removal (~$1/mo, defer)
- Removing/conditionalizing the `ignore_changes = [pool[0].count]` lifecycle (separate discussion — affects prod/prod-eu autoscaler behavior)

## Test plan

- [x] `terraform plan` shows expected diff (0 add / 2 change / 0 destroy)
- [x] Applied to live dev cluster, exit 0
- [x] All 3 new g6-standard-4 nodes reach Ready
- [x] Old 7 g6-standard-2 nodes drained and removed
- [x] Workloads rescheduled (Keycloak, ingress, Jitsi, etc.) — pods came back up on new pool
- [ ] Spot-check `verify-endpoints -e dev -t <tenant>` once pod stabilization completes (Loki/Grafana volume re-attach is slow on Linode CSI)

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

- No forbidden domains, personal info, or hardcoded credentials
- No private registry references
- No tenant info leaks
- `.example` template hygiene: real `terraform.dev.tfvars` remains gitignored
- Only Linode SKU identifiers (`g6-standard-2`, `g6-standard-4`) and generic tags

Clean to commit.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

- No secrets or credentials
- No network/firewall posture changes (file declares only LKE worker pool spec)
- No authorization/RBAC implications
- No escalation surface — switching pool types affects compute capacity and cost only
- Tags `["matrix", "dev", "primary"]` are operational labels, not privileged
- Comments accurately describe the on-demand model without leaking sensitive infra details

Clean to proceed.

## Version Bump Check

No portal code changes (admin-portal, account-portal, image-versions.env) — no version bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)