### PR TITLE
fix(stalwart): kill cold-start delivery latency at the data-path root

### DIFF
--- a/apps/manifests/stalwart/stalwart.yaml.tpl
+++ b/apps/manifests/stalwart/stalwart.yaml.tpl
@@ -199,6 +199,26 @@ data:
     #   Dev (no SES): direct MX delivery to the destination's mail servers.
     [queue.strategy]
     route = [{if = "is_local_domain('', rcpt_domain)", then = "'local'"}, {else = "'${STALWART_OUTBOUND_ROUTE_NAME}'"}]
+    # Retry-schedule selector — local-domain delivery uses the aggressive
+    # cold-start schedule below; everything else uses the standard one.
+    schedule = [{if = "is_local_domain('', rcpt_domain)", then = "'local'"}, {else = "'remote'"}]
+
+    # Cold-start delivery-latency fix: on a fresh pod the first local delivery
+    # can lose its inline attempt to a cold S3 PUT / cold PG+FTS write,
+    # deferring the message to the queue. With no explicit schedule Stalwart's
+    # first retry is ~2m, so a deferred magic-link/invite email overshoots the
+    # e2e 180s budget (and real users wait ~2m). Front-load short retries for
+    # the local (intra-platform, transactional) path so a deferred message is
+    # redelivered in ~10-30s, then back off normally.
+    [queue.schedule.local]
+    retry = ["10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h"]
+    notify = ["1d", "3d"]
+
+    # Standard schedule for outbound/relayed mail — documented Stalwart
+    # interval set; unchanged behaviour for non-local recipients.
+    [queue.schedule.remote]
+    retry = ["2m", "5m", "10m", "15m", "30m", "1h", "2h"]
+    notify = ["1d", "3d"]
 
     # Local delivery route - deliver to internal mailbox
     [queue.route."local"]
@@ -284,7 +304,7 @@ ${STALWART_OUTBOUND_ROUTE_TOML}
                   "server.*", "authentication.fallback-admin.*", "authentication.master.*",
                   "cluster.*", "config.local-keys.*", "storage.data", "storage.blob",
                   "storage.lookup", "storage.fts", "storage.directory", "certificate.*",
-                  "session.rcpt.*", "queue.strategy.*", "queue.route.*", "queue.limiter.*", "oauth.*",
+                  "session.rcpt.*", "queue.strategy.*", "queue.route.*", "queue.schedule.*", "queue.limiter.*", "oauth.*",
                   "spam.*", "spam-filter.list.*",
                   "auth.iprev.*", "auth.spf.*", "auth.dkim.*", "auth.dmarc.*"]
 

--- a/ci/scripts/ci-deploy-app.sh
+++ b/ci/scripts/ci-deploy-app.sh
@@ -271,6 +271,9 @@ case "$MODE" in
         echo "FATAL: cold-start gate #19 — Stalwart SMTP submission connect/AUTH not usable"
         exit 1
       fi
+      # Warm the cold S3/PG/FTS/spam delivery path on a throwaway deploy message
+      # so the first real magic-link/invite is fast (non-fatal, telemetry only).
+      mt_warm_stalwart_delivery || true
     else
       echo "Stalwart: skipping (mail_enabled is not true)"
     fi

--- a/scripts/create_env
+++ b/scripts/create_env
@@ -617,6 +617,9 @@ if [ "$MAIL_ENABLED" = "true" ]; then
     print_error "Cold-start gate #19 failed: Stalwart SMTP submission connect/AUTH not usable"
     exit 1
   fi
+  # Warm the cold S3/PG/FTS/spam delivery path on a throwaway deploy message
+  # so the first real magic-link/invite is fast (non-fatal, telemetry only).
+  mt_warm_stalwart_delivery || true
 fi
 
 # Deploy Collabora CODE (per-tenant office suite for in-browser document editing)

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -560,6 +560,142 @@ sys.exit(1)
     return 1
 }
 
+# Deploy-time Stalwart delivery warm-up + per-deploy delivery-latency telemetry.
+#
+# PURPOSE: Gate #19 above proves the *submission* path (connect+STARTTLS+AUTH)
+# is usable, but it stops at NOOP — it never actually delivers a message. The
+# FIRST real local delivery on a fresh/just-restarted Stalwart pays a stack of
+# cold-path costs all at once: the cold S3 PUT (blob store), the cold PG +
+# full-text-search index write, and the spam-filter (SpamAssassin/Stalwart
+# sieve) warm-up. If that first message is a user-facing magic-link/invite, the
+# user waits seconds for their email. This function sends ONE authenticated
+# warm-up message mailer@ -> mailer@ through the local-delivery path and reads
+# it back, so all of those cold writes happen on a throwaway *deploy* message
+# instead — making the first real user message fast. The warm-up message is
+# marked \Deleted and EXPUNGEd, so it never lingers in the mailbox. It also
+# emits per-deploy delivery-latency telemetry (elapsed seconds from sendmail to
+# IMAP-visible) into the deploy log.
+#
+# NON-FATAL BY DESIGN: gate #19 (mt_wait_for_stalwart_submission) is the single
+# fatal submission guard for the deploy. This warm-up is purely an optimization
+# + telemetry probe layered on top of it; making it fail-closed would
+# reintroduce exactly the fail-closed fragility the cold-start work has been
+# burning down (a slow-but-eventually-fine first delivery must not abort a
+# deploy). The bash function therefore ALWAYS returns 0; outcome is surfaced
+# only via print_success / print_warning. The embedded Python likewise always
+# exit(0) and prints a single MT_WARM_{OK,TIMEOUT,ERROR} sentinel line.
+#
+# Required env: KUBECONFIG, NS_AUTH, SMTP_RELAY_HOST, SMTP_RELAY_USERNAME,
+#               SMTP_RELAY_PASSWORD (export via
+#               scripts/lib/smtp-credentials.sh :: mt_export_smtp_relay_env).
+# Optional env: SMTP_RELAY_PORT (default 588), MT_WARM_DEADLINE (default 180s).
+mt_warm_stalwart_delivery() {
+    : "${KUBECONFIG:?mt_warm_stalwart_delivery: KUBECONFIG must be set}"
+    : "${NS_AUTH:?mt_warm_stalwart_delivery: NS_AUTH must be set}"
+    : "${SMTP_RELAY_HOST:?mt_warm_stalwart_delivery: SMTP_RELAY_HOST must be set (run mt_export_smtp_relay_env first)}"
+    : "${SMTP_RELAY_USERNAME:?mt_warm_stalwart_delivery: SMTP_RELAY_USERNAME must be set}"
+    : "${SMTP_RELAY_PASSWORD:?mt_warm_stalwart_delivery: SMTP_RELAY_PASSWORD must be set}"
+    local port="${SMTP_RELAY_PORT:-588}"
+    local deadline="${MT_WARM_DEADLINE:-180}"
+
+    print_status "Stalwart delivery warm-up: priming cold S3/PG/FTS/spam via one mailer@→mailer@ message"
+    print_status "  from NS_AUTH=${NS_AUTH} → submit ${SMTP_RELAY_HOST}:${port}, read-back IMAPS 993 (as ${SMTP_RELAY_USERNAME}), deadline ${deadline}s"
+
+    # Single ephemeral probe pod. Password is fed via stdin so it never lands
+    # in the Pod spec, argv, or CI logs. Host/port/user are non-secret env.
+    local py
+    py='
+import os,sys,ssl,time,smtplib,imaplib,random
+host=os.environ["PHOST"]; port=int(os.environ["PPORT"])
+user=os.environ["PUSER"]
+deadline=float(os.environ["PDEADLINE"])
+pw=sys.stdin.readline().rstrip("\n")
+# Unverified TLS context: mirror gate #19 / Keycloak lenient STARTTLS. Cert
+# validity is a separate gap with its own gate — do not couple to cert-manager.
+ctx=ssl._create_unverified_context()
+token="MT-WARMUP-%d-%d"%(int(time.time()),random.randint(100000,999999))
+try:
+    msg=("From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n%s\r\n"
+         %(user,user,token,"Deploy-time Stalwart delivery warm-up "+token))
+    s=smtplib.SMTP(host,port,timeout=20)
+    s.ehlo(); s.starttls(context=ctx); s.ehlo()
+    s.login(user,pw)
+    t0=time.time()
+    s.sendmail(user,[user],msg.encode("utf-8"))
+    s.quit()
+    M=imaplib.IMAP4_SSL(host,993,ssl_context=ctx)
+    M.login(user,pw)
+    end=t0+deadline
+    found=[]
+    while time.time()<end:
+        M.select("INBOX")
+        ids=set()
+        for crit in (["BODY",token],["SUBJECT",token]):
+            try:
+                typ,data=M.search(None,*crit)
+                if typ=="OK" and data and data[0]:
+                    ids.update(data[0].split())
+            except Exception:
+                pass
+        if ids:
+            found=sorted(ids)
+            break
+        time.sleep(5)
+    elapsed=int(round(time.time()-t0))
+    if found:
+        for i in found:
+            M.store(i,"+FLAGS",r"(\Deleted)")
+        M.expunge()
+        try: M.logout()
+        except Exception: pass
+        print("MT_WARM_OK elapsed=%ds"%elapsed)
+        sys.exit(0)
+    try: M.logout()
+    except Exception: pass
+    print("MT_WARM_TIMEOUT elapsed=%ds"%elapsed)
+    sys.exit(0)
+except Exception as e:
+    print("MT_WARM_ERROR %s: %s"%(type(e).__name__,str(e)))
+    sys.exit(0)
+'
+    local pod="stalwart-warmup-$$-${RANDOM}"
+    local out
+    out=$(mktemp)
+    # shellcheck disable=SC2064
+    trap "kubectl --kubeconfig='$KUBECONFIG' -n '$NS_AUTH' delete pod '$pod' --ignore-not-found --force --grace-period=0 >/dev/null 2>&1; rm -f '$out'" RETURN
+
+    local rc=0
+    printf '%s' "$SMTP_RELAY_PASSWORD" | kubectl --kubeconfig="$KUBECONFIG" \
+        run "$pod" -i --rm --restart=Never \
+        --image=python:3.13-alpine \
+        -n "$NS_AUTH" \
+        --env "PHOST=${SMTP_RELAY_HOST}" \
+        --env "PPORT=${port}" \
+        --env "PUSER=${SMTP_RELAY_USERNAME}" \
+        --env "PDEADLINE=${deadline}" \
+        --command -- python3 -c "$py" >"$out" 2>&1 || rc=$?
+
+    # Surface the warm-up output in the deploy log (contains no secrets).
+    sed 's/^/    [warm] /' "$out" || true
+
+    local line
+    line=$(grep -m1 -E 'MT_WARM_(OK|TIMEOUT|ERROR)' "$out" 2>/dev/null || true)
+    if printf '%s' "$line" | grep -q 'MT_WARM_OK'; then
+        local n
+        n=$(printf '%s' "$line" | sed -n 's/.*elapsed=\([0-9]*\)s.*/\1/p')
+        print_success "Stalwart delivery warm-up OK (cold-path delivered in ${n:-?}s)"
+    elif printf '%s' "$line" | grep -q 'MT_WARM_TIMEOUT'; then
+        local n
+        n=$(printf '%s' "$line" | sed -n 's/.*elapsed=\([0-9]*\)s.*/\1/p')
+        print_warning "Stalwart delivery warm-up did not confirm within ${deadline}s (telemetry only, non-fatal): not IMAP-visible after ${n:-?}s"
+    elif printf '%s' "$line" | grep -q 'MT_WARM_ERROR'; then
+        print_warning "Stalwart delivery warm-up did not confirm within ${deadline}s (telemetry only, non-fatal): ${line#MT_WARM_ERROR }"
+    else
+        print_warning "Stalwart delivery warm-up did not confirm within ${deadline}s (telemetry only, non-fatal): no warm-up sentinel in pod output (rc=$rc)"
+    fi
+    return 0
+}
+
 # Wait for admin-portal's /version endpoint to return 200.
 # Lightest sanity check that the full ingress + portal + version-injection
 # chain is up. Use as a final "everything's up" assertion.


### PR DESCRIPTION
## Why

After #417 (send-retry + IMAP backoff + honest readiness), CI shard-6 was *flaky*-green: a background root-cause investigation pinned the **residual** dominant flake as cold-start **delivery latency**. Keycloak *sends* fine, but the first local delivery on a fresh Stalwart pod takes **100–180s+** because:
- the inline delivery attempt hits a **cold S3 PUT** + **cold PG/FTS write** (both required for local delivery), and
- if the inline attempt loses to a cold timeout, the message is **deferred to the queue**, whose default first retry is ~2m — overshooting the e2e 180s budget (and making real users wait ~2m).

Greylisting/SPF/Postfix were **ruled out** (not in this authenticated-submission path).

## Fixes (both safe — no spam/auth/deliverability weakening)

**1. `apps/manifests/stalwart/stalwart.yaml.tpl` — front-load the local retry schedule.**
Add `[queue.schedule.local]` with `retry = ["10s","30s","1m",...]` selected for the local (intra-platform, transactional) path via a `schedule = [...]` selector that **byte-for-byte mirrors the existing, proven-working `route =` expression** directly above it. `[queue.schedule.remote]` keeps documented-standard intervals (`2m,5m,...`) so outbound behaviour is unchanged. `queue.schedule.*` added to `[config].local-keys`. The v0.15 TOML schema (`queue.schedule.<id>.retry` as a duration-string list, `schedule` selector evaluated like `route`) was verified against Stalwart docs. Caps the **~180s deferred mode** to ~10–30s.

**2. `scripts/lib/common.sh` — new NON-FATAL `mt_warm_stalwart_delivery`.**
After gate #19, an ephemeral pod (mirrors gate #19's structure) sends `mailer@→mailer@` through :588 and reads it back via :993 (then deletes it), forcing the cold S3/PG/FTS/spam work onto a *deploy* message so the first real magic-link/invite hits warm paths — attacks the **~103s inline mode** and every cold-first-message flavor. **Always returns `0`** (gate #19 remains the fatal submission guard — no new fail-closed path; avoids reintroducing the fragility this whole effort has been escaping) and logs **per-deploy delivery-latency telemetry**. Wired after the gate #19 call in both `ci-deploy-app.sh` (CI/dev path) and `create_env` (prod/monolithic path).

Layered with #417: that PR fixed send/connection/readiness; this attacks the delivery-latency residual.

## Validation
`bash -n` clean (common.sh, ci-deploy-app.sh, create_env); embedded Python `py_compile` OK; function defined; `queue.schedule` schema verified vs Stalwart v0.15 docs and structurally identical to the working `route=` precedent. End-to-end validation = the next cold-start pipelines (the warm-up also emits real delivery-latency numbers per deploy, so we'll *measure* whether the fix works rather than infer).

## OSS Compliance Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0** — clean. Password via stdin only (never argv/env/podspec/logs); no domains/PII/tenant/registry refs; public `python:3.13-alpine`.

## Security Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 2**
- `queue.schedule` TOML **schema-correct and prod-safe** — selector is a byte-for-byte mirror of the proven `route=` line; both `local`/`remote` schedules defined unconditionally (selector can't resolve to a missing strategy); `local-keys` correctly extended.
- `mt_warm_stalwart_delivery`: triple-layered non-fatal (Python `sys.exit(0)` all branches, bash `return 0`, `|| true` call sites); password stdin-only; randomized warm-up message `\Deleted`+`EXPUNGE`d; robust pod cleanup (`--rm` + RETURN trap); bounded (socket timeouts + 180s poll) — no deadlock.
- LOW (awareness, consistent with already-merged gate #19): unpinned `python:3.13-alpine` minor tag (ephemeral throwaway pod); unverified TLS (justified — mirrors gate #19 / Keycloak lenient STARTTLS; in-cluster traffic).

## Version Bump
No-op — manifest/deploy/CI/lib only; no `apps/admin-portal` or `apps/account-portal` runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)