### PR TITLE
feat(infra): split phase1-dev for on-demand-dev shared state

### DIFF
--- a/phase1-dev/MIGRATION.md
+++ b/phase1-dev/MIGRATION.md
@@ -1,0 +1,240 @@
+# One-time migration: split phase1 dev workspace → phase1-dev
+
+This is an operator-run, one-time migration. Run it on your laptop with full
+access to the dev workspace, the Linode account, and your password manager.
+Until you complete it, the dev workspace's `terraform plan` against `phase1/`
+will want to destroy the LKE cluster, the VPC, the VPC subnet, and
+`local_file.kubeconfig` — those resources are now declared in `phase1-dev/`
+and need to be re-homed.
+
+CI cannot run this. `terraform state rm` / `terraform import` mutate state, so
+they're operator-only.
+
+## Why this split exists
+
+The dev cluster is now on-demand: CI brings it up, an idle reaper destroys it.
+Both code paths need to read/write durable state, but Terraform state for
+`phase1/` lives on the operator's laptop. The fix is to give the dev cluster
+its own Terraform root (`phase1-dev/`) with a Linode Object Storage backend.
+
+Everything else — prod, prod-eu, the dev always-up VMs (postgres-dev,
+headscale-dev, turn-server-dev) — keeps its state in `phase1/` and is
+**not** touched by this migration.
+
+## Prerequisites
+
+- `terraform` >= 1.11 (`use_lockfile = true` in the S3 backend is a 1.11
+  feature). Check with `terraform version`.
+- `linode-cli` installed and authenticated against the same account that owns
+  the dev cluster.
+- `lpass` (LastPass CLI) logged in for storing the new credentials.
+- Working directory: the repo root (`~/code/mothertree`).
+
+## Step 1 — Create the Terraform-state bucket
+
+Create the bucket Terraform's S3 backend will write to. Region `us-lax-1`
+(matches the dev LKE cluster's region).
+
+```bash
+linode-cli obj mb mothertree-tf-state-dev --cluster us-lax-1
+```
+
+Verify it landed:
+
+```bash
+linode-cli obj la --cluster us-lax-1 | grep mothertree-tf-state-dev
+```
+
+## Step 2 — Create a scoped access key for the state bucket
+
+This key only has access to `mothertree-tf-state-dev` — not the heartbeat
+bucket (which Terraform manages separately), not any tenant S3 buckets.
+
+```bash
+linode-cli object-storage keys-create \
+  --label "tf-state-dev" \
+  --bucket_access '[{"region":"us-lax","bucket_name":"mothertree-tf-state-dev","permissions":"read_write"}]'
+```
+
+Capture the `access_key` and `secret_key` from the output.
+
+## Step 3 — Store the credentials
+
+Save them in LastPass as a new entry named `mothertree-tf-state-dev-s3-credentials`.
+
+Then add to your gitignored secrets env (whichever one you currently source
+when running `manage_infra` — typically `secrets.dev.tfvars.env` for dev work,
+or `secrets.tfvars.env` if you've consolidated):
+
+```bash
+export AWS_ACCESS_KEY_ID="<access_key from step 2>"
+export AWS_SECRET_ACCESS_KEY="<secret_key from step 2>"
+```
+
+Terraform's S3 backend uses `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` for
+authentication even against non-AWS S3 — these names are required.
+
+## Step 4 — Back up the current dev state
+
+```bash
+cd phase1
+terraform workspace select dev
+terraform state pull > /tmp/dev-state-backup-pre-split.tfstate
+```
+
+Keep this backup until the next dev destroy/recreate cycle has succeeded
+end-to-end. If anything goes wrong below, you can restore with:
+
+```bash
+terraform state push /tmp/dev-state-backup-pre-split.tfstate
+```
+
+## Step 5 — Capture the resource IDs you need for import
+
+```bash
+terraform state show 'module.lke_cluster.linode_lke_cluster.cluster' | grep '^id'
+terraform state show 'module.lke_cluster.linode_vpc.cluster_vpc'     | grep '^id'
+terraform state show 'module.lke_cluster.linode_vpc_subnet.cluster_subnet' | grep -E '^(id|vpc_id)'
+```
+
+You'll get three IDs. Write them down:
+
+- `LKE_CLUSTER_ID` — e.g. `123456`
+- `VPC_ID` — e.g. `78901`
+- `VPC_SUBNET_ID` — e.g. `234567` (and remember its parent `vpc_id`)
+
+If `terraform state show` is awkward, an equivalent lookup with `linode-cli`:
+
+```bash
+linode-cli lke clusters-list --json | jq '.[] | select(.label=="matrix-cluster-dev") | .id'
+linode-cli vpcs list --json       | jq '.[] | select(.label=="matrix-cluster-dev-vpc") | {id, subnets: [.subnets[] | {id, label}]}'
+```
+
+## Step 6 — Remove the LKE resources from the phase1 dev workspace
+
+This is the destructive-looking but actually safe step: `state rm` removes
+the resources from Terraform's tracking, but the real Linode resources
+continue to exist. You'll re-attach them to `phase1-dev`'s state in step 8.
+
+```bash
+# Still in phase1/, with the dev workspace selected.
+terraform state rm \
+  'module.lke_cluster.linode_lke_cluster.cluster' \
+  'module.lke_cluster.linode_vpc.cluster_vpc' \
+  'module.lke_cluster.linode_vpc_subnet.cluster_subnet' \
+  'local_file.kubeconfig'
+```
+
+Confirm the LKE cluster, VPC, and subnet still exist in Linode (they should):
+
+```bash
+linode-cli lke clusters-list --json | jq '.[] | select(.label=="matrix-cluster-dev") | .id'
+```
+
+## Step 7 — Initialise the phase1-dev backend
+
+```bash
+cd ../phase1-dev
+terraform init
+```
+
+Terraform will report that it's writing the initial state to the S3 bucket.
+If it complains about credentials, double-check that step 3's env vars are
+exported in the current shell.
+
+## Step 8 — Import the LKE resources into phase1-dev
+
+The subnet import takes a compound ID: `<vpc_id>,<subnet_id>`.
+
+```bash
+terraform import \
+  -var-file="$(pwd)/../terraform.tfvars" \
+  -var-file="$(pwd)/../terraform.dev.tfvars" \
+  'module.lke_cluster.linode_lke_cluster.cluster' "$LKE_CLUSTER_ID"
+
+terraform import \
+  -var-file="$(pwd)/../terraform.tfvars" \
+  -var-file="$(pwd)/../terraform.dev.tfvars" \
+  'module.lke_cluster.linode_vpc.cluster_vpc' "$VPC_ID"
+
+terraform import \
+  -var-file="$(pwd)/../terraform.tfvars" \
+  -var-file="$(pwd)/../terraform.dev.tfvars" \
+  'module.lke_cluster.linode_vpc_subnet.cluster_subnet' "$VPC_ID,$VPC_SUBNET_ID"
+```
+
+`local_file.kubeconfig` is recreated from `module.lke_cluster.kubeconfig` on
+the next apply — no manual import is needed (the file is at
+`../kubeconfig.dev.yaml` and will be overwritten).
+
+## Step 9 — Verify a zero-diff plan
+
+```bash
+terraform plan \
+  -var-file="$(pwd)/../terraform.tfvars" \
+  -var-file="$(pwd)/../terraform.dev.tfvars"
+```
+
+Expected outcome:
+
+- No changes to `module.lke_cluster.linode_lke_cluster.cluster`.
+- No changes to `module.lke_cluster.linode_vpc.cluster_vpc`.
+- No changes to `module.lke_cluster.linode_vpc_subnet.cluster_subnet`.
+- `local_file.kubeconfig` will create (writes the kubeconfig file from the
+  cluster's output — this is fine; the file already exists with the same
+  content from the prior phase1 apply).
+- `linode_object_storage_bucket.dev_state` will create.
+- `linode_object_storage_key.dev_state` will create.
+
+If any of the first three resources show a `~ update` or `-/+ replace`, stop
+and reconcile the diff against the on-Linode state before proceeding.
+
+## Step 10 — Apply
+
+```bash
+terraform apply \
+  -var-file="$(pwd)/../terraform.tfvars" \
+  -var-file="$(pwd)/../terraform.dev.tfvars"
+```
+
+This creates the heartbeat bucket + scoped access key and re-writes
+`../kubeconfig.dev.yaml`.
+
+## Step 11 — Verify the phase1 dev workspace still applies cleanly
+
+```bash
+cd ../phase1
+terraform workspace select dev
+terraform plan -refresh=false \
+  -var-file=../terraform.tfvars \
+  -var-file=../terraform.dev.tfvars \
+  -var env=dev \
+  -var env_dns_label=dev \
+  -var jitsi_tester_enabled=false
+```
+
+Expected: only the dev always-up VMs (postgres-dev, headscale-dev,
+turn-server-dev) and their firewalls/SSH keys should be in the plan. No LKE,
+no VPC, no kubeconfig.
+
+## Step 12 — Final sanity: rerun manage_infra end-to-end
+
+```bash
+./scripts/manage_infra -e dev --phase1
+```
+
+This re-runs both Terraform roots (phase1 dev workspace + phase1-dev) back to
+back. The resulting `terraform-outputs.dev.env` should include
+`DEV_STATE_BUCKET`, `DEV_STATE_S3_KEY`, `DEV_STATE_S3_SECRET`, and a non-empty
+`LKE_CLUSTER_ID`. CI will read these via the existing deploy-vault flow.
+
+## Rollback
+
+If something has gone catastrophically wrong:
+
+1. `cd phase1 && terraform workspace select dev`
+2. `terraform state push /tmp/dev-state-backup-pre-split.tfstate`
+3. Drop the `phase1-dev/` directory from your local checkout (don't commit
+   the revert) and re-run `manage_infra -e dev --phase1`. The dev workspace
+   will look the way it did before the migration.
+4. Delete the `mothertree-tf-state-dev` bucket and the scoped key.

--- a/phase1-dev/backend.tf
+++ b/phase1-dev/backend.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    linode = {
+      source  = "linode/linode"
+      version = "~> 3.9"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+
+  # Remote state on Linode Object Storage (S3-compatible).
+  #
+  # Bucket and scoped access key are created by the operator before first init —
+  # see ./MIGRATION.md. Credentials are picked up from the environment as
+  # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (Terraform requires the AWS_ names
+  # even for non-AWS S3 backends).
+  #
+  # use_lockfile = true enables native S3 conditional-write locking (requires
+  # Terraform >= 1.11) so we don't need a separate DynamoDB-style lock store.
+  backend "s3" {
+    bucket = "mothertree-tf-state-dev"
+    key    = "phase1-dev/terraform.tfstate"
+    region = "us-east-1" # required by validator; Linode ignores it
+
+    endpoints = {
+      s3 = "https://us-lax-1.linodeobjects.com"
+    }
+
+    use_path_style              = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+  }
+}

--- a/phase1-dev/main.tf
+++ b/phase1-dev/main.tf
@@ -1,0 +1,60 @@
+# phase1-dev — dev-only LKE cluster and CI heartbeat bucket.
+#
+# This directory was split out of phase1/ to give the dev cluster its own
+# remote-state backend (Linode Object Storage). That backend is what makes the
+# Phase 3 on-demand-dev model possible: CI brings the cluster up on demand and
+# an idle reaper destroys it, and both code paths need to read/write durable
+# shared state from environments that don't have the operator's laptop.
+#
+# - Prod and prod-eu continue to live in phase1/ with local state on the
+#   operator's machine — see CLAUDE.md and phase1/main.tf.
+# - The always-up dev VMs (postgres-dev, headscale-dev, turn-server-dev) also
+#   continue to live in phase1/ (dev workspace). Only the ephemeral LKE
+#   cluster, its VPC/subnet, and the kubeconfig file resource moved here.
+
+provider "linode" {
+  token = var.linode_token
+}
+
+# LKE cluster — module call mirrors phase1/main.tf for dev so the migration
+# (state pull → state rm → import) is a no-op `terraform plan`.
+module "lke_cluster" {
+  source = "../modules/lke-cluster"
+
+  cluster_label    = "${var.cluster_label}-dev"
+  region           = var.linode_region
+  k8s_version      = var.linode_k8s_version
+  node_pools       = var.linode_node_pools
+  tags             = sort(concat(var.common_tags, ["dev"]))
+  control_plane_ha = var.linode_control_plane_ha
+}
+
+# Kubeconfig written to repo root so deploy_infra / create_env can find it
+# with the same path expectations they use for prod / prod-eu.
+resource "local_file" "kubeconfig" {
+  content  = base64decode(module.lke_cluster.kubeconfig)
+  filename = "${path.root}/../kubeconfig.dev.yaml"
+
+  depends_on = [module.lke_cluster]
+}
+
+# Linode Object Storage bucket for the dev cluster lifecycle heartbeat
+# (last-used.txt). Read by the Phase 3 idle reaper from outside the cluster,
+# so it must survive across destroy/recreate cycles of the LKE cluster itself.
+resource "linode_object_storage_bucket" "dev_state" {
+  region = var.dev_state_region
+  label  = var.dev_state_bucket_label
+}
+
+# Scoped access key with read/write to the heartbeat bucket only.
+# CI writes the heartbeat with this key; the reaper reads it. The key has no
+# access to any other bucket (or the Terraform-state bucket).
+resource "linode_object_storage_key" "dev_state" {
+  label = "tf-managed-${var.dev_state_bucket_label}"
+
+  bucket_access {
+    region      = var.dev_state_region
+    bucket_name = linode_object_storage_bucket.dev_state.label
+    permissions = "read_write"
+  }
+}

--- a/phase1-dev/outputs.tf
+++ b/phase1-dev/outputs.tf
@@ -1,0 +1,83 @@
+# Outputs surfaced to scripts/manage_infra so they can be written into
+# terraform-outputs.dev.env (consumed by deploy_infra and CI).
+
+output "cluster_id" {
+  description = "The ID of the LKE cluster"
+  value       = module.lke_cluster.cluster_id
+}
+
+output "cluster_label" {
+  description = "The label of the LKE cluster"
+  value       = module.lke_cluster.cluster_label
+}
+
+output "cluster_region" {
+  description = "The region of the LKE cluster"
+  value       = module.lke_cluster.cluster_region
+}
+
+output "cluster_status" {
+  description = "The status of the LKE cluster"
+  value       = module.lke_cluster.cluster_status
+}
+
+output "cluster_ip_address" {
+  description = "The IP address of the LKE cluster"
+  value       = module.lke_cluster.cluster_ip_address
+}
+
+output "cluster_endpoint" {
+  description = "The endpoint for the LKE cluster"
+  value       = module.lke_cluster.cluster_endpoint
+}
+
+output "node_pools" {
+  description = "Information about the node pools"
+  value       = module.lke_cluster.node_pools
+}
+
+output "kubeconfig" {
+  description = "Base64 encoded kubeconfig for the LKE cluster"
+  value       = module.lke_cluster.kubeconfig
+  sensitive   = true
+}
+
+output "kubeconfig_path" {
+  description = "Path to the kubeconfig file written by local_file.kubeconfig"
+  value       = local_file.kubeconfig.filename
+}
+
+output "vpc_id" {
+  description = "The ID of the LKE VPC (preserved across destroy-dev-cluster cycles)"
+  value       = module.lke_cluster.vpc_id
+}
+
+output "vpc_subnet_id" {
+  description = "The ID of the LKE VPC subnet (destroyed by destroy-dev-cluster, recreated on next bring-up)"
+  value       = module.lke_cluster.vpc_subnet_id
+}
+
+# CI heartbeat bucket — surfaced into terraform-outputs.dev.env so dev-heartbeat.sh
+# and the Phase 3 reaper can authenticate against Linode Object Storage.
+
+output "dev_state_bucket" {
+  description = "Linode Object Storage bucket label used for the on-demand-dev heartbeat file"
+  value       = linode_object_storage_bucket.dev_state.label
+}
+
+output "dev_state_endpoint" {
+  description = "Linode Object Storage endpoint hostname for the dev_state bucket"
+  value       = linode_object_storage_bucket.dev_state.hostname
+}
+
+output "dev_state_access_key" {
+  description = "Scoped access key (read_write on dev_state bucket only)"
+  value       = linode_object_storage_key.dev_state.access_key
+  sensitive   = true
+}
+
+output "dev_state_secret_key" {
+  description = "Scoped secret key (read_write on dev_state bucket only)"
+  value       = linode_object_storage_key.dev_state.secret_key
+  sensitive   = true
+}

--- a/phase1-dev/terraform.dev.tfvars.example
+++ b/phase1-dev/terraform.dev.tfvars.example
@@ -1,0 +1,30 @@
+# phase1-dev tfvars template.
+#
+# The real values live at repo root in terraform.tfvars (shared defaults) and
+# terraform.dev.tfvars (dev overrides). manage_infra passes both to phase1-dev
+# the same way it passes them to phase1, so you usually do NOT need to maintain
+# a dev-specific tfvars file inside this directory.
+#
+# This template exists for documentation: it shows the subset of variables
+# phase1-dev consumes. Copy to phase1-dev/terraform.dev.tfvars (gitignored) only
+# if you want phase1-dev to take different values than phase1 does for dev.
+
+# LKE cluster sizing — must match what was applied via phase1 dev workspace
+# prior to migration, or the post-migration `terraform plan` will not be clean.
+linode_node_pools = [
+  {
+    type  = "g6-standard-4"
+    count = 3
+    tags  = ["matrix", "dev", "primary"]
+  }
+]
+
+# Cluster identity — leave at defaults unless you've also changed them at repo
+# root. The "-dev" suffix is added by main.tf.
+# cluster_label      = "matrix-cluster"
+# linode_region      = "us-lax"
+# linode_k8s_version = "1.34"
+
+# Heartbeat bucket — defaults are correct for the documented setup.
+# dev_state_bucket_label = "mothertree-dev-state"
+# dev_state_region       = "us-lax"

--- a/phase1-dev/variables.tf
+++ b/phase1-dev/variables.tf
@@ -1,0 +1,92 @@
+# Variables for phase1-dev. Mirror the subset of phase1 vars that the
+# lke-cluster module consumes — passed via the same root-level
+# terraform.tfvars + terraform.dev.tfvars files that phase1 uses.
+
+variable "linode_token" {
+  description = "Linode API token for authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "cluster_label" {
+  description = "Base label for the LKE cluster (the '-dev' suffix is appended in main.tf)"
+  type        = string
+  default     = "matrix-cluster"
+}
+
+variable "linode_region" {
+  description = "Linode region for the cluster (LKE compute region)"
+  type        = string
+  default     = "us-lax"
+}
+
+variable "linode_k8s_version" {
+  description = "Kubernetes version for the LKE cluster"
+  type        = string
+  default     = "1.34"
+  validation {
+    condition     = can(regex("^1\\.(2[4-9]|3[0-9])$", var.linode_k8s_version))
+    error_message = "Kubernetes version must be between 1.24 and 1.39."
+  }
+}
+
+variable "linode_control_plane_ha" {
+  description = "Enable High Availability for the LKE control plane (costs more)."
+  type        = bool
+  default     = false
+}
+
+variable "linode_node_pools" {
+  description = "List of node pools for the LKE cluster. Each pool can optionally include an autoscaler configuration."
+  type = list(object({
+    type  = string
+    count = number
+    tags  = list(string)
+    autoscaler = optional(object({
+      min = number
+      max = number
+    }))
+  }))
+  default = [
+    {
+      type  = "g6-standard-4"
+      count = 3
+      tags  = ["matrix", "dev", "primary"]
+    }
+  ]
+  validation {
+    condition = alltrue([
+      for pool in var.linode_node_pools : pool.count >= 1 && pool.count <= 10
+    ])
+    error_message = "Node pool count must be between 1 and 10."
+  }
+  validation {
+    condition = alltrue([
+      for pool in var.linode_node_pools : pool.autoscaler == null || (
+        pool.autoscaler.min >= 1 &&
+        pool.autoscaler.max >= pool.autoscaler.min &&
+        pool.autoscaler.max <= 10
+      )
+    ])
+    error_message = "Autoscaler min must be >= 1, max must be >= min, and max must be <= 10."
+  }
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources (env tag added automatically)"
+  type        = list(string)
+  default     = ["matrix", "terraform"]
+}
+
+variable "dev_state_bucket_label" {
+  description = "Label of the Linode Object Storage bucket used by CI for the dev cluster heartbeat. Must be globally unique within Linode Object Storage."
+  type        = string
+  default     = "mothertree-dev-state"
+}
+
+variable "dev_state_region" {
+  description = "Linode region for the dev_state Object Storage bucket and scoped access key. Use the LKE-style region label (e.g. 'us-lax')."
+  type        = string
+  default     = "us-lax"
+}
+

--- a/phase1/main.tf
+++ b/phase1/main.tf
@@ -32,8 +32,15 @@ provider "cloudflare" {
 
 # Kubernetes resources are managed in infra/ to avoid kubeconfig timing issues
 
-# Create LKE Cluster
+# Create LKE Cluster.
+#
+# Dev's LKE cluster (and only the LKE cluster — the always-up dev VMs continue
+# to live here in the dev workspace) was moved to ../phase1-dev/ in order to
+# back its state with Linode Object Storage. CI needs durable shared state to
+# implement the on-demand-dev model. Prod and prod-eu continue to keep their
+# LKE clusters in this directory with local state.
 module "lke_cluster" {
+  count  = var.env == "dev" ? 0 : 1
   source = "../modules/lke-cluster"
 
   cluster_label    = "${var.cluster_label}-${var.env}"
@@ -46,13 +53,28 @@ module "lke_cluster" {
 
 # Save kubeconfig to project root directory
 resource "local_file" "kubeconfig" {
-  content  = base64decode(module.lke_cluster.kubeconfig)
+  count    = var.env == "dev" ? 0 : 1
+  content  = base64decode(module.lke_cluster[0].kubeconfig)
   filename = "${path.root}/../kubeconfig.${var.env}.yaml"
 
   depends_on = [module.lke_cluster]
 }
 
-# Configure Kubernetes provider to query service CIDR
+# Track the address change introduced by adding `count = var.env == "dev" ? 0 : 1`
+# above so existing prod / prod-eu workspaces don't see a destroy + recreate.
+moved {
+  from = module.lke_cluster
+  to   = module.lke_cluster[0]
+}
+
+moved {
+  from = local_file.kubeconfig
+  to   = local_file.kubeconfig[0]
+}
+
+# Configure Kubernetes provider to query service CIDR.
+# Only used by prod / prod-eu (no kubernetes resources are declared in phase1
+# for dev after the split — the kubeconfig path won't exist for dev workspace).
 provider "kubernetes" {
   config_path = "${path.root}/../kubeconfig.${var.env}.yaml"
 }

--- a/phase1/outputs.tf
+++ b/phase1/outputs.tf
@@ -1,31 +1,36 @@
+# LKE outputs are guarded with `length(module.lke_cluster) > 0` so the dev
+# workspace (where the module count is 0 — see phase1/main.tf) can `terraform
+# apply` cleanly. Dev's LKE cluster lives in ../phase1-dev/ and exposes the
+# same outputs from there.
+
 output "cluster_id" {
   description = "The ID of the LKE cluster"
-  value       = module.lke_cluster.cluster_id
+  value       = length(module.lke_cluster) > 0 ? module.lke_cluster[0].cluster_id : null
 }
 
 output "cluster_label" {
   description = "The label of the LKE cluster"
-  value       = module.lke_cluster.cluster_label
+  value       = length(module.lke_cluster) > 0 ? module.lke_cluster[0].cluster_label : null
 }
 
 output "cluster_region" {
   description = "The region of the LKE cluster"
-  value       = module.lke_cluster.cluster_region
+  value       = length(module.lke_cluster) > 0 ? module.lke_cluster[0].cluster_region : null
 }
 
 output "cluster_status" {
   description = "The status of the LKE cluster"
-  value       = module.lke_cluster.cluster_status
+  value       = length(module.lke_cluster) > 0 ? module.lke_cluster[0].cluster_status : null
 }
 
 output "cluster_ip_address" {
   description = "The IP address of the LKE cluster"
-  value       = module.lke_cluster.cluster_ip_address
+  value       = length(module.lke_cluster) > 0 ? module.lke_cluster[0].cluster_ip_address : null
 }
 
 output "kubeconfig" {
   description = "Base64 encoded kubeconfig for the LKE cluster"
-  value       = module.lke_cluster.kubeconfig
+  value       = length(module.lke_cluster) > 0 ? module.lke_cluster[0].kubeconfig : null
   sensitive   = true
 }
 
@@ -36,12 +41,12 @@ output "kubeconfig_path" {
 
 output "cluster_endpoint" {
   description = "The endpoint for the LKE cluster"
-  value       = module.lke_cluster.cluster_endpoint
+  value       = length(module.lke_cluster) > 0 ? module.lke_cluster[0].cluster_endpoint : null
 }
 
 output "node_pools" {
   description = "Information about the node pools"
-  value       = module.lke_cluster.node_pools
+  value       = length(module.lke_cluster) > 0 ? module.lke_cluster[0].node_pools : null
 }
 
 output "matrix_domain" {
@@ -58,19 +63,19 @@ output "next_steps" {
   description = "Instructions for Phase 2 deployment"
   value       = <<-EOT
     Phase 1 completed successfully!
-    
+
     Next steps for Phase 2:
     1. The kubeconfig has been automatically saved to:
        ${path.root}/../kubeconfig.${var.env}.yaml
-    
+
     2. Navigate to the phase2 directory:
        cd ${path.root}/../phase2
-       
+
     3. Initialize and apply Phase 2:
        terraform init
        terraform plan
        terraform apply
-    
+
     Matrix will be available at:
     - Synapse: https://${var.matrix_subdomain}.${var.domain}
     - Element: https://${var.element_subdomain}.${var.domain}
@@ -80,23 +85,19 @@ output "next_steps" {
 
 output "deployment_summary" {
   description = "Summary of the deployment"
-  value       = <<-EOT
-    Matrix infrastructure deployed successfully!
-    
-    Cluster Details:
-    - Cluster ID: ${module.lke_cluster.cluster_id}
-    - Region: ${module.lke_cluster.cluster_region}
-    - Status: ${module.lke_cluster.cluster_status}
-    - Kubeconfig: ${path.root}/../kubeconfig.${var.env}.yaml
-    
-    Matrix Domain: ${var.matrix_subdomain}.${var.domain}
-    ${var.turn_server_enabled ? "TURN Server: ${linode_instance.turn_server[0].ip_address}" : ""}
-    
-    Next Steps:
-    1. Run 'terraform apply' in phase2/ to deploy Matrix services
-    2. Wait for DNS propagation (5-10 minutes)
-    3. Access Matrix at https://${var.element_subdomain}.${var.domain}
-  EOT
+  value = length(module.lke_cluster) == 0 ? "LKE cluster managed in ../phase1-dev/ — see that directory's outputs." : format(
+    "Matrix infrastructure deployed successfully!\n\nCluster Details:\n- Cluster ID: %s\n- Region: %s\n- Status: %s\n- Kubeconfig: %s/../kubeconfig.%s.yaml\n\nMatrix Domain: %s.%s\n%s\n\nNext Steps:\n1. Run 'terraform apply' in phase2/ to deploy Matrix services\n2. Wait for DNS propagation (5-10 minutes)\n3. Access Matrix at https://%s.%s\n",
+    module.lke_cluster[0].cluster_id,
+    module.lke_cluster[0].cluster_region,
+    module.lke_cluster[0].cluster_status,
+    path.root,
+    var.env,
+    var.matrix_subdomain,
+    var.domain,
+    var.turn_server_enabled ? "TURN Server: ${linode_instance.turn_server[0].ip_address}" : "",
+    var.element_subdomain,
+    var.domain,
+  )
 }
 
 # TURN Server Outputs
@@ -183,4 +184,3 @@ output "postgres_server_label" {
   description = "Label of the PostgreSQL server"
   value       = var.postgres_enabled ? module.postgres_server[0].postgres_server_label : null
 }
-

--- a/scripts/destroy-dev-cluster.sh
+++ b/scripts/destroy-dev-cluster.sh
@@ -11,11 +11,11 @@
 #   - headscale-dev  (Linode VM + 10 Gi data volume)
 #   - turn-server-dev (Linode VM)
 #
-# Also does NOT touch the shared VPC (matrix-cluster-<env>-vpc). Even though it
-# is defined inside module.lke_cluster, it contains both the LKE cluster_subnet
-# (ephemeral) AND the support_subnet (which holds the always-up VMs). Destroying
-# the VPC would require evicting the always-up VMs. The cluster_subnet is
-# destroyed and recreated each cycle; the VPC + support_subnet persist.
+# Also does NOT touch the LKE VPC (matrix-cluster-<env>-vpc) or the on-demand-dev
+# heartbeat bucket. Both live in phase1-dev's S3-backed state and are preserved
+# across destroy/recreate cycles: the cluster_subnet is the only VPC-side
+# resource that cycles, and the heartbeat bucket must outlive the cluster so
+# the Phase 3 reaper can see "the cluster was last used at T".
 #
 # These are kept across destroy/recreate cycles. The cost/benefit of cycling
 # postgres-dev (~$13/mo) is poor: it's outside K8s, schema bootstrap is painful,
@@ -85,14 +85,18 @@ ALWAYS_UP_VOLUMES=(
 # these disappear, the -target list is wrong and we have widened the blast
 # radius beyond the ephemeral cluster.
 #
-# The VPC is included here even though it lives inside module.lke_cluster: it
-# is shared with the support_subnet (always-up VMs) and must persist across
-# destroy/recreate cycles. See header for the full rationale.
-ALWAYS_UP_TF_MODULES=(
+# Two states are checked: phase1 (dev workspace; always-up VMs) and phase1-dev
+# (Linode Object Storage backend; LKE VPC + heartbeat bucket).
+ALWAYS_UP_TF_MODULES_PHASE1=(
   "module.headscale_server"
   "module.postgres_server"
   "linode_instance.turn_server"
+)
+
+ALWAYS_UP_TF_MODULES_PHASE1_DEV=(
   "module.lke_cluster.linode_vpc.cluster_vpc"
+  "linode_object_storage_bucket.dev_state"
+  "linode_object_storage_key.dev_state"
 )
 
 CLUSTER_REGION="us-lax"
@@ -149,17 +153,18 @@ if [ "$DRY_RUN" = "true" ]; then
   echo "Region:         $CLUSTER_REGION"
   echo ""
 
-  echo "Terraform targets that would be destroyed:"
+  echo "Terraform targets that would be destroyed (phase1-dev / S3-backed state):"
   echo "  -target=module.lke_cluster.linode_lke_cluster.cluster"
   echo "  -target=module.lke_cluster.linode_vpc_subnet.cluster_subnet"
   echo "  -target=local_file.kubeconfig"
   echo ""
 
   echo "Always-up resources (will be preserved):"
-  echo "  - postgres-dev (VM + 10 Gi data volume)"
-  echo "  - headscale-dev (VM + 10 Gi data volume)"
-  echo "  - turn-server-dev (VM)"
-  echo "  - matrix-cluster-${MT_ENV}-vpc (shared with support_subnet → always-up VMs)"
+  echo "  - postgres-dev (VM + 10 Gi data volume)               [phase1 dev workspace]"
+  echo "  - headscale-dev (VM + 10 Gi data volume)              [phase1 dev workspace]"
+  echo "  - turn-server-dev (VM)                                [phase1 dev workspace]"
+  echo "  - matrix-cluster-${MT_ENV}-vpc                        [phase1-dev]"
+  echo "  - mothertree-dev-state Object Storage bucket + key    [phase1-dev]"
   echo ""
 
   if [ "$CLUSTER_EXISTS" = "true" ]; then
@@ -325,54 +330,69 @@ fi
 
 # ---------------------------------------------------------------------------
 # Step 3: terraform destroy (LKE cluster only — never the always-up VMs)
+#
+# The LKE cluster lives in phase1-dev/ (its own S3-backed state). The dev VMs
+# live in phase1/ (dev workspace, local state) and are NOT touched here.
 # ---------------------------------------------------------------------------
-print_status "Running terraform destroy (LKE cluster only)..."
+print_status "Running terraform destroy (LKE cluster only, in phase1-dev)..."
 
-ENV_DNS_LABEL="$MT_ENV"   # 'dev' (per manage_infra convention; only 'prod' is empty)
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+  print_error "phase1-dev S3 backend requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in your secrets env."
+  print_error "See phase1-dev/MIGRATION.md."
+  exit 1
+fi
 
-pushd "$REPO_ROOT/phase1" >/dev/null
+VAR_FILE_FLAGS=()
+if [ -f "$REPO_ROOT/terraform.tfvars" ]; then
+  VAR_FILE_FLAGS+=("-var-file=$REPO_ROOT/terraform.tfvars")
+fi
+if [ -f "$REPO_ROOT/terraform.${MT_ENV}.tfvars" ]; then
+  VAR_FILE_FLAGS+=("-var-file=$REPO_ROOT/terraform.${MT_ENV}.tfvars")
+fi
+
+pushd "$REPO_ROOT/phase1-dev" >/dev/null
 
   terraform init -input=false >/dev/null
-  terraform workspace select "$MT_ENV"
 
-  VAR_FILE_FLAGS=()
-  if [ -f "$REPO_ROOT/terraform.tfvars" ]; then
-    VAR_FILE_FLAGS+=("-var-file=$REPO_ROOT/terraform.tfvars")
-  fi
-  if [ -f "$REPO_ROOT/terraform.${MT_ENV}.tfvars" ]; then
-    VAR_FILE_FLAGS+=("-var-file=$REPO_ROOT/terraform.${MT_ENV}.tfvars")
-  fi
-
-  # Target only the ephemeral cluster pieces — explicitly NOT the VPC. The VPC
-  # is defined inside module.lke_cluster but it is shared with the support_subnet
-  # (always-up VMs); targeting `module.lke_cluster` as a whole pulls the VPC in
-  # and Linode rejects the delete because the VPC still has resources in it.
-  # The post-destroy assertion below double-checks the VPC + always-up VMs
-  # survive in state.
+  # Target only the ephemeral cluster pieces — NOT the VPC, the heartbeat
+  # bucket, or its access key. The post-destroy assertion below double-checks
+  # they survive in state.
   terraform destroy -auto-approve "${VAR_FILE_FLAGS[@]}" \
     -target=module.lke_cluster.linode_lke_cluster.cluster \
     -target=module.lke_cluster.linode_vpc_subnet.cluster_subnet \
-    -target=local_file.kubeconfig \
-    -var env="$MT_ENV" \
-    -var env_dns_label="$ENV_DNS_LABEL" \
-    -var jitsi_tester_enabled=false
+    -target=local_file.kubeconfig
 
-  # Defense in depth: confirm always-up VM modules survived the destroy.
-  # Anchor the match to a full module/resource path (entry + dot or end-of-line)
-  # so a future rename like `module.headscale_server` → `module.headscale` doesn't
-  # silently keep passing because something else still contains the substring.
-  print_status "Asserting always-up VMs are still in terraform state..."
-  STATE_LIST=$(terraform state list 2>/dev/null)
-  for entry in "${ALWAYS_UP_TF_MODULES[@]}"; do
-    if ! echo "$STATE_LIST" | grep -qE "^${entry}(\.|$)"; then
-      print_error "ASSERTION FAILED: $entry is missing from terraform state!"
+  # Defense in depth: confirm VPC + heartbeat bucket survived. Anchor the match
+  # to a full module/resource path so substring rename collisions don't slip by.
+  print_status "Asserting VPC + heartbeat bucket are still in phase1-dev state..."
+  STATE_LIST_PHASE1_DEV=$(terraform state list 2>/dev/null)
+  for entry in "${ALWAYS_UP_TF_MODULES_PHASE1_DEV[@]}"; do
+    if ! echo "$STATE_LIST_PHASE1_DEV" | grep -qE "^${entry}(\.|$)"; then
+      print_error "ASSERTION FAILED: $entry is missing from phase1-dev terraform state!"
       print_error "The destroy widened beyond the ephemeral cluster — this is a bug."
       exit 3
     fi
   done
-  print_success "All always-up resources (postgres-dev, headscale-dev, turn-server-dev, VPC) preserved in state"
+  print_success "VPC + heartbeat bucket preserved in phase1-dev state"
 
 popd >/dev/null
+
+# Also verify the phase1 dev workspace VMs are untouched (defense in depth
+# even though this script never invokes terraform against phase1).
+print_status "Asserting always-up VMs are still in phase1 dev state..."
+pushd "$REPO_ROOT/phase1" >/dev/null
+  terraform init -input=false >/dev/null
+  terraform workspace select "$MT_ENV" >/dev/null
+  STATE_LIST_PHASE1=$(terraform state list 2>/dev/null)
+  for entry in "${ALWAYS_UP_TF_MODULES_PHASE1[@]}"; do
+    if ! echo "$STATE_LIST_PHASE1" | grep -qE "^${entry}(\.|$)"; then
+      print_error "ASSERTION FAILED: $entry is missing from phase1 dev state!"
+      print_error "The dev VMs should be untouched by destroy-dev-cluster.sh — investigate."
+      exit 3
+    fi
+  done
+popd >/dev/null
+print_success "All always-up resources (postgres-dev, headscale-dev, turn-server-dev, VPC, heartbeat bucket) preserved"
 
 # ---------------------------------------------------------------------------
 # Step 4: orphan sweep — block volumes (two-pass)
@@ -460,7 +480,8 @@ echo "Always-up resources preserved:"
 echo "  - postgres-dev VM + 10 Gi data volume"
 echo "  - headscale-dev VM + 10 Gi data volume"
 echo "  - turn-server-dev VM"
-echo "  - matrix-cluster-${MT_ENV}-vpc (shared with support_subnet → always-up VMs)"
+echo "  - matrix-cluster-${MT_ENV}-vpc (LKE VPC, in phase1-dev state)"
+echo "  - mothertree-dev-state Object Storage bucket + scoped access key"
 echo "  - DNS records (Cloudflare)"
 echo ""
 echo "To rebuild the cluster: ./scripts/manage_infra -e $MT_ENV --phase1 \\"

--- a/scripts/manage_infra
+++ b/scripts/manage_infra
@@ -205,11 +205,22 @@ if [ "$RUN_PHASE1" = "true" ]; then
       print_warning "This will DESTROY all infrastructure for '$MT_ENV'!"
       echo "============================================================"
       echo ""
-      echo "This includes:"
-      echo "  - LKE Kubernetes cluster"
-      echo "  - OpenVPN server"
-      echo "  - TURN server"
+      echo "This includes (phase1):"
+      echo "  - LKE Kubernetes cluster (prod / prod-eu only — dev's LKE lives in phase1-dev)"
+      echo "  - PostgreSQL VM + 10 Gi data volume (dev: postgres-dev)"
+      echo "  - Headscale VM + 10 Gi data volume (dev: headscale-dev)"
+      echo "  - TURN server VM"
       echo "  - All associated firewalls and VPC resources"
+      if [ "$MT_ENV" = "dev" ]; then
+        echo ""
+        echo "And also (phase1-dev):"
+        echo "  - Dev LKE Kubernetes cluster + VPC + subnet"
+        echo "  - Heartbeat bucket (mothertree-dev-state) + scoped access key"
+        echo "    (CI deploy vault will need re-generation after next bring-up)"
+      fi
+      echo ""
+      echo "For ephemeral dev teardown (preserves VMs + heartbeat bucket) use:"
+      echo "  ./scripts/manage_infra -e dev --destroy-cluster-only"
       echo ""
       read -p "Type 'destroy $MT_ENV' to confirm: " confirm
       if [ "$confirm" != "destroy $MT_ENV" ]; then
@@ -237,24 +248,82 @@ if [ "$RUN_PHASE1" = "true" ]; then
         -var env_dns_label="$ENV_DNS_LABEL" \
         -var jitsi_tester_enabled="$JITSI_TESTER_ENABLED"
 
-      # Extract outputs for reference
+      # Extract outputs for reference. For dev the LKE cluster lives in
+      # ../phase1-dev (own S3-backed state); read it from there below.
       echo ""
       print_status "Infrastructure outputs:"
       TURN_SERVER_IP=$(terraform output -raw turn_server_ip 2>/dev/null || echo "")
       if [ -n "$TURN_SERVER_IP" ] && [ "$TURN_SERVER_IP" != "null" ]; then
         echo "  TURN server IP: $TURN_SERVER_IP"
       fi
+      HEADSCALE_SERVER_IP=$(terraform output -raw headscale_server_ip 2>/dev/null || echo "")
+      POSTGRES_SERVER_IP=$(terraform output -raw postgres_server_ip 2>/dev/null || echo "")
 
       echo "  Kubeconfig: $REPO_ROOT/kubeconfig.$MT_ENV.yaml"
+    fi
+  popd >/dev/null
 
-      # Write terraform outputs to static env file for CI and other tools
-      # that cannot access local terraform state.
-      source "${REPO_ROOT}/scripts/lib/paths.sh"
-      _mt_resolve_infra_config "$MT_ENV"
-      if [ -n "${MT_INFRA_CONFIG:-}" ]; then
-        _TF_OUTPUTS_FILE="${MT_INFRA_CONFIG%/*}/terraform-outputs.${MT_ENV}.env"
-        print_status "Writing Terraform outputs to $_TF_OUTPUTS_FILE"
-        cat > "$_TF_OUTPUTS_FILE" <<TFEOF
+  # ---------------------------------------------------------------------------
+  # Phase1-dev: dev-only second Terraform root that manages the ephemeral LKE
+  # cluster + VPC + CI heartbeat bucket. Its state lives on Linode Object
+  # Storage so CI / the idle reaper can read and update it from anywhere —
+  # operator's laptop need not be online.
+  # ---------------------------------------------------------------------------
+  LKE_CLUSTER_ID=""
+  DEV_STATE_BUCKET=""
+  DEV_STATE_S3_KEY=""
+  DEV_STATE_S3_SECRET=""
+  DEV_STATE_S3_ENDPOINT=""
+  if [ "$MT_ENV" = "dev" ]; then
+    if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+      print_error "phase1-dev S3 backend requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in your secrets env."
+      print_error "See phase1-dev/MIGRATION.md for one-time setup."
+      exit 1
+    fi
+
+    pushd "$REPO_ROOT/phase1-dev" >/dev/null
+      print_status "Phase1-dev: Initializing Terraform (Linode Object Storage backend)..."
+      terraform init -input=false
+
+      if [ "$DESTROY" = "true" ]; then
+        print_status "Phase1-dev: Destroying LKE cluster + heartbeat bucket..."
+        terraform destroy -auto-approve "${VAR_FILE_FLAGS[@]}"
+
+      elif [ "$PLAN_ONLY" = "true" ]; then
+        print_status "Phase1-dev: Planning changes..."
+        terraform plan "${VAR_FILE_FLAGS[@]}"
+
+      else
+        print_status "Phase1-dev: Applying LKE cluster + heartbeat bucket..."
+        terraform apply -input=false -auto-approve "${VAR_FILE_FLAGS[@]}"
+
+        LKE_CLUSTER_ID=$(terraform output -raw cluster_id 2>/dev/null || echo "")
+        DEV_STATE_BUCKET=$(terraform output -raw dev_state_bucket 2>/dev/null || echo "")
+        DEV_STATE_S3_ENDPOINT=$(terraform output -raw dev_state_endpoint 2>/dev/null || echo "")
+        DEV_STATE_S3_KEY=$(terraform output -raw dev_state_access_key 2>/dev/null || echo "")
+        DEV_STATE_S3_SECRET=$(terraform output -raw dev_state_secret_key 2>/dev/null || echo "")
+      fi
+    popd >/dev/null
+  else
+    # prod / prod-eu: LKE cluster still in phase1.
+    pushd "$REPO_ROOT/phase1" >/dev/null
+      LKE_CLUSTER_ID=$(terraform output -raw cluster_id 2>/dev/null || echo "")
+    popd >/dev/null
+  fi
+
+  # ---------------------------------------------------------------------------
+  # Write terraform outputs to static env file for CI / deploy_infra. The file
+  # is the union of phase1 (TURN/Headscale/PostgreSQL) and, for dev, phase1-dev
+  # (LKE_CLUSTER_ID + DEV_STATE_*). Skipped on --plan / --destroy so we don't
+  # clobber the prior env file with empties.
+  # ---------------------------------------------------------------------------
+  if [ "$DESTROY" != "true" ] && [ "$PLAN_ONLY" != "true" ]; then
+    source "${REPO_ROOT}/scripts/lib/paths.sh"
+    _mt_resolve_infra_config "$MT_ENV"
+    if [ -n "${MT_INFRA_CONFIG:-}" ]; then
+      _TF_OUTPUTS_FILE="${MT_INFRA_CONFIG%/*}/terraform-outputs.${MT_ENV}.env"
+      print_status "Writing Terraform outputs to $_TF_OUTPUTS_FILE"
+      cat > "$_TF_OUTPUTS_FILE" <<TFEOF
 # Auto-generated by manage_infra after phase1 terraform apply
 # Used by deploy_infra and create_env (replaces terraform output calls)
 # Re-generated whenever manage_infra --phase1 runs successfully
@@ -264,17 +333,21 @@ VPN_SERVER_IP=""
 VPN_SERVER_PRIVATE_IP=""
 VPN_SERVER_TUNNEL_IP=""
 VPN_NETWORK_CIDR=""
-TURN_SERVER_IP="$(terraform output -raw turn_server_ip 2>/dev/null || echo "")"
-LKE_CLUSTER_ID="$(terraform output -raw cluster_id 2>/dev/null || echo "")"
-HEADSCALE_SERVER_IP="$(terraform output -raw headscale_server_ip 2>/dev/null || echo "")"
-POSTGRES_SERVER_IP="$(terraform output -raw postgres_server_ip 2>/dev/null || echo "")"
+TURN_SERVER_IP="${TURN_SERVER_IP:-}"
+LKE_CLUSTER_ID="${LKE_CLUSTER_ID:-}"
+HEADSCALE_SERVER_IP="${HEADSCALE_SERVER_IP:-}"
+POSTGRES_SERVER_IP="${POSTGRES_SERVER_IP:-}"
+# Dev-only: on-demand-dev heartbeat bucket credentials (empty for prod/prod-eu).
+DEV_STATE_BUCKET="${DEV_STATE_BUCKET:-}"
+DEV_STATE_S3_ENDPOINT="${DEV_STATE_S3_ENDPOINT:-}"
+DEV_STATE_S3_KEY="${DEV_STATE_S3_KEY:-}"
+DEV_STATE_S3_SECRET="${DEV_STATE_S3_SECRET:-}"
 TFEOF
-        print_status "Terraform outputs file written — include in CI deploy vault when updating secrets"
-      else
-        print_warning "Could not resolve infra config path — terraform outputs file not written"
-      fi
+      print_status "Terraform outputs file written — include in CI deploy vault when updating secrets"
+    else
+      print_warning "Could not resolve infra config path — terraform outputs file not written"
     fi
-  popd >/dev/null
+  fi
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Splits the dev LKE cluster into a new `phase1-dev/` Terraform root with a Linode Object Storage backend (`use_lockfile = true`, TF >= 1.11) so CI and the Phase 3 idle reaper can read durable shared state from environments without the operator's laptop.
- `phase1/` continues to manage prod / prod-eu LKE clusters with local state, and continues to manage the always-up dev VMs (`postgres-dev`, `headscale-dev`, `turn-server-dev`). Only the ephemeral LKE + VPC + subnet + kubeconfig resources for dev move into `phase1-dev/`.
- Prod and prod-eu plans are zero-impact (`moved` blocks track the address change introduced by `count = var.env == "dev" ? 0 : 1` on `module.lke_cluster` and `local_file.kubeconfig`).

## What changed

- **`phase1-dev/`** (new): `backend.tf` (S3 backend → `mothertree-tf-state-dev` bucket on `us-lax-1`), `main.tf` (lke_cluster module + kubeconfig file + `mothertree-dev-state` heartbeat bucket + scoped read_write access key for the Phase 3 reaper), `variables.tf`, `outputs.tf` (`cluster_id`, `dev_state_bucket`, `dev_state_endpoint`, `dev_state_access_key`/`secret_key` — sensitive), `terraform.dev.tfvars.example`, and `MIGRATION.md` (one-time operator runbook).
- **`phase1/main.tf`**: gate `module.lke_cluster` and `local_file.kubeconfig` with `count = var.env == "dev" ? 0 : 1`. Add `moved` blocks so existing prod / prod-eu state doesn't see destroy+recreate.
- **`phase1/outputs.tf`**: guard all `module.lke_cluster.*` references with `length() > 0 ? ... : null` so the dev workspace can apply with `count = 0`.
- **`scripts/manage_infra`**: for `env = dev`, run `phase1-dev/` after `phase1/` and emit `DEV_STATE_BUCKET`, `DEV_STATE_S3_ENDPOINT`, `DEV_STATE_S3_KEY`, `DEV_STATE_S3_SECRET` into `terraform-outputs.dev.env`. Fail fast if `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` aren't set. `--destroy` confirmation message updated to call out `phase1-dev` resources.
- **`scripts/destroy-dev-cluster.sh`**: redirect the LKE destroy from `phase1/` (dev workspace) to `phase1-dev/`. Keep VPC + heartbeat bucket via `-target` list. Post-destroy assertion now checks both states (phase1 always-up VMs + phase1-dev VPC/bucket).

## Migration

Pre-existing dev state needs a one-time operator migration before this branch's `terraform apply` will succeed for dev. Runbook is in `phase1-dev/MIGRATION.md`. High level:
1. Create the `mothertree-tf-state-dev` bucket and a scoped access key via `linode-cli`.
2. Add `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` to the gitignored secrets env file.
3. `terraform state pull` backup, then `terraform state rm` the LKE resources in `phase1/` (dev workspace).
4. `terraform import` them into `phase1-dev/`.
5. Verify `terraform plan` is zero-diff before applying.

Prod / prod-eu plans are zero-impact after this PR — verified locally with `terraform plan -refresh=false` against both workspaces (only pre-existing autoscaler drift on pool count is shown, identical to plans against `main`).

## Test plan

- [x] `cd phase1-dev && terraform init -backend=false && terraform validate` — clean
- [x] `cd phase1 && terraform workspace select prod   && terraform plan -refresh=false` — `0 to add, 0 to destroy`, all addresses moved cleanly
- [x] `cd phase1 && terraform workspace select prod-eu && terraform plan -refresh=false` — `0 to add, 0 to destroy`, all addresses moved cleanly
- [x] Manual review: `phase1-dev/main.tf` module call passes identical params to what `phase1/main.tf` passes for dev today
- [ ] Operator runs `phase1-dev/MIGRATION.md` end to end (will be done on this branch before merge)
- [ ] Post-migration: `./scripts/manage_infra -e dev --phase1` succeeds and `terraform-outputs.dev.env` contains `LKE_CLUSTER_ID`, `DEV_STATE_BUCKET`, `DEV_STATE_S3_KEY`, `DEV_STATE_S3_SECRET`
- [ ] Post-migration: `./scripts/destroy-dev-cluster.sh -e dev --dry-run` lists phase1-dev targets correctly

## OSS Compliance Review

CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0 — no findings. Bucket labels (`mothertree-tf-state-dev`, `mothertree-dev-state`) and region identifiers are public infrastructure, no credentials in the diff, sensitive outputs marked appropriately.

## Security Review

CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 (the two MEDIUM items raised — `--destroy` confirmation prompt incomplete, asymmetry vs `destroy-dev-cluster.sh` — were addressed in this PR by expanding the warning text to enumerate phase1-dev resources and pointing operators at `--destroy-cluster-only` for the ephemeral path) | LOW: 3 advisory (placeholder S3 backend region, no `lifecycle.prevent_destroy` on heartbeat bucket — by design so `--destroy` works, and a cosmetic gitignore-pattern note). Credential flow, key scope, blast radius, and `moved` blocks all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)