### PR TITLE
fix(e2e): gate external IMAPS cold-start readiness + robust connect budget

### DIFF
--- a/.woodpecker/deploy-dev-finalize.yaml
+++ b/.woodpecker/deploy-dev-finalize.yaml
@@ -122,3 +122,60 @@ steps:
         from_secret: e2e_pool2_base_domain
     commands:
       - ci/scripts/ci-deploy-app.sh dev remint-caldav-tokens
+
+  # Cold-start gap #20: FATAL gate for the EXTERNAL IMAPS path the e2e tests
+  # use. Pinned root cause (controlled experiment): a cold Stalwart delivers
+  # mail in ~48ms — there is NO data-path latency. The e2e symptom
+  # `[imap] Delivery SLOW: ~110s after 1 poll(s)` is 100% the e2e IMAP client
+  # (CI box → external IMAPS endpoint) being unable to ESTABLISH a session for
+  # ~110s on cold-start (NodeBalancer/:993/cert convergence); once connected
+  # the message is instantly present.
+  #
+  # Gate #19 guards the in-cluster Keycloak→Stalwart :588 SMTP path; nothing
+  # guarded the external :993 IMAPS path the e2e shards connect to, and on a
+  # main-push it was unguarded entirely. This step polls that external path
+  # from the CI box (the literal path e2e/helpers/imap.ts takes) and converts
+  # the silent in-shard 110s stall into an explicit, loud pre-e2e wait that
+  # self-heals once the edge converges.
+  #
+  # Wired AFTER remint-caldav-tokens so the e2e-mailrt user already exists;
+  # the gate authenticates as that exact user (the calendar-external-invite
+  # shards use it). Like create-test-users/remint-caldav-tokens this has NO
+  # step-level `when:` override — it inherits the workflow-level
+  # `pull_request | push:main` so it runs for EVERY pipeline (gap-#18 lesson:
+  # the deploy steps are PR-only no-ops but these provisioning/gate steps are
+  # not; e2e shards run on the main-push pipeline too and gate deploy-prod).
+  - name: imaps-readiness
+    image: bash
+    environment:
+      CI: "true"
+      CI_VALKEY_PASSWORD:
+        from_secret: ci_valkey_password
+      DEPLOY_VAULT_PASSWORD:
+        from_secret: deploy_vault_password
+      GITHUB_PAT:
+        from_secret: github_pat
+      LINODE_CLI_TOKEN:
+        from_secret: linode_token
+      E2E_POOL1_TENANT:
+        from_secret: e2e_pool1_tenant
+      E2E_POOL2_TENANT:
+        from_secret: e2e_pool2_tenant
+      E2E_POOL1_BASE_DOMAIN:
+        from_secret: e2e_pool1_base_domain
+      E2E_POOL2_BASE_DOMAIN:
+        from_secret: e2e_pool2_base_domain
+      E2E_POOL1_STALWART_ADMIN_PASSWORD:
+        from_secret: e2e_pool1_stalwart_admin_password
+      E2E_POOL1_STALWART_IMAP_HOST:
+        from_secret: e2e_pool1_stalwart_imap_host
+      E2E_POOL1_STALWART_IMAP_PORT:
+        from_secret: e2e_pool1_stalwart_imap_port
+      E2E_POOL2_STALWART_ADMIN_PASSWORD:
+        from_secret: e2e_pool2_stalwart_admin_password
+      E2E_POOL2_STALWART_IMAP_HOST:
+        from_secret: e2e_pool2_stalwart_imap_host
+      E2E_POOL2_STALWART_IMAP_PORT:
+        from_secret: e2e_pool2_stalwart_imap_port
+    commands:
+      - ci/scripts/ci-deploy-app.sh dev imaps-readiness

--- a/ci/scripts/ci-deploy-app.sh
+++ b/ci/scripts/ci-deploy-app.sh
@@ -25,6 +25,9 @@ set -euo pipefail
 #                          (cold-start gap #17: run AFTER create-test-users so
 #                           late-created e2e users get tokens; calendar-automation
 #                           only reads the Secret at startup)
+#   imaps-readiness — FATAL gate: prove an authenticated IMAPS session to the
+#                          EXTERNAL Stalwart endpoint the e2e tests use is
+#                          establishable before e2e runs (cold-start gap #20)
 #
 # Required environment variables:
 #   DEPLOY_VAULT_PASSWORD — Ansible Vault password
@@ -432,9 +435,145 @@ case "$MODE" in
     fi
     ;;
 
+  imaps-readiness)
+    # Cold-start gap #20 — FATAL gate for the EXTERNAL IMAPS path the e2e
+    # tests use.
+    #
+    # Pinned root cause (controlled experiment): a cold Stalwart delivers
+    # mail in ~48ms — there is NO data-path latency. The e2e symptom
+    # `[imap] Delivery SLOW: ~110s after 1 poll(s)` is 100% the e2e IMAP
+    # client (CI box → external IMAPS endpoint) being unable to ESTABLISH a
+    # session for ~110s on cold-start (NodeBalancer / :993 / cert
+    # convergence); once connected the message is instantly present
+    # (`1 matched` on poll #1).
+    #
+    # Cold-start gate #19 (mt_wait_for_stalwart_submission) guards the
+    # in-cluster Keycloak→Stalwart :588 SMTP-submission path, but NOTHING
+    # guards the external IMAPS :993 path the e2e shards actually connect to,
+    # and on a main-push that path is unguarded entirely. This step converts
+    # the silent in-shard 110s stall into an explicit, loud, attributed
+    # pre-e2e wait that self-heals (the connect just needs the external edge
+    # to converge).
+    #
+    # Mirrors gate #19's bounded-poll + fail-closed + clear-logging style,
+    # but runs FROM THE CI BOX against the external IMAPS endpoint
+    # (E2E_STALWART_IMAP_HOST:E2E_STALWART_IMAP_PORT) — exactly the path the
+    # e2e/helpers/imap.ts client takes — NOT from an in-cluster pod (that
+    # would take the internal ClusterIP path and false-green).
+    #
+    # Lives here (a finalize-sibling that runs on BOTH pull_request and
+    # push:main, like create-test-users/remint-caldav-tokens — gap-#18
+    # lesson) and is wired AFTER remint-caldav-tokens so the e2e-mailrt user
+    # already exists; we authenticate as that exact user (the one the
+    # calendar-external-invite shards use) so the gate exercises the literal
+    # path under test.
+    echo "=== Cold-start gate #20: external IMAPS session readiness ==="
+    source "$REPO_ROOT/scripts/lib/config.sh"
+    mt_load_tenant_config
+
+    if [ "${MAIL_ENABLED:-false}" != "true" ]; then
+      echo "Mail not enabled for tenant $E2E_TENANT — no external IMAPS path to gate"
+      echo "=== CI Deploy App complete: env=$MT_ENV mode=$MODE ==="
+      exit 0
+    fi
+
+    # ci-resolve-tenant.sh (sourced above) already mapped the leased pool's
+    # E2E_STALWART_IMAP_HOST / E2E_STALWART_IMAP_PORT / E2E_STALWART_ADMIN_PASSWORD
+    # to their standard names — the same vars e2e/helpers/imap.ts reads.
+    : "${E2E_STALWART_IMAP_HOST:?FATAL: E2E_STALWART_IMAP_HOST required (pool secret e2e_poolN_stalwart_imap_host)}"
+    : "${E2E_STALWART_IMAP_PORT:?FATAL: E2E_STALWART_IMAP_PORT required (pool secret e2e_poolN_stalwart_imap_port)}"
+    : "${E2E_STALWART_ADMIN_PASSWORD:?FATAL: E2E_STALWART_ADMIN_PASSWORD required (pool secret e2e_poolN_stalwart_admin_password)}"
+    : "${E2E_BASE_DOMAIN:?FATAL: E2E_BASE_DOMAIN required to build the e2e-mailrt master username}"
+
+    # Master-user auth username form, copied EXACTLY from
+    # e2e/helpers/imap.ts :: connectAsMaster: it tries "<localpart>%master"
+    # first (and "<email>%master" as a fallback). e2e-mailrt is the fixed
+    # mail-roundtrip user created by ci-create-test-users.sh as
+    # e2e-mailrt@${E2E_BASE_DOMAIN}; the calendar-external-invite shards
+    # authenticate as exactly this principal.
+    MASTER_USER="e2e-mailrt"
+    MASTER_USER_EMAIL="e2e-mailrt@${E2E_BASE_DOMAIN}"
+
+    GATE_DEADLINE="${MT_IMAPS_GATE_DEADLINE:-240}"
+    echo "Cold-start gate #20: verifying authenticated IMAPS session"
+    echo "  from CI box → ${E2E_STALWART_IMAP_HOST}:${E2E_STALWART_IMAP_PORT}"
+    echo "  (TLS connect + LOGIN as ${MASTER_USER}%master + SELECT INBOX + LOGOUT), deadline ${GATE_DEADLINE}s"
+
+    # Dependency-light: python3 stdlib imaplib (no npm ci needed here — this
+    # workflow may not have run it; sibling CI scripts already shell out to
+    # python3 the same way). Password is fed via STDIN, never argv/env, so it
+    # is not visible in the process list or /proc/<pid>/environ (mirrors
+    # gate #19 in scripts/lib/common.sh). Host/port/user are non-secret env.
+    _imaps_py='
+import os, sys, ssl, time, imaplib
+host = os.environ["IHOST"]
+port = int(os.environ["IPORT"])
+ulocal = os.environ["IUSER_LOCAL"]
+uemail = os.environ["IUSER_EMAIL"]
+deadline = time.time() + float(os.environ["IDEADLINE"])
+pw = sys.stdin.readline().rstrip("\n")
+# Dev/CI uses self-signed certs; mirror imap.ts rejectUnauthorized:false.
+# Cert validity is a separate gap with its own gate — do not couple this
+# connect-readiness probe to cert-manager convergence.
+ctx = ssl._create_unverified_context()
+# Same candidate order as e2e/helpers/imap.ts connectAsMaster
+# (candidates = [userEmail, username]): full email first, then localpart,
+# each as "<name>%master".
+candidates = [uemail + "%master", ulocal + "%master"]
+attempt = 0
+last = "(no attempt)"
+while time.time() < deadline:
+    attempt += 1
+    for cand in candidates:
+        M = None
+        try:
+            M = imaplib.IMAP4_SSL(host, port, ssl_context=ctx, timeout=15)
+            M.login(cand, pw)
+            typ, _ = M.select("INBOX")
+            if typ != "OK":
+                raise RuntimeError("SELECT INBOX returned %s" % typ)
+            M.logout()
+            print("STALWART_IMAPS_PROBE_OK attempt=%d %s:%d LOGIN=%s"
+                  % (attempt, host, port, cand))
+            sys.exit(0)
+        except Exception as e:
+            last = "%s as %s: %s" % (type(e).__name__, cand, e)
+            try:
+                if M is not None:
+                    M.logout()
+            except Exception:
+                pass
+    print("  attempt %d IMAPS session not ready yet: %s" % (attempt, last),
+          flush=True)
+    time.sleep(10)
+print("STALWART_IMAPS_PROBE_FAIL last_error: %s" % last)
+sys.exit(1)
+'
+    _gate_rc=0
+    printf '%s' "$E2E_STALWART_ADMIN_PASSWORD" | \
+      IHOST="$E2E_STALWART_IMAP_HOST" \
+      IPORT="$E2E_STALWART_IMAP_PORT" \
+      IUSER_LOCAL="$MASTER_USER" \
+      IUSER_EMAIL="$MASTER_USER_EMAIL" \
+      IDEADLINE="$GATE_DEADLINE" \
+      python3 -c "$_imaps_py" || _gate_rc=$?
+
+    if [ "$_gate_rc" -ne 0 ]; then
+      echo "FATAL: cold-start gate #20 — external IMAPS session to" \
+           "${E2E_STALWART_IMAP_HOST}:${E2E_STALWART_IMAP_PORT} not establishable" \
+           "within ${GATE_DEADLINE}s as ${MASTER_USER}%master."
+      echo "       This is the external edge (NodeBalancer/:993/cert) NOT having"
+      echo "       converged — it is the exact ~110s cold-connect stall the e2e"
+      echo "       calendar-external-invite shards would otherwise hit silently."
+      echo "       Failing the build loudly (hard gate; never silently skipped)."
+      exit 1
+    fi
+    echo "OK: external IMAPS session to ${E2E_STALWART_IMAP_HOST}:${E2E_STALWART_IMAP_PORT} is usable"
+    ;;
+
   *)
     echo "ERROR: Unknown mode: $MODE"
-    echo "Valid modes: prep, finalize, matrix, nextcloud, jitsi, stalwart, roundcube, calendar, email-probe, portals, remint-caldav-tokens"
+    echo "Valid modes: prep, finalize, matrix, nextcloud, jitsi, stalwart, roundcube, calendar, email-probe, portals, remint-caldav-tokens, imaps-readiness"
     exit 1
     ;;
 esac

--- a/e2e/helpers/imap.ts
+++ b/e2e/helpers/imap.ts
@@ -64,8 +64,10 @@ function createClient(authUser: string, config: ImapConfig): typeof ImapFlow {
  * Some principals use "user@domain" as name, others use just "user".
  * We try email first, then fall back to short username.
  *
- * Retries the full candidate list up to 3 times with a delay to handle
- * transient connection issues (common when connecting via external ingress).
+ * Retries the full candidate list with capped-exponential backoff (~180s
+ * sleep-only budget) to ride out the cold-start external IMAPS connect
+ * window. The FATAL pre-e2e cold-start gate #20 is the primary guard; this
+ * is the fallback (see connectAsMaster body for the pinned root cause).
  */
 async function connectAsMaster(
   userEmail: string,
@@ -73,7 +75,17 @@ async function connectAsMaster(
 ): Promise<typeof ImapFlow> {
   const username = userEmail.split('@')[0];
   const candidates = [userEmail, username];
-  const maxAttempts = 5;
+  // Belt-and-suspenders FALLBACK for the pinned root cause: on cold-start the
+  // external IMAPS edge (CI box → NodeBalancer/:993/cert) can take ~110s to
+  // accept a session, even though a cold Stalwart delivers mail in ~48ms (no
+  // data-path latency). The PRIMARY guard is the FATAL pre-e2e cold-start
+  // gate #20 (ci/scripts/ci-deploy-app.sh imaps-readiness); this connect-retry
+  // budget is the fallback so a cold window can't fail a shard if the gate is
+  // bypassed. Sleep-only budget = 2+4+8+16+30*5 = 180s (comfortably exceeds
+  // the observed ~110s cold-connect window); the per-attempt connect/greet
+  // timeouts add further wall-clock on top. Still bounded — the final
+  // descriptive throw fires on exhaustion so a real outage fails loudly.
+  const maxAttempts = 10;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     for (const name of candidates) {
@@ -104,9 +116,13 @@ async function connectAsMaster(
     }
 
     if (attempt < maxAttempts) {
-      // Exponential backoff: 2s, 4s, 8s, 16s (bounded — final descriptive
-      // throw still fires on exhaustion so a real outage fails loudly).
-      await new Promise((r) => setTimeout(r, 2_000 * 2 ** (attempt - 1)));
+      // Exponential backoff capped at 30s: 2s, 4s, 8s, 16s, then 30s each
+      // (9 sleeps total = 180s sleep-only budget — exceeds the observed
+      // ~110s external IMAPS cold-connect window). Bounded: the final
+      // descriptive throw still fires on exhaustion so a real outage fails
+      // loudly rather than hanging.
+      const backoffMs = Math.min(2_000 * 2 ** (attempt - 1), 30_000);
+      await new Promise((r) => setTimeout(r, backoffMs));
     }
   }
 


### PR DESCRIPTION
## The pinned root cause (this closes the arc)

A **controlled experiment** (Stalwart `level=trace`, restart→cold, one `mailer@→mailer@` submission) proved a cold Stalwart delivers mail in **~48ms** — S3 blob PUT + PG/FTS included. **There is no cold data-path delivery latency.** The recurring `[imap] Delivery SLOW: ~110s after 1 poll(s)` on shard-6/shard-4 is — definitively, from a real pipeline's logs — **the e2e IMAP client (CI box → external IMAPS endpoint) unable to ESTABLISH a session for ~110s on cold-start** (NodeBalancer / :993 listener / cert convergence). Once connected, the message is *instantly* present (`1 matched` on poll #1).

This refuted both the research agent's data-path theory **and** PR #418 (now **closed**). Gate #19 guards the in-cluster `:588` SMTP path; **nothing guarded the external `:993` IMAPS path the shards actually use**, and on main-push it was unguarded entirely — so e2e silently absorbed the ~110s edge-convergence, masked by Playwright retry (flaky-green).

> "Pin it first" paid for itself twice over: one 48ms trace overturned a research theory *and* a built, reviewed PR.

## Fixes

**FIX 1 (primary) — FATAL external-IMAPS-readiness gate.** New `imaps-readiness` step in `.woodpecker/deploy-dev-finalize.yaml`, placed after `remint-caldav-tokens` with **no step-level `when:`** so it inherits `pull_request | push:main` (the gap-#18 lesson — it runs on the prod-gating main-push path too, where everything else mail-related was a no-op). It polls the **external** IMAPS endpoint *from the CI box* (the literal path `e2e/helpers/imap.ts` takes): TLS connect + `LOGIN` as `e2e-mailrt%master` + `SELECT INBOX` + `LOGOUT`; bounded **240s** (env-overridable `MT_IMAPS_GATE_DEADLINE`), 10s interval; `exit 1` + loud attribution on deadline. Converts the silent in-shard 110s stall into an explicit, self-healing, correctly-attributed pre-e2e wait. Password via **stdin** (gate #19 pattern), never argv/env. Skips when `mail_enabled != true`.

**FIX 2 (fallback) — robust connect budget.** `e2e/helpers/imap.ts` `connectAsMaster`: `maxAttempts` 5→10, backoff capped 30s (~180s sleep budget > observed ~110s cold window), final descriptive throw retained. Robust even if the gate is bypassed; `waitForEmailBody` poll/timeout semantics (#417) untouched.

## Validation
`bash -n` clean; embedded python `py_compile` OK; `e2e tsc --noEmit` **zero new errors** (238-baseline is pre-existing missing-@types/node noise); new Woodpecker step parses, step order + inherited `when:` verified to match `create-test-users`/`remint-caldav-tokens`. The gate's own per-deploy log will *measure* the real external-IMAPS cold-convergence time on every pipeline.

## OSS Compliance Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0** — clean. Password stdin-only; host/domain/tenant all `from_secret`/runtime-resolved; no real values, PII, or private-registry refs; secret wiring mirrors sibling steps.

## Security Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 1 | LOW: 0**
- MEDIUM (non-blocking, documented in-code & commit): the IMAPS probe uses an unverified TLS context, **deliberately mirroring `e2e/helpers/imap.ts` (`rejectUnauthorized:false`)** for the dev self-signed-cert env. Gate is **dev-only** (`ci-deploy-app.sh dev imaps-readiness`). Must NOT be copied into a prod gate without re-enabling verification — flagged for reader visibility.
- Confirmed: credentials stdin-only (not argv/env/process-list, gate-#19 pattern); FATAL gate correctly bounded (240s hard deadline, 15s per-attempt, `exit 1`, no infinite loop, skips mail-disabled so it can't false-fail every deploy); imap.ts retry bounded (no hang); new dispatch case purely additive, default still fails closed.
- Informational: the `e2e_pool{1,2}_stalwart_imap_host/_port/_stalwart_admin_password` secrets the step needs **already exist** (used by `e2e-shard-*.yaml` today — the wiring was copied from there), so no provisioning prerequisite.

## Version Bump
No-op — CI pipeline + e2e test harness only; no portal runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)