### PR TITLE
feat(infra): on-demand-dev phase 2 — destroy script + cold-start fixes

### DIFF
--- a/apps/manifests/nextcloud/before-starting-hook.sh
+++ b/apps/manifests/nextcloud/before-starting-hook.sh
@@ -9,16 +9,14 @@
 
 set -e
 
-# Install static support files unconditionally — these are required by the
-# readiness probe (oidc-health.php) and by deploy-calendar-automation.sh
-# (create-caldav-tokens.php). They must be in place BEFORE the install-state
-# guard below, because on a fresh cold-start pod Nextcloud is not yet
-# installed when this hook runs, so the guard would otherwise exit before
-# the cp runs and the readiness probe would fail forever (pod stays 1/2 Ready
-# because the probe re-runs but the install only completes once Apache is up,
-# and these hooks only fire once per container start).
-cp /docker-entrypoint-hooks.d/before-starting/oidc-health.php /var/www/html/oidc-health.php 2>/dev/null || true
-cp /docker-entrypoint-hooks.d/before-starting/create-caldav-tokens.php /var/www/html/create-caldav-tokens.php 2>/dev/null || true
+# Install static support files BEFORE the install-state guard below: the
+# readiness probe (oidc-health.php) must exist on first boot, before Nextcloud
+# is fully installed. Log on failure — a silent failure here would reproduce
+# the exact "pod stuck at 1/2 Ready" bug this block is meant to prevent.
+cp /docker-entrypoint-hooks.d/before-starting/oidc-health.php /var/www/html/oidc-health.php \
+    || echo "[before-starting] WARN: failed to install oidc-health.php — readiness probe will fail"
+cp /docker-entrypoint-hooks.d/before-starting/create-caldav-tokens.php /var/www/html/create-caldav-tokens.php \
+    || echo "[before-starting] WARN: failed to install create-caldav-tokens.php — calendar provisioning will fail"
 
 # Guard: skip the rest of the hook if Nextcloud isn't fully installed yet
 # (first boot race condition). The entrypoint generates config.php from env

--- a/apps/manifests/nextcloud/before-starting-hook.sh
+++ b/apps/manifests/nextcloud/before-starting-hook.sh
@@ -9,11 +9,23 @@
 
 set -e
 
-# Guard: skip if Nextcloud isn't fully installed yet (first boot race condition).
-# The entrypoint generates config.php from env vars, but the app may not be
-# fully bootstrapped when this hook runs on a fresh emptyDir pod.
+# Install static support files unconditionally — these are required by the
+# readiness probe (oidc-health.php) and by deploy-calendar-automation.sh
+# (create-caldav-tokens.php). They must be in place BEFORE the install-state
+# guard below, because on a fresh cold-start pod Nextcloud is not yet
+# installed when this hook runs, so the guard would otherwise exit before
+# the cp runs and the readiness probe would fail forever (pod stays 1/2 Ready
+# because the probe re-runs but the install only completes once Apache is up,
+# and these hooks only fire once per container start).
+cp /docker-entrypoint-hooks.d/before-starting/oidc-health.php /var/www/html/oidc-health.php 2>/dev/null || true
+cp /docker-entrypoint-hooks.d/before-starting/create-caldav-tokens.php /var/www/html/create-caldav-tokens.php 2>/dev/null || true
+
+# Guard: skip the rest of the hook if Nextcloud isn't fully installed yet
+# (first boot race condition). The entrypoint generates config.php from env
+# vars, but the app may not be fully bootstrapped when this hook runs on a
+# fresh emptyDir pod. The occ commands below require an installed instance.
 if ! php /var/www/html/occ status --output=json 2>/dev/null | grep -q '"installed":true'; then
-    echo "[before-starting] Nextcloud not yet installed, skipping hook (will run on next restart)"
+    echo "[before-starting] Nextcloud not yet installed, skipping occ commands (will run on next restart)"
     exit 0
 fi
 
@@ -123,11 +135,5 @@ if [ -f "$LOGIN_CONTROLLER" ]; then
 else
     echo "[before-starting] user_oidc not installed yet, skipping Login Flow v2 patch"
 fi
-
-# Install OIDC health check script (exec readiness probe uses this via CLI)
-cp /docker-entrypoint-hooks.d/before-starting/oidc-health.php /var/www/html/oidc-health.php 2>/dev/null || true
-
-# Install CalDAV token creation script (deploy-calendar-automation.sh calls this via kubectl exec)
-cp /docker-entrypoint-hooks.d/before-starting/create-caldav-tokens.php /var/www/html/create-caldav-tokens.php 2>/dev/null || true
 
 echo "[before-starting] Done"

--- a/apps/manifests/roundcube/db-init-job.yaml.tpl
+++ b/apps/manifests/roundcube/db-init-job.yaml.tpl
@@ -67,10 +67,13 @@ spec:
           GRANT ALL PRIVILEGES ON DATABASE "${ROUNDCUBE_DB_NAME}" TO "${ROUNDCUBE_DB_USER}";
           EOF
 
-          # Revoke default PUBLIC connect privilege so other tenant users cannot connect
+          # Revoke default PUBLIC connect privilege so other tenant users cannot connect.
+          # Also grant CONNECT to pgbouncer so it can run auth_query (looks up client
+          # password hash from pg_shadow on the client's requested DB).
           psql -h ${PG_HOST} -U postgres -d postgres <<EOF
           REVOKE CONNECT ON DATABASE "${ROUNDCUBE_DB_NAME}" FROM PUBLIC;
           GRANT CONNECT ON DATABASE "${ROUNDCUBE_DB_NAME}" TO "${ROUNDCUBE_DB_USER}";
+          GRANT CONNECT ON DATABASE "${ROUNDCUBE_DB_NAME}" TO "pgbouncer";
           EOF
 
           # Grant schema permissions (needed for newer PostgreSQL versions)

--- a/apps/manifests/stalwart/db-init-job.yaml.tpl
+++ b/apps/manifests/stalwart/db-init-job.yaml.tpl
@@ -94,6 +94,10 @@ spec:
               psql -v ON_ERROR_STOP=1 -c "REVOKE CONNECT ON DATABASE \"$DB_NAME\" FROM PUBLIC";
               psql -v ON_ERROR_STOP=1 -c "GRANT CONNECT ON DATABASE \"$DB_NAME\" TO \"$DB_USER\"";
 
+              # PgBouncer needs CONNECT on this DB to run auth_query (looks up client
+              # password hash from pg_shadow on the client's requested DB).
+              psql -v ON_ERROR_STOP=1 -c "GRANT CONNECT ON DATABASE \"$DB_NAME\" TO \"pgbouncer\"";
+
               # Grants in stalwart database for tenant user
               psql -v ON_ERROR_STOP=1 -d "$DB_NAME" -c "REVOKE ALL ON SCHEMA public FROM PUBLIC";
               psql -v ON_ERROR_STOP=1 -d "$DB_NAME" -c "GRANT ALL PRIVILEGES ON SCHEMA public TO \"$DB_USER\"";

--- a/apps/manifests/synapse/db-init-job.yaml.tpl
+++ b/apps/manifests/synapse/db-init-job.yaml.tpl
@@ -104,6 +104,10 @@ spec:
               psql -v ON_ERROR_STOP=1 -c "REVOKE CONNECT ON DATABASE \"$DB_NAME\" FROM PUBLIC";
               psql -v ON_ERROR_STOP=1 -c "GRANT CONNECT ON DATABASE \"$DB_NAME\" TO \"$DB_USER\"";
 
+              # PgBouncer needs CONNECT on this DB to run auth_query (looks up client
+              # password hash from pg_shadow on the client's requested DB).
+              psql -v ON_ERROR_STOP=1 -c "GRANT CONNECT ON DATABASE \"$DB_NAME\" TO \"pgbouncer\"";
+
               # Grants in synapse database for tenant user
               psql -v ON_ERROR_STOP=1 -d "$DB_NAME" -c "REVOKE ALL ON SCHEMA public FROM PUBLIC";
               psql -v ON_ERROR_STOP=1 -d "$DB_NAME" -c "GRANT ALL PRIVILEGES ON SCHEMA public TO \"$DB_USER\"";

--- a/apps/values/docs-postgresql.yaml
+++ b/apps/values/docs-postgresql.yaml
@@ -87,9 +87,13 @@ primary:
         END
         $$;
 
-        -- Revoke default PUBLIC connect privilege for cross-tenant isolation
+        -- Revoke default PUBLIC connect privilege for cross-tenant isolation.
+        -- Grant CONNECT to pgbouncer so it can run auth_query against this DB
+        -- (auth_query looks up client password hash from pg_shadow on the
+        -- client's requested database).
         REVOKE CONNECT ON DATABASE keycloak FROM PUBLIC;
         GRANT CONNECT ON DATABASE keycloak TO keycloak;
+        GRANT CONNECT ON DATABASE keycloak TO pgbouncer;
 
 # PostgreSQL metrics exporter (postgres_exporter sidecar)
 metrics:

--- a/docs/nextcloud-db-init-job.yaml.tpl
+++ b/docs/nextcloud-db-init-job.yaml.tpl
@@ -78,6 +78,12 @@ spec:
               psql -v ON_ERROR_STOP=1 -c "REVOKE CONNECT ON DATABASE \"$DB_NAME\" FROM PUBLIC"
               psql -v ON_ERROR_STOP=1 -c "GRANT CONNECT ON DATABASE \"$DB_NAME\" TO \"$DB_USER\""
 
+              # Grant CONNECT to pgbouncer so it can run auth_query against this DB.
+              # PgBouncer connects to the client's requested DB to look up the client's
+              # password hash from pg_shadow; without CONNECT it fails with "permission
+              # denied for database" — see PR notes for full cold-start incident.
+              psql -v ON_ERROR_STOP=1 -c "GRANT CONNECT ON DATABASE \"$DB_NAME\" TO \"pgbouncer\""
+
               # Grant permissions to per-tenant user on nextcloud database
               echo "Granting permissions to $DB_USER..."
               psql -v ON_ERROR_STOP=1 -d "$DB_NAME" -c "REVOKE ALL ON SCHEMA public FROM PUBLIC"

--- a/scripts/destroy-dev-cluster.sh
+++ b/scripts/destroy-dev-cluster.sh
@@ -28,6 +28,17 @@
 #   ./scripts/destroy-dev-cluster.sh -e dev
 #   ./scripts/destroy-dev-cluster.sh -e dev --dry-run
 #   ./scripts/destroy-dev-cluster.sh -e dev --no-lock   # placeholder for Phase 3
+#
+# Exit codes:
+#   0 — success
+#   1 — generic failure (set -e, command failures)
+#   2 — wrong env (must be 'dev')
+#   3 — post-destroy assertion failed: an always-up resource disappeared
+#   4 — postgres-credentials Secret unavailable (would skip tenant DB drop)
+#   5 — discovered DB name failed the safe-identifier allowlist regex
+#   6 — DROP DATABASE failed on a discovered tenant DB
+#   7 — found a tagged 'dev' volume not in ALWAYS_UP_VOLUMES with an operator-style
+#       label (refuses to auto-delete; whitelist update needed)
 
 set -euo pipefail
 
@@ -213,10 +224,12 @@ fi
 # ---------------------------------------------------------------------------
 if [ "$CLUSTER_EXISTS" = "true" ]; then
 
-  # 2a — Force-evict known drain blockers. These three workload classes have
-  # consistently blocked node drain in dev (verified during Phase 1's pool roll).
-  # Each `|| true` covers the case where the resource is already gone.
-  print_status "Force-evicting known drain blockers..."
+  # 2a — Force-terminate pods that hold PVCs or have problematic finalizers,
+  # so the PVC sweep in 2b can release the underlying Linode block volumes
+  # cleanly. Without this, the orphan sweep in step 4 has to scoop up leaked
+  # CSI volumes. Each `|| true` covers the case where the resource is already
+  # gone (idempotency).
+  print_status "Force-evicting pods that block clean PVC release..."
 
   # Stuck Jitsi JVB pods (label is `app=jitsi-jvb`, NOT `app.kubernetes.io/name`).
   # Pods stick in Terminating for tens of days due to a hostPort/UDP cleanup quirk.
@@ -345,10 +358,13 @@ pushd "$REPO_ROOT/phase1" >/dev/null
     -var jitsi_tester_enabled=false
 
   # Defense in depth: confirm always-up VM modules survived the destroy.
+  # Anchor the match to a full module/resource path (entry + dot or end-of-line)
+  # so a future rename like `module.headscale_server` → `module.headscale` doesn't
+  # silently keep passing because something else still contains the substring.
   print_status "Asserting always-up VMs are still in terraform state..."
   STATE_LIST=$(terraform state list 2>/dev/null)
   for entry in "${ALWAYS_UP_TF_MODULES[@]}"; do
-    if ! echo "$STATE_LIST" | grep -q "$entry"; then
+    if ! echo "$STATE_LIST" | grep -qE "^${entry}(\.|$)"; then
       print_error "ASSERTION FAILED: $entry is missing from terraform state!"
       print_error "The destroy widened beyond the ephemeral cluster — this is a bug."
       exit 3
@@ -378,6 +394,16 @@ linode-cli volumes list --json 2>/dev/null | jq -r --arg region "$CLUSTER_REGION
     if [ "$skip" = "true" ]; then
       echo "  Preserving always-up volume: $label (id=$id)"
       continue
+    fi
+    # Defense: only auto-delete CSI-managed volumes (label `pvc-<uuid>`). A
+    # tagged 'dev' volume with a human label that ISN'T in ALWAYS_UP_VOLUMES is
+    # suspicious — it's probably a new always-up resource whose maintainer
+    # forgot to add it to the whitelist. Refuse rather than silently destroy.
+    if ! echo "$label" | grep -qE '^pvc-'; then
+      print_error "Refusing to delete tagged 'dev' volume with operator-style label: $label (id=$id)"
+      print_error "If this is a new always-up resource, add it to ALWAYS_UP_VOLUMES in this script."
+      print_error "If this is a real orphan, delete it manually: linode-cli volumes delete $id"
+      exit 7
     fi
     print_status "  Detaching + deleting tagged orphan: $label (id=$id)"
     linode-cli volumes detach "$id" 2>/dev/null || true

--- a/scripts/destroy-dev-cluster.sh
+++ b/scripts/destroy-dev-cluster.sh
@@ -1,0 +1,428 @@
+#!/bin/bash
+
+# Destroy Dev LKE Cluster (ephemeral)
+#
+# Purpose: Tear down the dev LKE cluster and the LKE-side resources it creates
+#          (CCM-managed NodeBalancer, CSI-provisioned PVCs/block volumes), so
+#          that nothing keeps billing while dev is "off".
+#
+# Explicitly does NOT touch the always-up VMs:
+#   - postgres-dev   (Linode VM + 10 Gi data volume)
+#   - headscale-dev  (Linode VM + 10 Gi data volume)
+#   - turn-server-dev (Linode VM)
+#
+# Also does NOT touch the shared VPC (matrix-cluster-<env>-vpc). Even though it
+# is defined inside module.lke_cluster, it contains both the LKE cluster_subnet
+# (ephemeral) AND the support_subnet (which holds the always-up VMs). Destroying
+# the VPC would require evicting the always-up VMs. The cluster_subnet is
+# destroyed and recreated each cycle; the VPC + support_subnet persist.
+#
+# These are kept across destroy/recreate cycles. The cost/benefit of cycling
+# postgres-dev (~$13/mo) is poor: it's outside K8s, schema bootstrap is painful,
+# and the volume is already at Linode's 10 Gi block-storage minimum.
+#
+# Idempotent: safe to re-run on an already-destroyed cluster.
+# Phase 2 of the on-demand-dev plan; Phase 3 will wire this into a CI reaper.
+#
+# Usage:
+#   ./scripts/destroy-dev-cluster.sh -e dev
+#   ./scripts/destroy-dev-cluster.sh -e dev --dry-run
+#   ./scripts/destroy-dev-cluster.sh -e dev --no-lock   # placeholder for Phase 3
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "${REPO_ROOT}/scripts/lib/common.sh"
+source "${REPO_ROOT}/scripts/lib/args.sh"
+
+mt_usage() {
+  cat <<EOF
+Usage: $0 -e dev [options]
+
+Destroys the dev LKE cluster + LKE-side resources (NodeBalancer, CSI volumes).
+Does NOT touch postgres-dev, headscale-dev, or turn-server-dev (always-up VMs).
+
+Options:
+  -e dev        Environment (must be 'dev')
+  --dry-run     Print resolved targets without destroying anything
+  --no-lock     Skip lock acquisition (Phase 3 placeholder; for now this is a no-op)
+  -h, --help    Show this help
+EOF
+}
+
+mt_parse_args "$@"
+mt_require_env
+
+# Hard guard: this script only supports dev. The cost model and the always-up VM
+# whitelist below are dev-specific.
+if [ "$MT_ENV" != "dev" ]; then
+  print_error "destroy-dev-cluster.sh only supports 'dev' (got '$MT_ENV')"
+  exit 2
+fi
+
+DRY_RUN="false"
+if mt_has_flag "--dry-run"; then DRY_RUN="true"; fi
+
+# Volumes that must NEVER be deleted by this script. These are attached to
+# always-up VMs that live outside the LKE cluster lifecycle.
+ALWAYS_UP_VOLUMES=(
+  "postgres-dev-data"
+  "headscale-dev-data"
+)
+
+# Terraform state entries that MUST still exist after the destroy. If any of
+# these disappear, the -target list is wrong and we have widened the blast
+# radius beyond the ephemeral cluster.
+#
+# The VPC is included here even though it lives inside module.lke_cluster: it
+# is shared with the support_subnet (always-up VMs) and must persist across
+# destroy/recreate cycles. See header for the full rationale.
+ALWAYS_UP_TF_MODULES=(
+  "module.headscale_server"
+  "module.postgres_server"
+  "linode_instance.turn_server"
+  "module.lke_cluster.linode_vpc.cluster_vpc"
+)
+
+CLUSTER_REGION="us-lax"
+CLUSTER_LABEL="matrix-cluster-${MT_ENV}"
+
+# All kubectl calls go via this wrapper so a stale kubeconfig pointing at a
+# destroyed cluster cannot hang the script.
+KUBECTL=(kubectl --kubeconfig="${REPO_ROOT}/kubeconfig.${MT_ENV}.yaml" --request-timeout=30s)
+
+mt_require_commands linode-cli jq terraform kubectl
+
+# Load shared infra secrets (linode_token, cloudflare_*, ssh_public_key) for terraform.
+# Match manage_infra's lookup order.
+if [ -f "$REPO_ROOT/secrets.tfvars.env" ]; then
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/secrets.tfvars.env"
+elif [ -f "$REPO_ROOT/secrets.${MT_ENV}.tfvars.env" ]; then
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/secrets.${MT_ENV}.tfvars.env"
+else
+  print_error "No secrets file found. Expected $REPO_ROOT/secrets.tfvars.env"
+  exit 1
+fi
+
+# linode-cli looks for LINODE_CLI_TOKEN in env. Map from terraform var if not set.
+export LINODE_CLI_TOKEN="${LINODE_CLI_TOKEN:-${TF_VAR_linode_token:-}}"
+if [ -z "${LINODE_CLI_TOKEN:-}" ]; then
+  print_error "LINODE_CLI_TOKEN (or TF_VAR_linode_token) is required"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1: detect cluster
+# ---------------------------------------------------------------------------
+print_status "Looking up '$CLUSTER_LABEL' in Linode..."
+CLUSTER_ID=$(linode-cli lke clusters-list --json 2>/dev/null \
+  | jq -r --arg label "$CLUSTER_LABEL" '.[] | select(.label == $label) | .id // empty')
+
+if [ -z "$CLUSTER_ID" ]; then
+  print_warning "No LKE cluster '$CLUSTER_LABEL' found — skipping K8s sweep + terraform destroy"
+  CLUSTER_EXISTS=false
+else
+  print_status "Found cluster id=$CLUSTER_ID"
+  CLUSTER_EXISTS=true
+fi
+
+# ---------------------------------------------------------------------------
+# Dry-run: print what we would do, then exit
+# ---------------------------------------------------------------------------
+if [ "$DRY_RUN" = "true" ]; then
+  echo ""
+  print_status "=== DRY RUN ==="
+  echo "Cluster:        $CLUSTER_LABEL (id=${CLUSTER_ID:-<not found>})"
+  echo "Region:         $CLUSTER_REGION"
+  echo ""
+
+  echo "Terraform targets that would be destroyed:"
+  echo "  -target=module.lke_cluster.linode_lke_cluster.cluster"
+  echo "  -target=module.lke_cluster.linode_vpc_subnet.cluster_subnet"
+  echo "  -target=local_file.kubeconfig"
+  echo ""
+
+  echo "Always-up resources (will be preserved):"
+  echo "  - postgres-dev (VM + 10 Gi data volume)"
+  echo "  - headscale-dev (VM + 10 Gi data volume)"
+  echo "  - turn-server-dev (VM)"
+  echo "  - matrix-cluster-${MT_ENV}-vpc (shared with support_subnet → always-up VMs)"
+  echo ""
+
+  if [ "$CLUSTER_EXISTS" = "true" ]; then
+    echo "Drain blockers that would be force-evicted:"
+    "${KUBECTL[@]}" get pods -A -l app=jitsi-jvb --no-headers 2>/dev/null \
+      | awk '{print "  jitsi-jvb: " $1 "/" $2}' || true
+    "${KUBECTL[@]}" get pod keycloak-keycloakx-0 -n infra-auth --no-headers 2>/dev/null \
+      | awk '{print "  keycloak: infra-auth/" $1}' || true
+    "${KUBECTL[@]}" get pods -n infra-ingress-internal -l app.kubernetes.io/name=ingress-nginx --no-headers 2>/dev/null \
+      | awk '{print "  ingress-internal: infra-ingress-internal/" $1}' || true
+    echo ""
+
+    echo "PVCs that would be deleted (cluster-wide):"
+    "${KUBECTL[@]}" get pvc -A --no-headers 2>/dev/null \
+      | awk '{print "  " $1 "/" $2 " (" $4 ")"}' || true
+    echo ""
+
+    echo "Tenant Nextcloud databases that would be dropped (postgres-dev, via PgBouncer):"
+    PG_PASSWORD=$("${KUBECTL[@]}" get secret postgres-credentials -n infra-db \
+      -o jsonpath='{.data.postgres-password}' 2>/dev/null | base64 -d || true)
+    if [ -n "$PG_PASSWORD" ]; then
+      "${KUBECTL[@]}" run psql-list-tenants --rm -i --restart=Never \
+        --image=postgres:16 --quiet -n default \
+        --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+        --env "PGUSER=postgres" \
+        --env "PGPASSWORD=$PG_PASSWORD" \
+        -- psql -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'nextcloud\\_%' ESCAPE '\\';" 2>/dev/null \
+        | grep -v '^$' | awk '{print "  " $1}' || echo "  (query failed)"
+    else
+      echo "  (postgres-credentials secret unavailable — would skip drop)"
+    fi
+    echo ""
+  fi
+
+  echo "Volume orphan-sweep candidates (region=$CLUSTER_REGION, tag=dev):"
+  linode-cli volumes list --json 2>/dev/null | jq -r --arg region "$CLUSTER_REGION" '
+    .[] | select(.tags | index("dev")) | select(.region == $region)
+    | "  \(.id)\t\(.label)\t(\(.size) Gi)"' || true
+  echo ""
+
+  echo "CSI orphan-sweep candidates (region=$CLUSTER_REGION, label=pvc-*, unattached):"
+  linode-cli volumes list --json 2>/dev/null | jq -r --arg region "$CLUSTER_REGION" '
+    .[] | select(.label | startswith("pvc-")) | select(.region == $region) | select(.linode_id == null)
+    | "  \(.id)\t\(.label)\t(\(.size) Gi)"' || true
+  echo ""
+
+  echo "NodeBalancer orphan-sweep candidates:"
+  if [ -n "$CLUSTER_ID" ]; then
+    linode-cli nodebalancers list --json 2>/dev/null | jq -r --arg region "$CLUSTER_REGION" --arg prefix "lke${CLUSTER_ID}-" '
+      .[] | select(.region == $region) | select(.label | startswith($prefix))
+      | "  \(.id)\t\(.label)"' || true
+  else
+    echo "  (cluster id unknown — would skip NB sweep)"
+  fi
+
+  print_status "Dry run complete. No changes made."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: K8s pre-destroy sweep (if cluster exists)
+# ---------------------------------------------------------------------------
+if [ "$CLUSTER_EXISTS" = "true" ]; then
+
+  # 2a — Force-evict known drain blockers. These three workload classes have
+  # consistently blocked node drain in dev (verified during Phase 1's pool roll).
+  # Each `|| true` covers the case where the resource is already gone.
+  print_status "Force-evicting known drain blockers..."
+
+  # Stuck Jitsi JVB pods (label is `app=jitsi-jvb`, NOT `app.kubernetes.io/name`).
+  # Pods stick in Terminating for tens of days due to a hostPort/UDP cleanup quirk.
+  "${KUBECTL[@]}" get pods -A -l app=jitsi-jvb -o name 2>/dev/null \
+    | xargs -r -I{} "${KUBECTL[@]}" delete {} --force --grace-period=0 --ignore-not-found 2>&1 \
+    | sed 's/^/  /' || true
+
+  # Keycloak StatefulSet — strict podAntiAffinity prevents in-place migration.
+  "${KUBECTL[@]}" delete pod keycloak-keycloakx-0 -n infra-auth --grace-period=10 --ignore-not-found 2>&1 \
+    | sed 's/^/  /' || true
+
+  # Internal ingress controller — PDB blocks ordinary eviction.
+  "${KUBECTL[@]}" delete pods -n infra-ingress-internal \
+    -l app.kubernetes.io/name=ingress-nginx --grace-period=10 --ignore-not-found 2>&1 \
+    | sed 's/^/  /' || true
+
+  # 2b — PVC sweep. Triggers Linode CSI to release the underlying block volumes
+  # cleanly (the `linode-block-storage-retain` storage class won't auto-delete
+  # otherwise — those become the orphans pass 2 sweeps below).
+  print_status "Deleting all PVCs cluster-wide (triggers CSI volume release)..."
+  "${KUBECTL[@]}" delete pvc --all -A --timeout=120s --ignore-not-found 2>&1 \
+    | sed 's/^/  /' || true
+
+  # Wait up to 60s for PVs to fully detach. Best-effort — if some are stuck,
+  # the orphan sweep below will catch them.
+  print_status "Waiting for PVs to detach..."
+  for _ in {1..30}; do
+    pv_count=$("${KUBECTL[@]}" get pv --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$pv_count" = "0" ]; then
+      print_success "All PVs detached"
+      break
+    fi
+    echo "  $pv_count PV(s) still present..."
+    sleep 2
+  done
+
+  # 2c — Drop tenant Nextcloud databases via the in-cluster PgBouncer.
+  # The postgres-dev VM is preserved across destroy/recreate cycles (always-up),
+  # which means the tenant DBs persist too. For Nextcloud specifically this
+  # breaks cold-start: the DB has tables + appconfig from the previous cycle,
+  # but the K8s `nextcloud-identity` Secret (which encodes config.php identity
+  # values) is destroyed with the cluster. The new pods can't replay the prior
+  # install state, the entrypoint sees the existing DB and skips install, and
+  # the deploy script then fails on `occ config:system:set` because Nextcloud
+  # reports installed=false. Dropping the DB lets the next deploy reinstall
+  # cleanly from an empty schema. (See PR notes for the full incident.)
+  #
+  # We run this BEFORE terraform destroy because PgBouncer is in-cluster — once
+  # the cluster is gone, the only path to postgres-dev is via direct Tailscale,
+  # which the operator's local machine doesn't always have.
+  print_status "Dropping tenant Nextcloud databases via in-cluster PgBouncer..."
+  PG_PASSWORD=$("${KUBECTL[@]}" get secret postgres-credentials -n infra-db \
+    -o jsonpath='{.data.postgres-password}' 2>/dev/null | base64 -d || true)
+  if [ -n "$PG_PASSWORD" ]; then
+    # Discover and drop every nextcloud_<tenant> database that exists.
+    DROP_SQL=$("${KUBECTL[@]}" run psql-drop-tenants --rm -i --restart=Never \
+      --image=postgres:16 --quiet -n default \
+      --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+      --env "PGUSER=postgres" \
+      --env "PGPASSWORD=$PG_PASSWORD" \
+      -- psql -tAc "SELECT 'DROP DATABASE IF EXISTS \"' || datname || '\" WITH (FORCE);' FROM pg_database WHERE datname LIKE 'nextcloud\\_%' ESCAPE '\\';" \
+      2>/dev/null | grep -E '^DROP DATABASE' || true)
+    if [ -n "$DROP_SQL" ]; then
+      echo "$DROP_SQL" | sed 's/^/  will run: /'
+      "${KUBECTL[@]}" run psql-drop-tenants --rm -i --restart=Never \
+        --image=postgres:16 --quiet -n default \
+        --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+        --env "PGUSER=postgres" \
+        --env "PGPASSWORD=$PG_PASSWORD" \
+        -- psql -v ON_ERROR_STOP=1 -c "$DROP_SQL" 2>&1 \
+        | sed 's/^/  /' || print_warning "  Some DROP statements may have failed"
+    else
+      echo "  No nextcloud_* databases found, skipping drop"
+    fi
+  else
+    print_warning "Could not load postgres-credentials secret — skipping tenant DB drop"
+    print_warning "Cold-start of Nextcloud on the next cycle will likely fail until you drop the DBs manually"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: terraform destroy (LKE cluster only — never the always-up VMs)
+# ---------------------------------------------------------------------------
+print_status "Running terraform destroy (LKE cluster only)..."
+
+ENV_DNS_LABEL="$MT_ENV"   # 'dev' (per manage_infra convention; only 'prod' is empty)
+
+pushd "$REPO_ROOT/phase1" >/dev/null
+
+  terraform init -input=false >/dev/null
+  terraform workspace select "$MT_ENV"
+
+  VAR_FILE_FLAGS=()
+  if [ -f "$REPO_ROOT/terraform.tfvars" ]; then
+    VAR_FILE_FLAGS+=("-var-file=$REPO_ROOT/terraform.tfvars")
+  fi
+  if [ -f "$REPO_ROOT/terraform.${MT_ENV}.tfvars" ]; then
+    VAR_FILE_FLAGS+=("-var-file=$REPO_ROOT/terraform.${MT_ENV}.tfvars")
+  fi
+
+  # Target only the ephemeral cluster pieces — explicitly NOT the VPC. The VPC
+  # is defined inside module.lke_cluster but it is shared with the support_subnet
+  # (always-up VMs); targeting `module.lke_cluster` as a whole pulls the VPC in
+  # and Linode rejects the delete because the VPC still has resources in it.
+  # The post-destroy assertion below double-checks the VPC + always-up VMs
+  # survive in state.
+  terraform destroy -auto-approve "${VAR_FILE_FLAGS[@]}" \
+    -target=module.lke_cluster.linode_lke_cluster.cluster \
+    -target=module.lke_cluster.linode_vpc_subnet.cluster_subnet \
+    -target=local_file.kubeconfig \
+    -var env="$MT_ENV" \
+    -var env_dns_label="$ENV_DNS_LABEL" \
+    -var jitsi_tester_enabled=false
+
+  # Defense in depth: confirm always-up VM modules survived the destroy.
+  print_status "Asserting always-up VMs are still in terraform state..."
+  STATE_LIST=$(terraform state list 2>/dev/null)
+  for entry in "${ALWAYS_UP_TF_MODULES[@]}"; do
+    if ! echo "$STATE_LIST" | grep -q "$entry"; then
+      print_error "ASSERTION FAILED: $entry is missing from terraform state!"
+      print_error "The destroy widened beyond the ephemeral cluster — this is a bug."
+      exit 3
+    fi
+  done
+  print_success "All always-up resources (postgres-dev, headscale-dev, turn-server-dev, VPC) preserved in state"
+
+popd >/dev/null
+
+# ---------------------------------------------------------------------------
+# Step 4: orphan sweep — block volumes (two-pass)
+# ---------------------------------------------------------------------------
+
+# Pass 1: Terraform-tagged 'dev' volumes that somehow survived terraform destroy.
+# Belt-and-suspenders — should be empty in practice. Skips the always-up VM
+# data volumes by label.
+print_status "Orphan sweep pass 1: tagged 'dev' volumes..."
+linode-cli volumes list --json 2>/dev/null | jq -r --arg region "$CLUSTER_REGION" '
+  .[] | select(.tags | index("dev")) | select(.region == $region)
+  | "\(.id)\t\(.label)"' \
+| while IFS=$'\t' read -r id label; do
+    # Skip the always-up VM data volumes — these are the whole point of "always-up".
+    skip=false
+    for protected in "${ALWAYS_UP_VOLUMES[@]}"; do
+      if [ "$label" = "$protected" ]; then skip=true; break; fi
+    done
+    if [ "$skip" = "true" ]; then
+      echo "  Preserving always-up volume: $label (id=$id)"
+      continue
+    fi
+    print_status "  Detaching + deleting tagged orphan: $label (id=$id)"
+    linode-cli volumes detach "$id" 2>/dev/null || true
+    sleep 2
+    linode-cli volumes delete "$id" || print_warning "  Failed to delete volume $id"
+  done
+
+# Pass 2: CSI-provisioned orphans. Linode CSI tags volumes with `[]`, labels them
+# `pvc-<uuid>`, and uses `linode-block-storage-retain` so they won't auto-delete
+# when the cluster goes away. We catch them by label prefix + region + unattached.
+#
+# IMPORTANT: this filter relies on dev being the only cluster in $CLUSTER_REGION
+# with unattached pvc-* volumes at this moment. Prod's CSI volumes will still
+# be attached to running prod nodes, so they won't match. If prod ever moves
+# into us-lax, this filter must be tightened. (Prod is currently us-east, prod-eu
+# is nl-ams — Phase 1 verified.)
+print_status "Orphan sweep pass 2: CSI-provisioned orphans (label=pvc-*, unattached, region=$CLUSTER_REGION)..."
+linode-cli volumes list --json 2>/dev/null | jq -r --arg region "$CLUSTER_REGION" '
+  .[] | select(.label | startswith("pvc-"))
+       | select(.region == $region)
+       | select(.linode_id == null)
+  | "\(.id)\t\(.label)"' \
+| while IFS=$'\t' read -r id label; do
+    print_status "  Deleting CSI orphan: $label (id=$id)"
+    linode-cli volumes delete "$id" || print_warning "  Failed to delete volume $id"
+  done
+
+# ---------------------------------------------------------------------------
+# Step 5: orphan sweep — NodeBalancers
+# ---------------------------------------------------------------------------
+# CCM-managed NBs are tagged ONLY ["kubernetes"] (no "dev" tag), so the reliable
+# signal is the label format `lke<cluster_id>-<hash>`. LKE *should* clean these
+# up on cluster destroy — this is belt-and-suspenders.
+if [ -n "${CLUSTER_ID:-}" ]; then
+  print_status "Orphan sweep: NodeBalancers labeled lke${CLUSTER_ID}-*..."
+  linode-cli nodebalancers list --json 2>/dev/null \
+    | jq -r --arg region "$CLUSTER_REGION" --arg prefix "lke${CLUSTER_ID}-" '
+        .[] | select(.region == $region) | select(.label | startswith($prefix)) | .id' \
+    | while read -r nb_id; do
+        print_status "  Deleting NodeBalancer id=$nb_id"
+        linode-cli nodebalancers delete "$nb_id" || print_warning "  Failed to delete NB $nb_id"
+      done
+else
+  print_status "Skipping NodeBalancer sweep (no cluster id captured)"
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+echo ""
+print_success "Dev cluster destroy complete."
+echo ""
+echo "Always-up resources preserved:"
+echo "  - postgres-dev VM + 10 Gi data volume"
+echo "  - headscale-dev VM + 10 Gi data volume"
+echo "  - turn-server-dev VM"
+echo "  - matrix-cluster-${MT_ENV}-vpc (shared with support_subnet → always-up VMs)"
+echo "  - DNS records (Cloudflare)"
+echo ""
+echo "To rebuild the cluster: ./scripts/manage_infra -e $MT_ENV --phase1 \\"
+echo "                        && ./scripts/deploy_infra -e $MT_ENV"

--- a/scripts/destroy-dev-cluster.sh
+++ b/scripts/destroy-dev-cluster.sh
@@ -270,30 +270,43 @@ if [ "$CLUSTER_EXISTS" = "true" ]; then
   print_status "Dropping tenant Nextcloud databases via in-cluster PgBouncer..."
   PG_PASSWORD=$("${KUBECTL[@]}" get secret postgres-credentials -n infra-db \
     -o jsonpath='{.data.postgres-password}' 2>/dev/null | base64 -d || true)
-  if [ -n "$PG_PASSWORD" ]; then
-    # Discover and drop every nextcloud_<tenant> database that exists.
-    DROP_SQL=$("${KUBECTL[@]}" run psql-drop-tenants --rm -i --restart=Never \
-      --image=postgres:16 --quiet -n default \
-      --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
-      --env "PGUSER=postgres" \
-      --env "PGPASSWORD=$PG_PASSWORD" \
-      -- psql -tAc "SELECT 'DROP DATABASE IF EXISTS \"' || datname || '\" WITH (FORCE);' FROM pg_database WHERE datname LIKE 'nextcloud\\_%' ESCAPE '\\';" \
-      2>/dev/null | grep -E '^DROP DATABASE' || true)
-    if [ -n "$DROP_SQL" ]; then
-      echo "$DROP_SQL" | sed 's/^/  will run: /'
-      "${KUBECTL[@]}" run psql-drop-tenants --rm -i --restart=Never \
+  if [ -z "$PG_PASSWORD" ]; then
+    print_error "Could not load postgres-credentials secret — refusing to continue."
+    print_error "Cold-start of Nextcloud on the next cycle would fail. Either drop the DBs"
+    print_error "manually before re-running this script, or fix the postgres-credentials Secret."
+    exit 4
+  fi
+  # Discover nextcloud_<tenant> databases. Output one name per line.
+  TENANT_DBS=$("${KUBECTL[@]}" run psql-list-tenants --rm -i --restart=Never \
+    --image=postgres:16 --quiet -n default \
+    --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+    --env "PGUSER=postgres" \
+    --env "PGPASSWORD=$PG_PASSWORD" \
+    -- psql -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'nextcloud\\_%' ESCAPE '\\';" \
+    2>/dev/null | grep -E '^[a-z0-9_-]+$' || true)
+  if [ -z "$TENANT_DBS" ]; then
+    echo "  No nextcloud_* databases found, skipping drop"
+  else
+    while IFS= read -r db; do
+      # Allowlist regex defends against SQL identifier injection. tenant DB names
+      # are operator-controlled via deploy scripts and always match `nextcloud_<tenant>`
+      # with lowercase + digits + underscore/hyphen; anything else is suspicious.
+      if [[ ! "$db" =~ ^nextcloud_[a-z0-9][a-z0-9_-]*$ ]]; then
+        print_error "  Refusing to drop suspicious DB name: $db"
+        exit 5
+      fi
+      print_status "  Dropping $db"
+      # DROP DATABASE cannot run inside a transaction block, so each DROP must
+      # be its own psql -c invocation (one auto-commit transaction each).
+      "${KUBECTL[@]}" run psql-drop --rm -i --restart=Never \
         --image=postgres:16 --quiet -n default \
         --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
         --env "PGUSER=postgres" \
         --env "PGPASSWORD=$PG_PASSWORD" \
-        -- psql -v ON_ERROR_STOP=1 -c "$DROP_SQL" 2>&1 \
-        | sed 's/^/  /' || print_warning "  Some DROP statements may have failed"
-    else
-      echo "  No nextcloud_* databases found, skipping drop"
-    fi
-  else
-    print_warning "Could not load postgres-credentials secret — skipping tenant DB drop"
-    print_warning "Cold-start of Nextcloud on the next cycle will likely fail until you drop the DBs manually"
+        -- psql -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS \"$db\" WITH (FORCE);" 2>&1 \
+        | sed 's/^/    /' \
+        || { print_error "  Failed to drop $db — aborting"; exit 6; }
+    done <<< "$TENANT_DBS"
   fi
 fi
 

--- a/scripts/manage_infra
+++ b/scripts/manage_infra
@@ -100,6 +100,9 @@ if mt_has_flag "--destroy-cluster-only"; then
   if mt_has_flag "--dry-run"; then
     DELEGATE_FLAGS+=("--dry-run")
   fi
+  if mt_has_flag "--no-lock"; then
+    DELEGATE_FLAGS+=("--no-lock")
+  fi
   exec "${REPO_ROOT}/scripts/destroy-dev-cluster.sh" "${DELEGATE_FLAGS[@]}"
 fi
 

--- a/scripts/manage_infra
+++ b/scripts/manage_infra
@@ -20,6 +20,7 @@
 #   ./scripts/manage_infra -e dev --jitsi_tester=yes  # All phases with jitsi tester
 #   ./scripts/manage_infra -e prod --plan             # Show what would change (TF only)
 #   ./scripts/manage_infra -e prod --destroy          # Tear down (requires confirmation)
+#   ./scripts/manage_infra -e dev --destroy-cluster-only  # Ephemeral: nuke LKE only, keep VMs
 #   ./scripts/manage_infra -e dev --dns               # Only update DNS records
 #   ./scripts/manage_infra -e dev --firewall --ansible  # Firewall + Ansible only
 
@@ -44,7 +45,11 @@ mt_usage() {
   echo "  -e <env>               Environment (e.g., prod, dev)"
   echo "  --jitsi_tester=yes|no  Enable/disable Jitsi tester VM (default: no)"
   echo "  --plan                 Show planned changes without applying (phase1 only)"
-  echo "  --destroy              Tear down infrastructure (phase1 only, requires confirmation)"
+  echo "  --destroy              Tear down ALL infrastructure incl. always-up VMs (phase1 only, requires confirmation)"
+  echo "  --destroy-cluster-only Ephemeral: destroy ONLY the dev LKE cluster + LKE-side resources."
+  echo "                         Preserves postgres-dev, headscale-dev, turn-server-dev VMs."
+  echo "                         Dev environment only. Delegates to scripts/destroy-dev-cluster.sh."
+  echo "  --dry-run              With --destroy-cluster-only, print resolved targets without destroying"
   echo "  --lb-ip=X.X.X.X       Override ingress LB IP for DNS (auto-detected if omitted)"
   echo "  -h, --help             Show this help"
   echo ""
@@ -80,6 +85,22 @@ fi
 
 if mt_has_flag "--destroy"; then
   DESTROY="true"
+fi
+
+# --destroy-cluster-only delegates to a separate script that destroys only the
+# ephemeral dev LKE cluster + LKE-side resources, preserving the always-up VMs
+# (postgres-dev, headscale-dev, turn-server-dev). This is the Phase 2 entrypoint
+# of the on-demand-dev plan; Phase 3 will call it from a CI reaper.
+if mt_has_flag "--destroy-cluster-only"; then
+  if [ "$MT_ENV" != "dev" ]; then
+    print_error "--destroy-cluster-only is only supported for env=dev (got '$MT_ENV')"
+    exit 2
+  fi
+  DELEGATE_FLAGS=("-e" "$MT_ENV")
+  if mt_has_flag "--dry-run"; then
+    DELEGATE_FLAGS+=("--dry-run")
+  fi
+  exec "${REPO_ROOT}/scripts/destroy-dev-cluster.sh" "${DELEGATE_FLAGS[@]}"
 fi
 
 # Parse phase selection flags


### PR DESCRIPTION
## Summary

Phase 2 of the on-demand-dev plan: dev LKE cluster becomes ephemeral. CI/operator can tear it down with `manage_infra --destroy-cluster-only` and bring it back via `manage_infra --phase1 && deploy_infra && create_env`. Always-up VMs (postgres-dev, headscale-dev, turn-server-dev) and the shared VPC are preserved across cycles.

Also includes the cold-start fixes surfaced by the first end-to-end validation cycle — without these, `create_env` fails after destroy/recreate because per-tenant DB grants and Nextcloud's `oidc-health.php` probe file are tied to state that the cluster destroy wipes.

## What's in this PR

- **`scripts/destroy-dev-cluster.sh`** (new): targets only `linode_lke_cluster.cluster` + `linode_vpc_subnet.cluster_subnet` (NOT the whole module — the VPC is shared with the support_subnet that holds the always-up VMs). Drops `nextcloud_<tenant>` DBs via in-cluster PgBouncer before terraform destroy. Force-evicts known drain blockers (JVB, Keycloak, internal ingress). Sweeps PVCs + orphan volumes + orphan NodeBalancers. Post-destroy assertion confirms always-up resources survive in terraform state.
- **`scripts/manage_infra`**: `--destroy-cluster-only` flag (dev only) delegates to it.
- **`apps/manifests/nextcloud/before-starting-hook.sh`**: moved `cp oidc-health.php` and `cp create-caldav-tokens.php` to run **before** the install-state guard. On cold start Nextcloud isn't installed yet when this hook runs, so the previous order meant the readiness probe file never appeared and pods stayed 1/2 Ready forever.
- **DB-init templates** (synapse / stalwart / roundcube / nextcloud) + keycloak init SQL: added `GRANT CONNECT ON DATABASE ... TO pgbouncer`. PgBouncer runs `auth_query` against the client's requested DB to look up password hashes from `pg_shadow`; without CONNECT it fails with "permission denied for database" and the failure is cached via `server_login_retry`. Existing tenant DBs had this grant from an older deploy path; newly recreated ones did not.

## Validation

Full destroy/recreate/create_env cycle against live dev:

| Step | Result |
|---|---|
| `manage_infra --destroy-cluster-only` | 5m3s |
| Idempotency re-run | clean exit, assertion passed |
| `manage_infra --phase1` (recreate) | 1m13s |
| `deploy_infra -e dev` | 6m34s |
| `create_env -e dev -t mothertree` | 20m33s |
| `create_env -e dev -t innba` | 22m35s |
| `verify-endpoints` per tenant | 11/11 external endpoints OK |
| Linode orphan check | 0 leaked dev resources |

A second cycle is running now to verify the fixes work without manual intervention.

## Known follow-ups (deferred, not in this PR)

Surfaced by the validation cycle but out of scope for Phase 2:

- **Nextcloud entrypoint shell-eval breaks on passwords containing `\$<digit>`** — bash word expansion eats `\$8` in the install command. Worked around with `printf %q` for manual install. Worth a wrapper or upstream report.
- **Cold-start install race**: N replicas race `maintenance:install`. Worked around by scaling to 1 during first install. Long-term: single-shot install Job before deployment scales up.
- **Identity Secret bootstrap gap**: `deploy-nextcloud.sh`'s "extract identity from running pod" assumes the pod survives through install; on cold start it can leave the deployment in odd state. Manual `kubectl create secret nextcloud-identity` was needed during validation.
- These are all Phase 3 readiness-gate concerns (`mt_wait_for_nextcloud_installed` belongs alongside the Keycloak / Stalwart / admin-portal gates).

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No real tenant domains, hardcoded credentials, personal info, or private registry references. Script reads `LINODE_CLI_TOKEN` from sourced (gitignored) secrets files and `postgres-password` from an in-cluster Secret at runtime.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 3 | **LOW**: 2

### MEDIUM

- **SQL identifier injection surface in DROP DATABASE generation** — `scripts/destroy-dev-cluster.sh:282`. Builds SQL by concatenating `datname` with literal `\"`. Bounded blast radius (dev-only, operator-controlled names) but should use `format('... %I ...', datname)` / `quote_ident()` for safety.
- **Postgres superuser password in pod env** — `scripts/destroy-dev-cluster.sh:155,179,279,285`. `kubectl run --env PGPASSWORD=...` puts the password in the PodSpec for the pod's lifetime (`--rm`, seconds). Consider stdin or transient Secret.
- **CSI orphan sweep relies on prod being outside `us-lax`** — `scripts/destroy-dev-cluster.sh:391-404`. Comment already flags this. If prod moves into us-lax, transiently-unattached prod CSI volumes could match the filter. Tighten with tag check or destroyed-cluster PV manifest cross-reference.

### LOW

- No mutex against concurrent destroys (Phase 3 placeholder `--no-lock` exists).
- `pgbouncer` role gets CONNECT on every per-tenant DB across envs — confirmed necessary for `auth_query`, no schema/table grants added, no cross-tenant data access widening.

### Architecture assessment

> The destroy script's safety architecture (double-guarded `MT_ENV=="dev"`, explicit terraform `-target` list excluding the VPC, post-destroy state assertion verifying `module.headscale_server` / `module.postgres_server` / `linode_instance.turn_server` / `module.lke_cluster.linode_vpc.cluster_vpc` survive, always-up volume label whitelist, NodeBalancer filter scoped to the destroyed cluster's ID prefix) is well-designed and effectively prevents blast-radius escape onto prod or the always-up VMs.

## Version Bump

No portal code changes; no bump needed.

## Test plan

- [x] Dry-run destroy against live dev resolves correct targets + always-up preservation
- [x] Real destroy + idempotency re-run + recreate + deploy_infra + create_env (both tenants) end-to-end
- [x] Endpoint verification (11/11 external per tenant) + Linode orphan scan (0 leaked)
- [ ] Second cycle (this branch's fixes applied) end-to-end without manual intervention — IN PROGRESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)