### PR TITLE
ci: bump terraform 1.9.8 → 1.13.3 on CI VM

### DIFF
--- a/ci/ansible/playbook.yml
+++ b/ci/ansible/playbook.yml
@@ -357,7 +357,7 @@
 
     - name: Install Terraform
       ansible.builtin.unarchive:
-        src: https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_linux_amd64.zip
+        src: https://releases.hashicorp.com/terraform/1.13.3/terraform_1.13.3_linux_amd64.zip
         dest: /usr/local/bin
         remote_src: true
         mode: "0755"


### PR DESCRIPTION
## Summary

- `phase1-dev/backend.tf` requires `terraform >= 1.11` (for `use_lockfile` — S3 native locking).
- CI VM was pinned to **1.9.8** in `ci/ansible/playbook.yml`, so every `terraform destroy` invoked by the dev-reaper cron has been failing with `Error: Unsupported Terraform Core version` since `phase1-dev` was introduced.
- Effect: dev LKE cluster never gets destroyed even when idle; reaper is stuck in a 15-min loop hitting the same error.
- Bumping CI VM terraform to **1.13.3** (current stable). `phase1/main.tf` only requires `>= 1.0`, so prod/legacy paths are unaffected.

## Roll-out

After merge, reprovision the CI VM so Ansible re-downloads the new binary:

```bash
./ci/scripts/provision-ci.sh --ansible-only
```

The `ansible.builtin.unarchive` task overwrites `/usr/local/bin/terraform` on every run, so no manual cleanup needed.

## Test plan

- [ ] Merge → run `./ci/scripts/provision-ci.sh --ansible-only`
- [ ] SSH to CI VM, confirm `terraform version` reports `v1.13.3`
- [ ] Wait for next reaper tick (or run `/usr/local/bin/dev-reaper.sh` manually as root); confirm it reaches and completes `terraform destroy` against `phase1-dev`
- [ ] Confirm the dev LKE cluster (`matrix-cluster-dev`) is destroyed in Linode after the run

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No OSS compliance issues. No tenant domains, credentials, or private registry references.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 1 (pre-existing) | **LOW**: 0

- **MEDIUM (pre-existing, out of scope)**: terraform zip is downloaded from `releases.hashicorp.com` without SHA256/GPG verification. This gap existed before this PR; same source, same delivery method. Worth a follow-up that adds `checksum:` to the `unarchive` task using HashiCorp's published `terraform_<ver>_SHA256SUMS`.
- No version-specific CVEs in 1.13.3. 1.9.x is EOL; 1.13.x is actively patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)