### PR TITLE
fix(nextcloud): include version in install-Job identity Secret (cold-start gap #16)

### DIFF
--- a/apps/manifests/nextcloud/identity-init-configmap.yaml
+++ b/apps/manifests/nextcloud/identity-init-configmap.yaml
@@ -133,6 +133,16 @@ data:
     # The rsync above populates /mnt/html but config/custom_apps/themes are separate subPaths
     # so they won't be populated by the rsync. That's fine — config.php goes to /mnt/config/.
 
+    # Defense-in-depth (cold-start gap #16): if the identity Secret somehow
+    # lacks a version (e.g. an old install Job that predated the version key),
+    # fall back to the image's own version rather than writing
+    # 'version' => '' into config.php — an empty version makes Nextcloud
+    # declare a multi-major DB upgrade and abort `occ upgrade`.
+    if [ -z "${NC_VERSION:-}" ]; then
+        NC_VERSION=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+        echo "NC_VERSION empty — falling back to image version: $NC_VERSION"
+    fi
+
     # Write version.php with the stored version (for upgrade detection by entrypoint)
     # If NC_VERSION matches the image version, entrypoint skips rsync+install (fast boot).
     # If NC_VERSION is older, entrypoint detects upgrade and runs occ upgrade.

--- a/apps/manifests/nextcloud/install-job.yaml.tpl
+++ b/apps/manifests/nextcloud/install-job.yaml.tpl
@@ -108,8 +108,18 @@ spec:
               PASSWORDSALT=$(extract passwordsalt)
               SECRET=$(extract secret)
 
-              if [ -z "$INSTANCEID" ] || [ -z "$PASSWORDSALT" ] || [ -z "$SECRET" ]; then
-                echo "ERROR: failed to extract identity values from config.php"
+              # Read the installed Nextcloud version straight from the image's
+              # version.php. We use the SAME form as deploy-nextcloud.sh step 7b
+              # and the seed-identity init container's IMAGE_VERSION comparison
+              # (implode(".", $OC_Version) — the full array, e.g. 32.0.5.1).
+              # Storing it here means the seed-identity init writes a non-empty
+              # 'version' into config.php on the very first cold boot, so
+              # Nextcloud does not see config.php version '' vs version.php and
+              # wrongly declare a multi-major DB upgrade (cold-start gap #16).
+              NC_VERSION=$(runuser -u www-data -- php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+
+              if [ -z "$INSTANCEID" ] || [ -z "$PASSWORDSALT" ] || [ -z "$SECRET" ] || [ -z "$NC_VERSION" ]; then
+                echo "ERROR: failed to extract identity values from config.php / version.php"
                 exit 1
               fi
               echo "Identity extracted: instanceid=${INSTANCEID:0:6}... (values not logged)"
@@ -134,7 +144,8 @@ spec:
                 "data": {
                   "instanceid":   "$(b64 "$INSTANCEID")",
                   "passwordsalt": "$(b64 "$PASSWORDSALT")",
-                  "secret":       "$(b64 "$SECRET")"
+                  "secret":       "$(b64 "$SECRET")",
+                  "version":      "$(b64 "$NC_VERSION")"
                 }
               }
               EOF


### PR DESCRIPTION
## Summary

Cold-start gap #16: on a fresh (cold) tenant, `deploy-dev-nextcloud` fails with
`Exception: Updates between multiple major versions and downgrades are unsupported` (exit 5).

**Root cause:** the Nextcloud install Job (`install-job.yaml.tpl`) posts the
`nextcloud-identity` Secret with only `instanceid`/`passwordsalt`/`secret` — no
`version` key. The `seed-identity` init container reads `version` from that Secret
and writes `config.php` with `'version' => '${NC_VERSION}'`, which becomes `''`.
On boot Nextcloud sees `version.php` = 32.0.x but `config.php` version = `''` →
declares a multi-major DB upgrade → `occ upgrade` aborts. Only reproduces on a
cold tenant; warm redeploys dodge it because `deploy-nextcloud.sh` step 7b
backfills the `version` key on a later pass.

**Fix A (source fix, `install-job.yaml.tpl`):** read the installed version from
the image's `version.php` using the **same** `implode(".", $OC_Version)` form as
deploy-nextcloud.sh step 7b and the init container's `IMAGE_VERSION` comparison
(the full array, e.g. `32.0.5.1` — using a 3-component slice would mismatch step
7b and churn the Secret / re-trigger the upgrade path), and store it under a new
`version` key in the Secret via the existing `b64()` helper (`base64 -w0`).

**Fix B (defense-in-depth, `identity-init-configmap.yaml`, ~3 lines):** if
`NC_VERSION` is empty when `seed-identity` runs, fall back to the image's own
version before writing `config.php`, so `'version' => ''` can never be written.

Validated locally: both manifests render (`envsubst '${NS_FILES}'`) and parse as
valid YAML (`yq`); both embedded scripts pass `bash -n` / `sh -n`. helmfile lint
does not cover these raw `kubectl apply` manifests, so render + syntax checks are
the applicable validation.

## Stacking

Base branch is **`fix/cold-start-gap-15-finalize-oidc-probe`** (PR #410), NOT
`main`. Gap #16 blocks the `deploy-dev-finalize` step from ever running, and gap
#15 is exactly what finalize needs — the two are mutually blocking for a green
pipeline. Stacking gap #16 on top of gap #15 makes a single pipeline exercise
both fixes. The PR diff is scoped to just the gap #16 changes.

**Merge order:** merge PR #410 (gap #15) to `main` first, then this PR.
(After #410 merges, GitHub will retarget this PR's base to `main` automatically.)

## OSS Compliance Review

> NOTE: This worktree runtime cannot spawn subagents (Task/Agent tools for
> `oss-compliance`/`security-reviewer`/`version-bump` are unavailable here, same
> limitation the gap #15 agent reported). The parent session MUST run the three
> mandatory subagents before merge. Below is a rigorous manual review against
> the rubric.

Manual review of the staged diff (24 insertions, 3 deletions, 2 files):
no real tenant domains, no PII/emails, no hardcoded credentials, no private
registry references. The only image (`nextcloud:32.0.5-apache`) is a public
Docker Hub image and pre-existed this change. **CLEAN.**

## Security Review

> Same subagent limitation as above — manual review against the rubric.

- No new secret material is logged. `NC_VERSION` (e.g. `32.0.5.1`) is
  non-sensitive; the existing code already echoes a truncated instanceid.
- Version is base64-encoded into the Secret via the existing `b64()` helper
  (`base64 -w0`) — the repo's gap-#11 newline-injection footgun is avoided.
- Fail-fast guard extended to cover `$NC_VERSION` (loud `exit 1` if extraction
  fails), consistent with CLAUDE.md "Fail Fast — Never Silently Skip".
- Fix B's fallback uses only the image's own `version.php` — no external input,
  no injection surface (static `php -r` script, value flows through the existing
  shell→JSON pattern). **CLEAN.**

`version-bump`: no portal code touched (`apps/admin-portal/`,
`apps/account-portal/`) → **no-op** (expected, noted).

## Test plan

- [ ] CI cold-start pipeline: `deploy-dev-nextcloud` completes (no exit 5 / multi-major error)
- [ ] `deploy-dev-finalize` / `create-test-users` runs (was previously blocked by gap #16)
- [ ] 10 e2e shards green
- [ ] gate (`mothertree-build`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)