### PR TITLE
fix(infra-config): support auth_host override in env config

### DIFF
--- a/scripts/lib/infra-config.sh
+++ b/scripts/lib/infra-config.sh
@@ -108,6 +108,20 @@ _mt_infra_load_env_config() {
     PGBACKREST_S3_REGION=$(yq '.pgbackrest.s3_region // ""' "$infra_config")
     export PGBACKREST_S3_ENDPOINT PGBACKREST_S3_BUCKET PGBACKREST_S3_REGION
 
+    # Optional auth_host override.
+    # `_mt_infra_derive_hostnames` normally computes
+    # AUTH_HOST = `auth.${env_label}.${INFRA_DOMAIN}`. In envs where that
+    # subdomain isn't actually deployed — e.g. single-tenant environments
+    # whose Keycloak ingress lives under the tenant's own subdomain rather
+    # than the infra-level one — the computed value will not resolve in DNS
+    # and downstream callers fail. When `auth_host` is set in the env
+    # config, the derived value is overridden so AUTH_HOST points at the
+    # actual reachable ingress. Used by Keycloak's --hostname arg, Synapse's
+    # OIDC issuer URL, and the mt_wait_for_keycloak_oidc readiness gate.
+    AUTH_HOST_OVERRIDE=$(yq '.auth_host // ""' "$infra_config")
+    if [ "$AUTH_HOST_OVERRIDE" = "null" ]; then AUTH_HOST_OVERRIDE=""; fi
+    export AUTH_HOST_OVERRIDE
+
     # PgBouncer + Tailscale sidecar (external PG VM connectivity)
     PGBOUNCER_ENABLED=$(yq '.pgbouncer.enabled // false' "$infra_config")
     PG_VM_TAILSCALE_IP=$(yq '.pgbouncer.pg_vm_tailscale_ip // ""' "$infra_config")
@@ -416,7 +430,11 @@ _mt_infra_derive_hostnames() {
     infra_subdomain="${MT_ENV}."
   fi
 
-  export AUTH_HOST="auth.${infra_subdomain}${INFRA_DOMAIN}"
+  if [ -n "${AUTH_HOST_OVERRIDE:-}" ]; then
+    export AUTH_HOST="$AUTH_HOST_OVERRIDE"
+  else
+    export AUTH_HOST="auth.${infra_subdomain}${INFRA_DOMAIN}"
+  fi
   export PROMETHEUS_HOST="prometheus.internal.${infra_subdomain}${INFRA_DOMAIN}"
   export GRAFANA_HOST="grafana.internal.${infra_subdomain}${INFRA_DOMAIN}"
   export ALERTMANAGER_HOST="alertmanager.internal.${infra_subdomain}${INFRA_DOMAIN}"


### PR DESCRIPTION
## Summary

Pipeline #1222's `deploy-prod-eu` failed at the new `mt_wait_for_keycloak_oidc` readiness gate (PR A, #388). The gate curl'd a URL whose hostname doesn't resolve in DNS, because `AUTH_HOST` is computed as `auth.${env_label}.${INFRA_DOMAIN}` — but in a single-tenant env where the Keycloak ingress actually lives under the tenant's own subdomain, that computed hostname has no DNS record. The gap was silent before the gate landed; the post-merge pipeline finally surfaced it.

`deploy-prod` succeeded in the same pipeline — this fix is only needed to unblock the affected env.

## Change

Add an optional `auth_host` field to the env-level infra config (`config/platform/infra/<env>.config.yaml` in the private submodule). When set, `_mt_infra_derive_hostnames` uses it directly instead of computing from `infra_subdomain + INFRA_DOMAIN`. AUTH_HOST flows into:

- Keycloak's `--hostname` arg (chart values)
- Synapse's OIDC issuer URL (chart values)
- The readiness gate's curl target (`scripts/lib/common.sh`)

All three converge on the one reachable hostname. Backwards-compatible — envs without the override continue to compute as before.

## Operator follow-up after merge

1. Set `auth_host: <actual ingress hostname>` in the relevant env's config in `config/platform/infra/`.
2. Commit + push the submodule.
3. Rebuild the deploy vault is **not** needed (the override is read at deploy time from the operator-side config, which CI gets via submodule init in ci-deploy.sh).
4. Bump the submodule pointer in mothertree-oss in a follow-up PR (or in a chore commit alongside this PR's merge).
5. Re-run the deploy via the next main push or manually trigger a pipeline.

## OSS Compliance Review

CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0 — clean (operator domain and tenant references were initially leaked into the source comment + commit message; both sanitized via amend).

## Security Review

CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0 — clean. Override source is the operator's private submodule (already trusted), value flows into existing AUTH_HOST consumers — no new attack surface.

## Test plan

- [ ] Merge this PR.
- [ ] Operator: set `auth_host` in the affected env's infra config + commit submodule.
- [ ] Re-run deploy pipeline for the affected env.
- [ ] Verify Keycloak `--hostname` arg and Synapse OIDC issuer in chart values render to the override hostname (helmfile -e <env> -l name=keycloak template + similar for synapse).
- [ ] Verify gate passes against the override URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)