### PR TITLE
fix(monitoring): wire cert-manager metrics + add ingress-sourced cert expiry alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Cert-expiry alerting was silently dead. The cert-manager `ServiceMonitor`
+  was missing the `release: kube-prometheus-stack` label that
+  kube-prometheus-stack's Prometheus uses to select ServiceMonitors, so
+  `certmanager_certificate_*` metrics were never scraped and the
+  `CertificateExpiringSoon` / `CertificateNotReady` alerts had no input data.
+  The Blackbox HTTPS endpoint probes were also blind: they traverse Cloudflare
+  and measure CF's edge cert (auto-renewed by CF, ~85 days remaining), not our
+  origin Let's Encrypt cert. Added the missing label, plus two new alerts on
+  metrics that are scraped independently of cert-manager:
+  `IngressCertExpiringSoon` (uses `nginx_ingress_controller_ssl_expire_time_seconds`,
+  per-host, sourced from the cert the ingress controller is actually serving)
+  and `CertificateRenewalStuck` (fires 24h after cert-manager's scheduled
+  renewal hasn't happened — catches stuck renewals ~30 days before expiry
+  instead of 7).
+
 ## [0.9.3] - 2026-03-13
 
 ### Added

--- a/apps/values/cert-manager.yaml
+++ b/apps/values/cert-manager.yaml
@@ -17,10 +17,16 @@ cainjector:
     limits:
       memory: 256Mi
 
-# Enable ServiceMonitor for Prometheus metrics (cert expiry alerts)
+# Enable ServiceMonitor for Prometheus metrics (cert expiry alerts).
+# kube-prometheus-stack's Prometheus selects ServiceMonitors with
+# `release: kube-prometheus-stack`. Without this label cert-manager's metrics
+# are silently never scraped — and the `CertificateExpiringSoon` /
+# `CertificateNotReady` alerts never fire because their input metrics don't exist.
 prometheus:
   servicemonitor:
     enabled: true
+    labels:
+      release: kube-prometheus-stack
 
 # Webhook resources
 webhook:

--- a/apps/values/prometheus.yaml
+++ b/apps/values/prometheus.yaml
@@ -398,6 +398,34 @@ additionalPrometheusRulesMap:
             for: 30m
             labels:
               severity: warning
+          # Catches stuck renewals ~30 days before expiry. `renewal_timestamp_seconds`
+          # is when cert-manager scheduled the next renewal; if that time has passed
+          # by more than 24 hours, the renewal hasn't completed. This would have caught
+          # the wildcard-tls deadlock on day 1 instead of day 30 (see fix(tls) Certificate
+          # split, CHANGELOG 2026-05-15).
+          - alert: CertificateRenewalStuck
+            annotations:
+              summary: 'Certificate {{ $labels.namespace }}/{{ $labels.name }} renewal is stuck'
+              description: 'Certificate {{ $labels.name }} in namespace {{ $labels.namespace }} was scheduled to renew at {{ $labels.renewal_time }} but has not — cert-manager renewal has been pending for >24h.'
+            expr: |-
+              (time() - certmanager_certificate_renewal_timestamp_seconds) > 86400
+            for: 1h
+            labels:
+              severity: warning
+          # Per-host cert expiry sourced directly from the cert the ingress controller
+          # is actually serving — independent of cert-manager metrics being scraped.
+          # Defense-in-depth against the failure mode where the cert-manager
+          # ServiceMonitor isn't labeled correctly and metrics go silently missing.
+          # Excludes the `_` default-server entry (nginx-ingress's built-in fake cert).
+          - alert: IngressCertExpiringSoon
+            annotations:
+              summary: 'Ingress cert for {{ $labels.host }} expiring soon'
+              description: 'TLS certificate served by ingress-nginx for host {{ $labels.host }} (secret {{ $labels.secret_name }}) expires in less than 14 days.'
+            expr: |-
+              nginx_ingress_controller_ssl_expire_time_seconds{host!="_"} - time() < 14 * 24 * 3600
+            for: 1h
+            labels:
+              severity: warning
   tenant-app-alerts:
     groups:
       - name: tenant-apps.rules


### PR DESCRIPTION
## Summary

Cert-expiry alerting was silently dead. Investigation triggered by today's prod incident where the wildcard cert renewal had been deadlocked for 30 days and was hours from expiring without any alert firing.

Two root causes:

1. **cert-manager metrics never scraped.** kube-prometheus-stack's Prometheus selects ServiceMonitors with `release: kube-prometheus-stack`. cert-manager's chart-created ServiceMonitor doesn't carry that label, so `certmanager_certificate_*` metrics returned empty. Both existing alerts (`CertificateExpiringSoon`, `CertificateNotReady`) had no input data and never fired.
2. **Blackbox HTTPS probes look at the wrong cert.** Probes traverse Cloudflare and measure CF's edge cert (Google Trust Services, auto-renewed by CF, ~85 days remaining). They never see the origin Let's Encrypt cert.

## Changes

- `apps/values/cert-manager.yaml`: add `prometheus.servicemonitor.labels.release: kube-prometheus-stack` so cert-manager metrics are actually scraped.
- `apps/values/prometheus.yaml`:
  - **`IngressCertExpiringSoon`** — sources per-host expiry from `nginx_ingress_controller_ssl_expire_time_seconds`, which is taken from the cert ingress-nginx is actually serving and is already scraped today. Independent of cert-manager metrics → defense in depth against the same blind spot recurring.
  - **`CertificateRenewalStuck`** — fires 24h after `certmanager_certificate_renewal_timestamp_seconds` has passed. Catches deadlocked renewals ~30 days before expiry instead of 7. (This alert would have fired on day 1 of the incident we just hit.)

Both alerts route through AlertManager's existing `severity: warning` path (Matrix room + email).

## Why not a direct-origin Blackbox probe

Considered, but ingress-nginx already exposes per-host cert expiry from the served cert, which is strictly better: it's the same source of truth (the actual cert nginx is serving), already scraped, covers every ingress host automatically, no DNS/CF/kube-proxy gymnastics required. The Blackbox approach would have added a per-tenant Blackbox module (or hostAliases on the blackbox pod) just to bypass Cloudflare on the request path — and would still only check one representative hostname per cert.

## Test plan

- [ ] After deploy, confirm `kubectl -n infra-monitoring exec <prometheus> -- wget -qO- 'http://localhost:9090/api/v1/query?query=certmanager_certificate_expiration_timestamp_seconds'` returns non-empty
- [ ] Confirm `nginx_ingress_controller_ssl_expire_time_seconds{host!=\"_\"}` returns one series per ingress host (already does today)
- [ ] In Prometheus UI / Alertmanager, confirm `IngressCertExpiringSoon`, `CertificateRenewalStuck`, `CertificateExpiringSoon`, `CertificateNotReady` rules are loaded and not in error state
- [ ] Sanity: temporarily lower one threshold (e.g. 14d → 200d) to verify routing actually fires through to Matrix/email

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0. Helm value + alert rule changes only; no tenant data, secrets, or registry references.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0. Pure observability config. No new network exposure, no new RBAC, no new secrets. Alert rules are read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)