### PR TITLE
feat(infra): on-demand-dev phase 3 PR A — readiness gates + lke lifecycle

### DIFF
--- a/ci/scripts/ci-lease-tenant.sh
+++ b/ci/scripts/ci-lease-tenant.sh
@@ -124,6 +124,27 @@ echo ""
 echo "--- Creating test users (prefix: ${PREFIX})"
 echo "Keycloak: ${KEYCLOAK_URL} | Realm: ${REALM}"
 
+# Cold-start gate: wait for the tenant realm's OIDC discovery endpoint to
+# serve before requesting a token. On a freshly-rolled or cold-started
+# cluster, Keycloak takes another 30-90s after pod-Ready to fully boot the
+# realm. Pipeline #1163 (Phase 1 PR #376) failed here when the lease step
+# requested a token mid-warm-up and got HTTP 503 from nginx. The deploy_infra
+# gate covers cold-start; this re-check covers warm-cluster reuse and
+# defense-in-depth.
+DISCOVERY_URL="${KEYCLOAK_URL}/realms/${REALM}/.well-known/openid-configuration"
+echo "Waiting for Keycloak OIDC discovery: ${DISCOVERY_URL}"
+for i in $(seq 1 60); do
+  if curl -sf -m 5 "$DISCOVERY_URL" >/dev/null 2>&1; then
+    echo "  OIDC discovery responsive after $((i*5))s"
+    break
+  fi
+  if (( i == 60 )); then
+    echo "ERROR: Keycloak OIDC discovery never became responsive at $DISCOVERY_URL"
+    exit 1
+  fi
+  sleep 5
+done
+
 # Get service account token — capture response first to diagnose failures.
 # The previous curl -sf | python3 pipe crashed on empty input (curl suppresses
 # error bodies with -f, python3 gets empty stdin, JSONDecodeError kills the

--- a/modules/lke-cluster/main.tf
+++ b/modules/lke-cluster/main.tf
@@ -19,18 +19,9 @@ resource "linode_lke_cluster" "cluster" {
   # Linode API/provider may return tags in a different order; sort to avoid noisy diffs.
   tags = sort(var.tags)
 
-  # IMPORTANT:
-  # If Linode autoscaler is enabled on a pool, Linode will change the *current* pool size
-  # (pool.count) outside Terraform. If Terraform manages pool.count, plans will constantly
-  # try to revert the pool back to the configured value (fighting autoscaling).
-  #
-  # We deliberately ignore drift in pool.count so autoscaling can work without noisy plans.
-  # NOTE: ignore_changes requires static paths (no splats).
-  lifecycle {
-    ignore_changes = [
-      pool[0].count,
-    ]
-  }
+  # pool.count is managed by Terraform. Was previously ignored so the autoscaler
+  # could adjust without noisy plans, but that silently dropped tfvars changes.
+  # For autoscaler envs, set tfvars `count` to autoscaler.min so plans stay clean.
 
   # Node pools - defined inline as required by provider
   dynamic "pool" {

--- a/scripts/create_env
+++ b/scripts/create_env
@@ -525,6 +525,12 @@ if [ "$MAIL_ENABLED" = "true" ]; then
     print_error "deploy-stalwart.sh not found at $REPO_ROOT/apps/deploy-stalwart.sh"
     exit 1
   fi
+
+  # Cold-start gate: Stalwart's REST API can return 5xx for ~30-60s after
+  # pod-Ready on a fresh deploy (negative-RCPT cache + OIDC directory warm-up).
+  # provision-smtp-service-accounts (next step) hits /api/principal/deploy, so
+  # we wait until the REST layer responds. Non-fatal: caller retries on 5xx.
+  mt_wait_for_stalwart
 else
   print_status "Stalwart: skipping (features.mail_enabled is not true)"
 fi
@@ -748,6 +754,13 @@ if [ "$ACCOUNT_PORTAL_ENABLED" = "true" ]; then
   fi
 else
   print_status "Account Portal: skipping (features.account_portal_enabled is not true)"
+fi
+
+# Cold-start gate: confirm admin-portal /version is reachable end-to-end
+# (ingress + wildcard TLS + portal pod). Final "everything's up" assertion
+# before the cleanup/probe phase. Skipped when admin-portal isn't enabled.
+if [ "$ADMIN_PORTAL_ENABLED" = "true" ]; then
+  mt_wait_for_admin_portal
 fi
 
 # ── END app deploys ──────────────────────────────────────────────────

--- a/scripts/deploy_infra
+++ b/scripts/deploy_infra
@@ -553,6 +553,15 @@ mt_restart_if_changed statefulset/keycloak-keycloakx -n "$NS_AUTH"
 # This returns immediately if no rollout is in progress.
 kubectl -n "$NS_AUTH" rollout status statefulset/keycloak-keycloakx --timeout=300s
 
+# Cold-start gate: confirm Keycloak's OIDC discovery is actually serving.
+# Pod-Ready + rollout-complete is necessary but not sufficient — Keycloak takes
+# another 30-90s after pod-Ready to fully boot the realm and start serving
+# /.well-known/openid-configuration. Downstream callers (admin-portal,
+# ci-lease-tenant, every OIDC client) will 503 if they hit Keycloak in this
+# window. Master realm covers the full HTTP stack; tenant realms are checked
+# per-tenant by create_env.
+mt_wait_for_keycloak_oidc master
+
 # Sync Keycloak admin password.
 # The KEYCLOAK_ADMIN_PASSWORD env var only applies on first boot; afterwards the
 # password is stored in Keycloak's database. We use kcadm.sh to verify/update it,

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -353,3 +353,102 @@ mt_psql() {
         --env="PGPASSWORD=$pg_pass" \
         --command -- psql -h pgbouncer -U postgres -v ON_ERROR_STOP=1 "$@" 2>/dev/null
 }
+
+# ---------------------------------------------------------------------------
+# Cold-start readiness gates (on-demand-dev Phase 3)
+# ---------------------------------------------------------------------------
+# Helmfile `wait: true` and `kubectl rollout status` only confirm pods are
+# Ready — they don't confirm the application's external endpoints are actually
+# serving. On a fresh cold-cycle these helpers protect the rest of the deploy
+# (and downstream CI steps) from racing the application's warm-up window.
+# See on-demand-dev/03-phase3-ci-orchestration.md §B for the empirical
+# evidence (CI pipelines #1163, #1164) that motivates each gate.
+# ---------------------------------------------------------------------------
+
+# Wait for Keycloak's OIDC discovery endpoint to actually serve.
+# Use this from any path that depends on Keycloak being usable (not just up).
+#
+# Usage: mt_wait_for_keycloak_oidc [realm]   (default realm: "master")
+# Required env: AUTH_HOST
+#
+# The master realm is always present and exercises the full HTTP stack
+# (ingress + Keycloak + realm machinery). Pass a tenant realm explicitly when
+# you need to gate on that specific realm being registered and serving.
+mt_wait_for_keycloak_oidc() {
+    local realm="${1:-master}"
+    local auth_host="${AUTH_HOST:-}"
+    if [ -z "$auth_host" ]; then
+        print_error "mt_wait_for_keycloak_oidc: AUTH_HOST is not set"
+        return 1
+    fi
+    local url="https://${auth_host}/realms/${realm}/.well-known/openid-configuration"
+    print_status "Waiting for Keycloak OIDC discovery: $url"
+    local i
+    for i in $(seq 1 60); do
+        if curl -sf -m 5 "$url" >/dev/null 2>&1; then
+            print_success "Keycloak OIDC discovery responsive after $((i*5))s (realm=$realm)"
+            return 0
+        fi
+        sleep 5
+    done
+    print_error "Keycloak OIDC discovery never became responsive at $url"
+    return 1
+}
+
+# Wait for Stalwart's REST API to respond without 5xx.
+# Use this before any script triggers /api/principal/* calls (admin-portal,
+# account-portal, provision-smtp-service-accounts). Pod-Ready isn't enough —
+# the REST API can return 5xx for ~30-60s after pod-Ready on first deploy
+# (negative-RCPT cache warm-up + OIDC directory lookups).
+#
+# Usage: mt_wait_for_stalwart [mail_host]
+# Required env: MAIL_HOST (or pass mail_host as $1)
+#
+# This is intentionally a *warning*, not an error: admin-portal retries on
+# 5xx, and a slow Stalwart shouldn't block the entire deploy. The warning
+# surfaces the issue in CI logs for diagnosis if downstream calls flake.
+mt_wait_for_stalwart() {
+    local mail_host="${1:-${MAIL_HOST:-}}"
+    if [ -z "$mail_host" ]; then
+        print_warning "mt_wait_for_stalwart: MAIL_HOST not set, skipping"
+        return 0
+    fi
+    local url="https://${mail_host}/api/principal"
+    print_status "Waiting for Stalwart REST API: $url"
+    local code="000" i
+    for i in $(seq 1 30); do
+        code=$(curl -s -o /dev/null -w '%{http_code}' -m 5 "$url" 2>/dev/null || echo "000")
+        # 200 / 401 / 403 all mean the REST layer is responding (auth-required
+        # responses count). 5xx or "000" (timeout/refused) mean keep waiting.
+        if [[ "$code" =~ ^(200|401|403)$ ]]; then
+            print_success "Stalwart REST API responsive after $((i*5))s (HTTP $code)"
+            return 0
+        fi
+        sleep 5
+    done
+    print_warning "Stalwart REST API never became responsive (last code: $code) — proceeding"
+    return 0
+}
+
+# Wait for admin-portal's /version endpoint to return 200.
+# Lightest sanity check that the full ingress + portal + version-injection
+# chain is up. Use as a final "everything's up" assertion.
+#
+# Usage: mt_wait_for_admin_portal [admin_host]
+# Required env: ADMIN_HOST (or pass admin_host as $1)
+mt_wait_for_admin_portal() {
+    local admin_host="${1:-${ADMIN_HOST:-}}"
+    if [ -z "$admin_host" ]; then
+        print_warning "mt_wait_for_admin_portal: ADMIN_HOST not set, skipping"
+        return 0
+    fi
+    local url="https://${admin_host}/version"
+    print_status "Waiting for admin-portal /version: $url"
+    if curl -sf -m 5 --retry 30 --retry-delay 5 --retry-all-errors \
+        "$url" >/dev/null 2>&1; then
+        print_success "admin-portal /version returned 200"
+        return 0
+    fi
+    print_error "admin-portal /version never returned 200 at $url"
+    return 1
+}


### PR DESCRIPTION
## Summary

First slice of Phase 3 on the on-demand-dev rollout (see [`progress.md`](https://github.com/mothertree-labs/mothertree-oss/blob/main/../../) and [`03-phase3-ci-orchestration.md`](https://github.com/mothertree-labs/mothertree-oss/blob/main/../../) — design docs live outside the repo). This PR delivers two independent groundwork items:

- **Cold-start readiness gates** that downstream PRs (reaper + bring-up) depend on. Pod-Ready ≠ application-Ready for Keycloak / Stalwart / admin-portal; Phase 1's CI runs #1163 (lease step got HTTP 503 from a still-PodInitializing Keycloak) and #1164 (admin-portal `/api/invite` timed out against a freshly-deployed Stalwart) showed this empirically.
- **Removal of `ignore_changes = [pool[0].count]`** in the LKE module so `terraform.dev.tfvars` becomes the source of truth for pool count. Without this, Phase 3's cold-start path would silently inherit whatever pool size existed before — Phase 1 already had to manually `linode-cli lke pool-update --count N --autoscaler.enabled false` as a pre-step.

### Gates added (`scripts/lib/common.sh`)

| Helper | Polls | Failure mode | Call site |
|---|---|---|---|
| `mt_wait_for_keycloak_oidc [realm]` | `https://${AUTH_HOST}/realms/${realm}/.well-known/openid-configuration` (default realm `master`) | error after 5 min | end of `deploy_infra` after KC rollout; top of `ci-lease-tenant.sh` (tenant realm) |
| `mt_wait_for_stalwart [mail_host]` | `https://${MAIL_HOST}/api/principal` accepts 200/401/403 | warning only (admin-portal retries on 5xx) | `create_env` after `deploy-stalwart.sh`, before `provision-smtp-service-accounts` |
| `mt_wait_for_admin_portal [admin_host]` | `https://${ADMIN_HOST}/version` | error after ~2.5 min | end of `create_env` deploys, gated on `ADMIN_PORTAL_ENABLED` |

The Nextcloud gate (Phase 2 carry-over #1) is deferred to PR B — it depends on the install-Job pattern that this PR doesn't ship.

### Lifecycle removal — operator note

Removing `ignore_changes = [pool[0].count]` means `terraform plan` against **prod** and **prod-eu** will now show drift between the tfvars `count` and the autoscaler's current pool size whenever the autoscaler has scaled out. **Do not apply that diff during a load spike** — it would shrink the pool back to tfvars `count`. Mitigation in the inline comment: set tfvars `count` to `autoscaler.min` so plans stay clean unless the autoscaler is actively above min. The plan-noise cost is bounded; the correctness benefit (no silent skips, no manual pre-step in cold-start) is durable.

### Deferred from design doc §B (intentional)

The Synapse-rollout-restart-after-Keycloak fallback ("if despite the gate Synapse still hits the OIDC backoff trap...") is **not** included. Per design doc, condition it on observing the failure — don't add preemptively. The Keycloak gate at end of `deploy_infra` should make this unnecessary.

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0 — clean. No literal tenant domains, no secrets, no private registry refs. All hostnames are runtime env-var interpolations from per-tenant config.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 3 (all advisory observations, no blockers):

1. **URL interpolation without strict validation** — `AUTH_HOST` / `MAIL_HOST` / `ADMIN_HOST` come from operator-controlled tenant YAML, and curl is invoked with separate argv (no shell `eval`). Not reachable from runtime data; no action.
2. **Inconsistent failure policy across gates** — Stalwart returns 0 ("proceeding") when `MAIL_HOST` is unset or the API stays 5xx; Keycloak and admin-portal return non-zero. Stalwart's advisory behavior is intentional per design doc (caller retries on 5xx, and the gate is feature-flagged on `MAIL_ENABLED`).
3. **Terraform lifecycle removal — autoscaler drift** — surfaced in the operator-note section above. Not a security boundary issue.

No SSRF, no shell injection, no secret leakage. Wait loops are bounded.

## Version Bump

Not needed. No changes under `apps/admin-portal/` or `apps/account-portal/`, and `apps/image-versions.env` is untouched.

## Test plan

- [ ] CI dev pipeline passes against the leased dev pool (warm cluster — confirms gates don't break the existing happy path)
- [ ] Manually destroy + recreate dev via Phase 2's `destroy-dev-cluster.sh` + `manage_infra --phase1` + `deploy_infra` and confirm the Keycloak OIDC gate logs `Keycloak OIDC discovery responsive after Xs (realm=master)` at the end of `deploy_infra`
- [ ] On the same cold-cycled cluster, run `create_env -e dev -t mothertree` and verify both gates fire (Stalwart REST gate logs + admin-portal /version gate logs)
- [ ] Confirm `ci-lease-tenant.sh` doesn't regress the warm-cluster lease time (should be sub-second when discovery is already serving)
- [ ] After merge: update memory note (`project_on_demand_dev.md`) with Phase 3 PR A status

🤖 Generated with [Claude Code](https://claude.com/claude-code)