### PR TITLE
fix(stalwart): force CoreDNS rollout on rewrite change (cold-start gap #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- deploy-stalwart: force CoreDNS rollout (and node-local-dns DaemonSet, when present) on rewrite change so all replicas converge before the SMTP smoke test runs. Closes the cold-start race where provision-smtp's smoke test resolved `mail.<domain>` to the public LB IP via a lagging CoreDNS replica or a stale node-local cache.
+
 ## [0.9.3] - 2026-03-13
 
 ### Added

--- a/apps/deploy-stalwart.sh
+++ b/apps/deploy-stalwart.sh
@@ -422,59 +422,145 @@ print_status "Ensuring CoreDNS rewrite for $MAIL_HOST → stalwart.$NS_MAIL.svc.
 if ! kubectl -n kube-system get configmap coredns-custom >/dev/null 2>&1; then
     kubectl -n kube-system create configmap coredns-custom
 fi
-# jq builds the JSON merge-patch so we don't hand-escape keys/values.
-_coredns_patch=$(jq -cn \
-    --arg key "mail-${TENANT}.include" \
-    --arg body "rewrite name ${MAIL_HOST} stalwart.${NS_MAIL}.svc.cluster.local"$'\n' \
-    '{data: {($key): $body}}')
-kubectl -n kube-system patch configmap coredns-custom --type=merge -p "$_coredns_patch"
-print_success "CoreDNS rewrite applied (waiting for CoreDNS reload to propagate)"
+_coredns_key="mail-${TENANT}.include"
+_coredns_body="rewrite name ${MAIL_HOST} stalwart.${NS_MAIL}.svc.cluster.local"$'\n'
+
+# Detect whether the desired rewrite is already in place. If so, the patch is
+# a no-op and we can skip the (expensive) CoreDNS rollout below — the
+# rewrite has been live and converged for some time already.
+_coredns_existing=$(kubectl -n kube-system get configmap coredns-custom \
+    -o "jsonpath={.data.${_coredns_key}}" 2>/dev/null || true)
+if [ "$_coredns_existing" = "$_coredns_body" ]; then
+    print_status "CoreDNS rewrite already in place — skipping patch + rollout"
+    _coredns_changed=false
+else
+    # jq builds the JSON merge-patch so we don't hand-escape keys/values.
+    _coredns_patch=$(jq -cn \
+        --arg key "$_coredns_key" \
+        --arg body "$_coredns_body" \
+        '{data: {($key): $body}}')
+    kubectl -n kube-system patch configmap coredns-custom --type=merge -p "$_coredns_patch"
+    print_success "CoreDNS rewrite applied"
+    _coredns_changed=true
+fi
 
 # -----------------------------------------------------------------------------
-# Actively wait for the rewrite to take effect. CoreDNS auto-reloads the
-# Corefile via the `reload` plugin (~30s), but downstream callers connecting to
-# mail.<tenant-domain>:588 during the propagation window resolve to the public
-# LB IP (which does not expose 588) and hang. We MUST NOT return from this
-# script until the rewrite is live inside the cluster — otherwise the SMTP
-# smoke test in provision-smtp.js and any real caller (Synapse, Docs, Files,
-# portals) can race against an unresolved rewrite.
+# When the rewrite changed, force a CoreDNS rollout instead of relying on the
+# `reload` plugin. Background:
 #
-# Strategy: spin up a single short-lived busybox pod in NS_MAIL that runs an
-# internal poll loop (cheaper than relaunching a pod every iteration on LKE
-# where pod cold-start is ~5–10s). The pod compares the resolved address of
-# MAIL_HOST against the Stalwart ClusterIP and exits 0 on match / 1 on
-# timeout. Note: busybox `nslookup` prints the DNS server's own address line
-# first ("Address: 10.96.0.10#53") and only then the answer addresses after
-# "Name:" — the awk filter below skips lines until "Name:" appears.
+# CoreDNS's `reload` plugin watches the Corefile for changes (~30s poll), but
+# the custom rewrites live in a separate `coredns-custom` ConfigMap that
+# CoreDNS imports via `import custom/*.include`. Two compounding issues make
+# the natural reload path racy:
+#
+#   1. Per-replica kubelet ConfigMap mount sync timing differs by node, so
+#      one replica can serve the new rewrite while another still serves stale
+#      — and the kube-dns service IP load-balances across both. The previous
+#      probe (nslookup loop via the service IP, exit-on-first-success) masked
+#      this completely: it'd pass on whichever replica converged first while
+#      the other kept returning the public LB IP.
+#   2. If NodeLocal DNS Cache is in the resolver path, it caches resolutions
+#      per-node with its own positive TTL. CoreDNS being right doesn't help
+#      until NodeLocal's cached entry expires.
+#
+# Cold-start audit (2026-05-14, gap #14) traced a deploy-stalwart success
+# followed by an immediate provision-smtp SMTP smoke-test failure to exactly
+# this race — the smoke-test pod resolved mail.<domain> to the LB IP (port
+# 588 not exposed there) and hung past its 60s budget.
+#
+# Rollout-restart guarantees every replica has the new ConfigMap mounted and
+# Corefile loaded before we proceed; bouncing node-local-dns (when present)
+# flushes per-node caches. ~30-60s overhead per tenant; only paid when the
+# rewrite actually changed.
 # -----------------------------------------------------------------------------
-print_status "Waiting for CoreDNS rewrite to propagate ($MAIL_HOST → ClusterIP)"
+if [ "$_coredns_changed" = "true" ]; then
+    # Discover the CoreDNS deployment name via the standard k8s-app=kube-dns
+    # label rather than hardcoding "coredns" — the deployment is named
+    # "coredns" on most distros but some (e.g. legacy) use "kube-dns".
+    _coredns_deploy=$(kubectl -n kube-system get deploy -l k8s-app=kube-dns -o name | head -n1)
+    if [ -z "$_coredns_deploy" ]; then
+        print_error "No CoreDNS deployment found in kube-system (label k8s-app=kube-dns)"
+        exit 1
+    fi
+    print_status "Restarting $_coredns_deploy to propagate rewrite to all replicas"
+    kubectl -n kube-system rollout restart "$_coredns_deploy"
+    kubectl -n kube-system rollout status "$_coredns_deploy" --timeout=180s
+
+    if kubectl -n kube-system get ds node-local-dns >/dev/null 2>&1; then
+        print_status "Restarting node-local-dns DaemonSet to flush per-node caches"
+        kubectl -n kube-system rollout restart ds/node-local-dns
+        kubectl -n kube-system rollout status ds/node-local-dns --timeout=180s
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# Sanity check: after the rollout (or immediately, on a no-op), verify that
+# the rewrite is actually live. We query EACH CoreDNS pod's ClusterIP
+# directly (not via the kube-dns service IP) so a single laggy replica is
+# detected rather than masked by load-balancing. busybox `nslookup` accepts
+# a server as its second positional arg.
+#
+# The MAIL_HOST → ClusterIP mapping is the contract that downstream callers
+# (provision-smtp's SMTP smoke test, Synapse, Docs, Files, portals) depend
+# on. If even one CoreDNS replica is wrong, those callers can race against
+# the wrong answer and hit the public LB IP (which does not expose 588).
+# -----------------------------------------------------------------------------
+print_status "Verifying CoreDNS rewrite propagated to ALL replicas"
 _stalwart_cluster_ip=$(kubectl -n "$NS_MAIL" get svc stalwart -o jsonpath='{.spec.clusterIP}')
 if [ -z "$_stalwart_cluster_ip" ]; then
     print_error "Could not read Stalwart ClusterIP from svc/stalwart in $NS_MAIL"
     exit 1
 fi
-print_status "Expecting $MAIL_HOST to resolve to $_stalwart_cluster_ip inside the cluster"
+# Filter out pods with deletionTimestamp set: rollout-status returns once the
+# new ReplicaSet is fully ready, but old pods can linger in `Running` phase
+# for a few seconds while their containers terminate. Probing those IPs
+# would burn the entire 90s budget on dead addresses. (kubectl jsonpath
+# doesn't support negation, so use jq.)
+_coredns_pod_ips=$(kubectl -n kube-system get pods -l k8s-app=kube-dns -o json \
+    | jq -r '.items[]
+        | select(.status.phase == "Running")
+        | select(.metadata.deletionTimestamp == null)
+        | .status.podIP' \
+    | tr '\n' ' ')
+if [ -z "${_coredns_pod_ips// /}" ]; then
+    print_error "No running CoreDNS pods found (label k8s-app=kube-dns in kube-system)"
+    exit 1
+fi
+print_status "Expecting $MAIL_HOST → $_stalwart_cluster_ip from CoreDNS pods: $_coredns_pod_ips"
 
-# 18 attempts × 5s = ~90s budget, plus pod startup overhead.
+# Note: busybox `nslookup` prints the DNS server's own address line first
+# ("Address: <server>#53") and only then the answer addresses after "Name:"
+# — the awk filter below skips lines until "Name:" appears.
 _dns_probe_pod="smtp-dns-probe-$$"
 if kubectl run "$_dns_probe_pod" -n "$NS_MAIL" \
     --rm -i --restart=Never --image=busybox:1.36 --quiet \
     --command -- sh -c "
+        pod_ips='${_coredns_pod_ips}'
+        want='${_stalwart_cluster_ip}'
+        host='${MAIL_HOST}'
         for i in \$(seq 1 18); do
-            ip=\$(nslookup ${MAIL_HOST} 2>/dev/null | awk '/^Name:/{f=1; next} f && /^Address/{print \$2; exit}')
-            if [ \"\$ip\" = \"${_stalwart_cluster_ip}\" ]; then
-                echo \"OK: \$ip\"
+            all_ok=1
+            last_state=
+            for ip in \$pod_ips; do
+                got=\$(nslookup \"\$host\" \"\$ip\" 2>/dev/null | awk '/^Name:/{f=1; next} f && /^Address/{print \$2; exit}')
+                if [ \"\$got\" != \"\$want\" ]; then
+                    all_ok=0
+                    last_state=\"replica \$ip returned '\$got'\"
+                fi
+            done
+            if [ \"\$all_ok\" = '1' ]; then
+                echo \"OK: all CoreDNS replicas return \$want for \$host\"
                 exit 0
             fi
-            echo \"  attempt \$i: got '\$ip' (want ${_stalwart_cluster_ip}), retrying in 5s\"
+            echo \"  attempt \$i: \$last_state (want \$want), retrying in 5s\"
             sleep 5
         done
-        echo \"FAIL: ${MAIL_HOST} did not resolve to ${_stalwart_cluster_ip} after 90s (last seen: '\$ip')\"
+        echo \"FAIL: not all CoreDNS replicas converged on \$want for \$host within 90s (\$last_state)\"
         exit 1
     "; then
-    print_success "CoreDNS rewrite propagated: $MAIL_HOST → $_stalwart_cluster_ip"
+    print_success "CoreDNS rewrite verified across all replicas: $MAIL_HOST → $_stalwart_cluster_ip"
 else
-    print_error "CoreDNS rewrite for $MAIL_HOST did not propagate within 90s"
+    print_error "CoreDNS rewrite for $MAIL_HOST did not propagate to all replicas within 90s"
     print_error "Check kube-system/coredns-custom ConfigMap and CoreDNS pod logs:"
     print_error "  kubectl -n kube-system get configmap coredns-custom -o yaml"
     print_error "  kubectl -n kube-system logs -l k8s-app=kube-dns --tail=100"


### PR DESCRIPTION
## Summary

Closes **gap #14** from the [cold-start audit (2026-05-14)](Documents/Mothertree/Design Documents/on-demand-dev/05-cold-start-audit-2026-05-14.md): `deploy-stalwart` succeeds, then the immediate `provision-smtp` SMTP smoke test times out with `mail.<domain>` resolving to the public LB IP (port 588 not exposed there). Empirically reproduced on pipeline #1265 (warm reuse path), so this isn't fresh-CoreDNS-reload latency.

**Root causes the previous probe didn't close**:
1. The single-replica probe (busybox `nslookup` loop via the `kube-dns` service IP, exit-on-first-success) masked replica skew. Per-replica kubelet ConfigMap mount-sync timing differs by node, so one CoreDNS replica could serve the new rewrite while another served stale, and the service IP load-balanced across both. Probe exited after one converged; the smoke test ~90s later load-balanced to the lagging replica.
2. NodeLocal DNS Cache (when enabled) caches resolutions per-node with its own positive TTL. CoreDNS being right doesn't help until the per-node cache entry expires.

**Fix**:
- Idempotent change-detection on the `coredns-custom` ConfigMap key — skip the rollout entirely on a no-op (warm/no-change deploys pay nothing).
- On change: `kubectl rollout restart deployment/coredns` (discovered via `k8s-app=kube-dns` label rather than name-hardcoded) plus `ds/node-local-dns` when present, waiting for rollout status. Sidesteps the reload-plugin + mount-sync race entirely; flushes per-node caches.
- Replace the single-replica probe with a per-replica probe: query each running CoreDNS pod IP directly via busybox `nslookup HOST SERVER`, require ALL replicas to converge. `jq`-filter terminating pods (`metadata.deletionTimestamp`) so old pods that linger briefly post-rollout don't burn the 90s budget.

**Caveat**: this is logs-driven inference, not empirical proof — needs a passing `deploy-dev-stalwart` cold-start CI run on this PR before merge.

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0

No real domains, tenant identifiers, hardcoded credentials, registries, or PII. CHANGELOG uses `mail.<domain>` placeholder; deploy-stalwart references identifiers exclusively via runtime variables (`$TENANT`, `$MAIL_HOST`, `$NS_MAIL`). Only added image is `busybox:1.36` (public Docker Hub).

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 3 | **LOW**: 3

No critical or high findings. The MEDIUMs are pre-existing patterns this PR mildly amplifies, not new risks:

- **MEDIUM** — Shell interpolation of `MAIL_HOST` / `TENANT` into the `kubectl run -- sh -c "..."` heredoc. `MAIL_HOST` is single-quoted inside (`host='${MAIL_HOST}'`) so theoretically a `'`/`$`/backtick/`\` could break out, but DNS hostnames legitimately can't contain those characters and tenant config is operator-controlled. Worth documenting the trust boundary or asserting `MAIL_HOST` matches `^[a-zA-Z0-9.-]+$` defensively. (Pre-existing in this script.)
- **MEDIUM** — Cluster-DNS rolling restart on every changed-rewrite tenant deploy is a real (if scoped) availability risk. Briefly reduces DNS capacity cluster-wide and forces a node-local-dns cache flush. The change-detection guard limits this to first-time-or-changed deploys per tenant; in `create_env`-for-all-tenants prod runs it could chain N restarts. Mitigations to consider: batch ConfigMap mutations + restart once at the end, or only restart when the per-replica probe fails.
- **MEDIUM** — Probe pod runs in `NS_MAIL` with the default ServiceAccount and no `securityContext` (root, full caps). Pre-existing pattern in this script; pod is short-lived and only runs `nslookup`. Worth hardening with `--overrides` for `runAsNonRoot`/`seccompProfile: RuntimeDefault`/`drop: ALL`/`readOnlyRootFilesystem` in a follow-up.

LOWs: probe pod name uses `$$` (collision risk under reused PIDs); `head -n1` on label-matched deployments could miss a divergent secondary CoreDNS in the future; CoreDNS pod IPs trusted as DNS endpoints (mitigated by RBAC on `kube-system`).

None block merging — flagged for tracking.

## Version Bump

No portal code changes (admin-portal/account-portal not touched). No bump needed.

## Test plan

- [ ] Pipeline on this branch reaches `deploy-dev-stalwart`
- [ ] CoreDNS rollout block executes on first deploy after the cluster sees this code
- [ ] Per-replica probe converges (logs show "OK: all CoreDNS replicas return X for Y")
- [ ] `provision-smtp` SMTP smoke test passes (no timeout, no "resolves to LB IP")
- [ ] On a re-run of the same tenant deploy with no rewrite change, the rollout block is skipped (logs show "CoreDNS rewrite already in place — skipping patch + rollout")
- [ ] e2e shards green

🤖 Generated with Claude (mothertree)