### PR TITLE
fix(tls): split Certificate to avoid cert-manager same-FQDN deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Wildcard TLS renewal deadlock: split per-tenant TLS into two Certificates
+  (`wildcard-tls` for `*.domain` + `*.internal-domain`, and `apex-tls` for the
+  bare apex). cert-manager's ACME scheduler deduplicates challenges by
+  `(DNSName, Type)` only — a single Certificate that combines `*.example.com`
+  with `example.com` produces two authorizations at the same
+  `_acme-challenge.example.com` FQDN and the scheduler will never process the
+  second one (cert-manager#8643, behavior is reaffirmed as design intent in
+  v1.20). The first issuance can succeed by luck when one authz is cached on
+  the Let's Encrypt account; every fresh renewal deadlocks. Splitting the
+  Certificate puts each authz on its own Order, sidestepping the dedup. The
+  `matrix-wellknown` ingress now references the `apex-tls-${TENANT_NAME}`
+  secret.
+
 ## [0.9.3] - 2026-03-13
 
 ### Added

--- a/apps/manifests/synapse-admin/matrix-wellknown.yaml.tpl
+++ b/apps/manifests/synapse-admin/matrix-wellknown.yaml.tpl
@@ -14,7 +14,7 @@ spec:
   tls:
     - hosts:
         - ${TENANT_DOMAIN}
-      secretName: wildcard-tls-${TENANT_NAME}
+      secretName: apex-tls-${TENANT_NAME}
   rules:
     - host: ${TENANT_DOMAIN}
       http:

--- a/apps/manifests/wildcard/certificate.yaml.tpl
+++ b/apps/manifests/wildcard/certificate.yaml.tpl
@@ -1,15 +1,21 @@
-# Per-tenant wildcard TLS certificate (DNS-01 via Cloudflare)
-# Creates: Cloudflare token secret, ClusterIssuer, Certificate with reflector annotations
+# Per-tenant TLS certificates (DNS-01 via Cloudflare)
+# Creates: Cloudflare token secret, ClusterIssuer, two Certificates with reflector annotations.
 #
-# The Certificate lives in NS_MATRIX (one per tenant) and reflector mirrors the
-# resulting TLS secret to every other tenant namespace listed in TENANT_NAMESPACES.
+# The wildcard and bare-apex names are kept on SEPARATE Certificates because
+# cert-manager's ACME scheduler deduplicates challenges by (DNSName, Type) only,
+# without considering the Wildcard flag. A Certificate that mixes
+# `*.example.com` and `example.com` produces two authorizations with the same
+# `_acme-challenge.example.com` FQDN; the scheduler treats them as duplicates and
+# only ever processes one. The first issuance can succeed by luck (cached
+# authzs), but every fresh renewal deadlocks. Splitting puts each authz on its
+# own Order, sidestepping the bug. See cert-manager#8643.
 #
 # Required environment variables:
 #   TENANT_NAME              - Tenant name (e.g., example)
 #   WILDCARD_DOMAIN_EXTERNAL - External wildcard (e.g., *.example.com or *.dev.example.com)
 #   WILDCARD_DOMAIN_INTERNAL - Internal wildcard (e.g., *.prod.example.com or *.internal.dev.example.com)
 #   WILDCARD_DOMAIN_BARE     - Bare domain for .well-known (e.g., example.com or dev.example.com)
-#   NS_MATRIX                - Namespace where the Certificate resource lives
+#   NS_MATRIX                - Namespace where the Certificate resources live
 #   TENANT_NAMESPACES        - Comma-separated target namespaces for reflector mirroring
 #   CLOUDFLARE_API_TOKEN     - Cloudflare API token for DNS-01 challenge
 #   TLS_EMAIL                - Email for Let's Encrypt registration
@@ -53,10 +59,24 @@ spec:
   dnsNames:
     - "${WILDCARD_DOMAIN_EXTERNAL}"
     - "${WILDCARD_DOMAIN_INTERNAL}"
-    - "${WILDCARD_DOMAIN_BARE}"
   secretTemplate:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "${TENANT_NAMESPACES}"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
       reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "${TENANT_NAMESPACES}"
+---
+# Bare-apex Certificate (separate Order to avoid same-FQDN scheduler dedup with wildcard).
+# Consumed by the Matrix .well-known ingress only — no reflector needed.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: apex-tls
+  namespace: ${NS_MATRIX}
+spec:
+  secretName: apex-tls-${TENANT_NAME}
+  issuerRef:
+    name: letsencrypt-dns01-${TENANT_NAME}
+    kind: ClusterIssuer
+  dnsNames:
+    - "${WILDCARD_DOMAIN_BARE}"

--- a/scripts/create_env
+++ b/scripts/create_env
@@ -197,21 +197,30 @@ print_status "Reflector target namespaces: $TENANT_NAMESPACES"
 envsubst < "$REPO_ROOT/apps/manifests/wildcard/certificate.yaml.tpl" | kubectl apply -f -
 print_status "Wildcard certificate resources applied"
 
-# Wait for the certificate to be issued (DNS-01 can take 1-2 minutes)
-# cert-manager's Cloudflare DNS solver has a known issue where challenge cleanup
-# fails with an empty zone ID, causing a deadlock: validated challenges can't
-# finalize, blocking remaining challenges from starting. We detect this and
-# recover by removing finalizers from stuck challenges and letting cert-manager retry.
-print_status "Waiting for wildcard certificate to be ready (DNS-01 validation)..."
-if kubectl wait --for=condition=Ready certificate/wildcard-tls -n "$NS_MATRIX" --timeout=120s 2>/dev/null; then
-  print_success "Wildcard TLS certificate is ready"
-else
-  print_warning "Certificate not ready after 120s, checking for stuck challenges..."
+# Wait for the certificates to be issued (DNS-01 can take 1-2 minutes).
+# Both `wildcard-tls` (*.domain + *.internal-domain) and `apex-tls` (bare domain)
+# are issued independently. They live on separate Orders so they cannot deadlock
+# each other under cert-manager's same-FQDN scheduler dedup (see cert-manager#8643).
+# The recovery block below removes finalizers from any challenge stuck `valid` with
+# a finalizer (Cloudflare cleanup edge cases) and retries.
+print_status "Waiting for TLS certificates to be ready (DNS-01 validation)..."
+CERT_OK=true
+for cert in wildcard-tls apex-tls; do
+  if kubectl wait --for=condition=Ready "certificate/${cert}" -n "$NS_MATRIX" --timeout=120s 2>/dev/null; then
+    print_success "${cert} certificate is ready"
+  else
+    CERT_OK=false
+    print_warning "${cert} not ready after 120s"
+  fi
+done
+
+if [ "$CERT_OK" != "true" ]; then
+  print_warning "Checking for stuck challenges..."
 
   # Find challenges stuck in cleanup (valid state but finalizer prevents GC)
   STUCK_CHALLENGES=$(kubectl get challenges -n "$NS_MATRIX" -o json 2>/dev/null \
     | jq -r '.items[]
-             | select(.metadata.name | startswith("wildcard-tls-"))
+             | select((.metadata.name | startswith("wildcard-tls-")) or (.metadata.name | startswith("apex-tls-")))
              | select(.status.state == "valid")
              | select((.metadata.finalizers // []) | length > 0)
              | .metadata.name' 2>/dev/null)
@@ -224,31 +233,33 @@ else
         && print_status "  Removed finalizer from $ch"
     done
 
-    # Delete remaining wildcard challenges (e.g. ones that never started)
-    kubectl get challenges -n "$NS_MATRIX" -o name 2>/dev/null \
-      | grep "wildcard-tls-" \
-      | xargs -r kubectl delete -n "$NS_MATRIX" 2>/dev/null || true
+    # Delete remaining challenges, orders, CRs for both certs so cert-manager retries from scratch
+    for prefix in wildcard-tls- apex-tls-; do
+      kubectl get challenges -n "$NS_MATRIX" -o name 2>/dev/null \
+        | grep "$prefix" \
+        | xargs -r kubectl delete -n "$NS_MATRIX" 2>/dev/null || true
+      kubectl get orders -n "$NS_MATRIX" -o name 2>/dev/null \
+        | grep "$prefix" \
+        | xargs -r kubectl delete -n "$NS_MATRIX" 2>/dev/null || true
+      kubectl get certificaterequests -n "$NS_MATRIX" -o name 2>/dev/null \
+        | grep "$prefix" \
+        | xargs -r kubectl delete -n "$NS_MATRIX" 2>/dev/null || true
+    done
 
-    # Delete stale orders and certificate requests so cert-manager retries from scratch
-    kubectl get orders -n "$NS_MATRIX" -o name 2>/dev/null \
-      | grep "wildcard-tls-" \
-      | xargs -r kubectl delete -n "$NS_MATRIX" 2>/dev/null || true
-    kubectl get certificaterequests -n "$NS_MATRIX" -o name 2>/dev/null \
-      | grep "wildcard-tls-" \
-      | xargs -r kubectl delete -n "$NS_MATRIX" 2>/dev/null || true
-
-    print_status "Waiting for cert-manager to retry (up to 180s)..."
-    if kubectl wait --for=condition=Ready certificate/wildcard-tls -n "$NS_MATRIX" --timeout=180s 2>/dev/null; then
-      print_success "Wildcard TLS certificate is ready (after retry)"
-    else
-      print_warning "Wildcard certificate still not ready after retry"
-      print_warning "Check status: kubectl get certificate wildcard-tls -n $NS_MATRIX"
-      print_warning "Continuing deployment — ingresses will use the cert once it's issued"
-    fi
+    print_status "Waiting for cert-manager to retry (up to 180s per cert)..."
+    for cert in wildcard-tls apex-tls; do
+      if kubectl wait --for=condition=Ready "certificate/${cert}" -n "$NS_MATRIX" --timeout=180s 2>/dev/null; then
+        print_success "${cert} certificate is ready (after retry)"
+      else
+        print_warning "${cert} still not ready after retry"
+        print_warning "Check status: kubectl get certificate ${cert} -n $NS_MATRIX"
+      fi
+    done
+    print_warning "Continuing deployment — ingresses will use certs once they're issued"
   else
-    print_warning "No stuck challenges found — certificate may still be validating"
-    print_warning "Check status: kubectl get certificate wildcard-tls -n $NS_MATRIX"
-    print_warning "Continuing deployment — ingresses will use the cert once it's issued"
+    print_warning "No stuck challenges found — certificates may still be validating"
+    print_warning "Check status: kubectl get certificate -n $NS_MATRIX"
+    print_warning "Continuing deployment — ingresses will use certs once they're issued"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Split per-tenant TLS into two Certificates: `wildcard-tls` (`*.${DOMAIN}`, `*.${INTERNAL_DOMAIN}`) and `apex-tls` (bare `${DOMAIN}`). cert-manager's ACME scheduler dedups challenges by `(DNSName, Type)` only — a single Certificate mixing wildcard + apex produces two authzs at the same `_acme-challenge.${DOMAIN}` FQDN, and only one ever gets scheduled. Initial issuance can succeed via cached LE authzs but every fresh renewal deadlocks. Maintainers reaffirmed this is design intent (cert-manager#8643); `compareChallenges` is byte-identical across v1.13–v1.20, so upgrading does not help.
- `matrix-wellknown` ingress now references `apex-tls-\${TENANT_NAME}` (only consumer of the bare apex).
- `create_env` wait/recovery loop now covers both certs and removes finalizers on stuck challenges of either prefix.

## Production incident context

prod's `wildcard-tls-mothertree` was scheduled to expire today 23:54Z. The April 14 renewal had been stuck `pending` for 30 days with the exact symptom this PR fixes. I manually performed the same split in prod (deleted stuck Order, patched Certificate to drop apex, applied new `apex-tls` Certificate, patched `matrix-wellknown` ingress). Both certs now valid through 2026-08-13; reflector has propagated the new wildcard secret to all 8 tenant namespaces. This PR makes the layout permanent so dev/prod-eu and future tenants don't trip on the same bug.

## Test plan

- [ ] CI dev deploy — confirm both `wildcard-tls` and `apex-tls` reach Ready=True in `tn-${tenant}-matrix`
- [ ] Hit `https://${TENANT_DOMAIN}/.well-known/matrix/server` from outside; confirm valid TLS chain (apex-tls)
- [ ] Hit `https://matrix.${TENANT_DOMAIN}/_matrix/client/versions`; confirm valid TLS chain (wildcard-tls)
- [ ] `kubectl get secret apex-tls-\${TENANT_NAME} -n tn-\${tenant}-matrix` — confirm exists, only in NS_MATRIX (no reflector)
- [ ] `kubectl get secret wildcard-tls-\${TENANT_NAME} -A` — confirm reflector still mirrors to all tenant + infra-auth namespaces

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0. All references are template variables or `example.com` placeholders. No secrets/tenant data/private registry refs.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0. No new secrets, no new network exposure, same LE Cloudflare DNS-01 issuance flow on two Orders instead of one. TLS coverage of bare apex preserved (moved from wildcard SAN to dedicated apex cert). \`kubectl patch ... finalizers\` is scoped to wildcard-tls-/apex-tls- prefixes in \$NS_MATRIX only. No reflector on apex-tls is intentional (consumed only by matrix-wellknown in NS_MATRIX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)