### PR TITLE
fix(on-demand-dev): post-merge fixes from CI provisioning

### DIFF
--- a/ci/ansible/playbook.yml
+++ b/ci/ansible/playbook.yml
@@ -408,27 +408,30 @@
         dest: /usr/local/bin/kubectl
         mode: "0755"
 
-    - name: Install jq, envsubst, ansible-core, awscli, python3-pip
+    - name: Install jq, envsubst, ansible-core, python3-pip
       ansible.builtin.apt:
         name:
           - jq
           - gettext-base
           - ansible-core
-          # awscli is used by scripts/dev-heartbeat.sh + dev-reaper.sh (s3 cp
-          # against Linode Object Storage). The Debian-packaged v1 is fine —
-          # we only need basic `s3 cp` with --endpoint-url.
-          - awscli
-          # pip is used to install linode-cli below (no apt package available).
+          # pip is used to install awscli + linode-cli below; the apt-packaged
+          # awscli was removed from the default repos starting in Ubuntu 24.04
+          # / Debian 13, so we install both via pip instead.
           - python3-pip
         state: present
 
-    - name: Install linode-cli (on-demand-dev bring-up + reaper)
-      # Used by scripts/dev-bringup.sh (cluster existence check + kubeconfig
-      # fetch via `linode-cli lke kubeconfig-view`) and by destroy-dev-cluster.sh
-      # (orphan sweep). `--break-system-packages` is needed on Ubuntu 23.04+
-      # because the OS enforces PEP 668 against site-packages writes.
+    - name: Install awscli + linode-cli via pip (on-demand-dev bring-up + reaper)
+      # awscli: used by scripts/dev-heartbeat.sh + dev-reaper.sh for `s3 cp`
+      # against the Linode Object Storage heartbeat bucket.
+      # linode-cli: used by scripts/dev-bringup.sh (cluster existence check +
+      # kubeconfig fetch via `linode-cli lke kubeconfig-view`) and by
+      # destroy-dev-cluster.sh (orphan sweep).
+      # `--break-system-packages` is needed on Ubuntu 23.04+ / Debian 12+
+      # because the OS enforces PEP 668 against system site-packages writes.
       ansible.builtin.pip:
-        name: linode-cli
+        name:
+          - awscli
+          - linode-cli
         state: present
         extra_args: --break-system-packages
 
@@ -610,14 +613,14 @@
     # heartbeat bucket itself) are preserved by destroy-dev-cluster.sh's
     # whitelist + post-destroy assertion.
     - name: Clone mothertree-oss for the idle reaper
-      # The reaper runs `git fetch && reset --hard origin/master` at the top of
+      # The reaper runs `git fetch && reset --hard origin/main` at the top of
       # every run so it always invokes the latest destroy-dev-cluster.sh.
       ansible.builtin.git:
         repo: "https://github.com/mothertree-labs/mothertree-oss.git"
         dest: /home/woodpecker/mothertree-checkout
-        version: master
+        version: main
         # Don't auto-update on every playbook run — the reaper does that. But
-        # ensure the clone exists and is on master.
+        # ensure the clone exists and is on main.
         update: false
         force: false
       become: true

--- a/scripts/dev-reaper.sh
+++ b/scripts/dev-reaper.sh
@@ -133,9 +133,9 @@ if [ ! -d "$REPO_DIR" ]; then
 fi
 
 # Pull latest code so we run with whatever destroy logic is on main.
-log "syncing $REPO_DIR to origin/master"
+log "syncing $REPO_DIR to origin/main"
 git -C "$REPO_DIR" fetch --quiet origin
-git -C "$REPO_DIR" reset --hard --quiet origin/master
+git -C "$REPO_DIR" reset --hard --quiet origin/main
 git -C "$REPO_DIR" submodule update --init --recursive --quiet 2>/dev/null || true
 
 # Files we write into the repo dir that contain the Linode API token / kubeconfig.


### PR DESCRIPTION
## Summary

Follow-up to #391. Three small fixes surfaced by running the operator deploy steps end-to-end against the live CI VM:

- **`awscli` no longer available via apt** on the CI VM (Ubuntu 24.04 — Canonical removed the package). Install both `awscli` and `linode-cli` via pip in a single task with `--break-system-packages`.
- **`master` → `main`** in two places: the Ansible git clone task in `ci/ansible/playbook.yml` and the `git reset --hard origin/master` line in `scripts/dev-reaper.sh`. The public repo's default branch is `main`; `master` doesn't exist remotely.
- **Bump `config/platform` submodule pointer** to `bf21941`, which carries the regenerated `terraform-outputs.dev.env` (`DEV_STATE_*`), the new reaper-related entries in `ci/ansible-vars.yml`, and the rebuilt `deploy-vault-dev.vault`.

After this lands, no further operator steps are needed — the dev-cluster on-demand lifecycle is fully wired end-to-end. The reaper is already running on the CI VM (every 15 min, `flock`'d), the Woodpecker secret `linode_token` is set, and the heartbeat has been pre-touched so the reaper sees the existing dev cluster as active.

## OSS Compliance Review

CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0 — clean.

## Security Review

CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0 — clean. Packaging change + branch name correction + submodule pointer bump; no new credentials, no new RBAC, no new exposure surface.

## Test plan

- [x] `awscli` + `linode-cli` install via pip (verified live on CI VM — `aws-cli/1.45.6`, `linode-cli v5.67.0`)
- [x] Reaper clone task succeeds against `origin/main` (verified — `/home/woodpecker/mothertree-checkout/` populated)
- [x] Reaper deployed and dry-run succeeds (`idle=15s < 7200s → skipping destroy`)
- [x] Heartbeat round-trip works (write + read back via aws-cli)
- [x] Woodpecker secret `linode_token` exists for the `ensure-dev-cluster` step
- [ ] First PR after this merges actually exercises `ensure-dev-cluster` cold or warm (operator to validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)