### PR TITLE
fix(dev-reaper): run git sync as woodpecker to fix idle-cluster teardown

### DIFF
--- a/scripts/dev-reaper.sh
+++ b/scripts/dev-reaper.sh
@@ -133,10 +133,14 @@ if [ ! -d "$REPO_DIR" ]; then
 fi
 
 # Pull latest code so we run with whatever destroy logic is on main.
-log "syncing $REPO_DIR to origin/main"
-git -C "$REPO_DIR" fetch --quiet origin
-git -C "$REPO_DIR" reset --hard --quiet origin/main
-git -C "$REPO_DIR" submodule update --init --recursive --quiet 2>/dev/null || true
+# The checkout is owned by `woodpecker` (Ansible clones it as that user); cron
+# runs us as root, and git refuses with "dubious ownership" when the worktree
+# owner differs from the caller. Run the sync as woodpecker via sudo. `-H` sets
+# HOME so git can find woodpecker's ~/.gitconfig if any.
+log "syncing $REPO_DIR to origin/main (as woodpecker)"
+sudo -u woodpecker -H git -C "$REPO_DIR" fetch --quiet origin
+sudo -u woodpecker -H git -C "$REPO_DIR" reset --hard --quiet origin/main
+sudo -u woodpecker -H git -C "$REPO_DIR" submodule update --init --recursive --quiet 2>/dev/null || true
 
 # Files we write into the repo dir that contain the Linode API token / kubeconfig.
 # Mode 0600 root-owned, but still: scrub on exit so a compromise of the


### PR DESCRIPTION
## Summary
- Reaper cron runs as root, but the reaper checkout at `/home/woodpecker/mothertree-checkout` is owned by `woodpecker` (Ansible clones it with `become_user: woodpecker`). Git refuses with "dubious ownership", `set -euo pipefail` aborts, and `destroy-dev-cluster.sh` is never reached.
- Wrap the three `git -C $REPO_DIR ...` invocations with `sudo -u woodpecker -H` so the sync runs as the worktree owner. Everything else (kubeconfig fetch, secrets file, destroy invocation) stays as root.

## Impact
Observed: 35 reaper invocations in the last 12h reached the destroy branch and all failed on `git fetch`. The idle LKE cluster was kept alive purely by intermittent PR activity refreshing the heartbeat — costs were quietly accumulating. After this lands and the CI VM is re-provisioned, the next reap of a >2h-idle dev cluster will succeed.

## Rollout
1. Merge this PR.
2. Re-run Ansible on the CI VM: `./ci/scripts/provision-ci.sh --ansible-only` (this re-copies `dev-reaper.sh` to `/usr/local/bin/`).
3. Watch `/var/log/dev-reaper.log` after the next 7200s-idle window — should see "destroy complete" instead of "dubious ownership".

## Test plan
- [ ] Confirm `sudo -u woodpecker -H git -C /home/woodpecker/mothertree-checkout fetch origin` succeeds on the CI VM (smoke-test of sudoers + safe.directory)
- [ ] After Ansible re-provision, force-test by setting `IDLE_HOURS=0.01` in `/etc/mothertree-reaper.env` on a non-prod-affecting moment and watch a destroy go through end-to-end, then revert
- [ ] Verify `/var/log/dev-reaper.log` no longer contains "dubious ownership"

## OSS Compliance Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0** — no domains, personal info, credentials, private registry refs, or tenant data introduced.

## Security Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0**

Notes for context (not findings):
- Privilege transition is a downward drop (root → woodpecker) scoped to three git invocations; control returns to root afterward.
- Secrets file (`secrets.tfvars.env`) and kubeconfig are still written by root mode 0600 AFTER the git sync — woodpecker owning the parent dir does not grant read access to 0600 root-owned files within it. No new exposure path.
- Cleanup trap is set before file creation; unchanged.
- `sudo -u woodpecker -H` incidentally strips the reaper env (`LINODE_CLI_TOKEN`, `AWS_*`, `VALKEY_PASSWORD`) from the child git process — minor defense-in-depth win against malicious git hooks.
- `sudo -u` is preferable to adding `safe.directory` to root's gitconfig, which would weaken the protection `safe.directory` is designed to provide.
- If sudoers is misconfigured, `sudo` fails, `set -e` aborts before destroy runs — fail-loud, consistent with project convention.

## Version Bump Check
No portal code changes. No version bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)