### PR TITLE
chore(ci): upgrade Woodpecker 3.13.0 → 3.14.1 + fix restart gap on version bump

### DIFF
--- a/ci/ansible/playbook.yml
+++ b/ci/ansible/playbook.yml
@@ -17,8 +17,8 @@
     - "{{ vars_file | default('ansible-vars.yml') }}"
 
   vars:
-    woodpecker_version: "{{ woodpecker_version_override | default('3.13.0') }}"
-    plugin_git_version: "{{ plugin_git_version_override | default('2.8.1') }}"
+    woodpecker_version: "{{ woodpecker_version_override | default('3.14.1') }}"
+    plugin_git_version: "{{ plugin_git_version_override | default('2.9.1') }}"
     # Path to tenant config submodule (relative to playbook)
     _tenants_dir: "{{ playbook_dir }}/../../config/tenants"
 
@@ -101,6 +101,56 @@
         - woodpecker-server
         - woodpecker-agent
         - woodpecker-cli
+
+    # Installing the .deb only swaps the binary on disk — it does NOT restart
+    # the running services. A pure version bump changes no config file, so the
+    # restart handlers never fire, leaving the old process running. The agent
+    # then crash-loops on a GRPC version mismatch against the stale server.
+    # This block detects that drift and cycles the services in the correct
+    # order (server first, wait until it reports the new version, then agent).
+    # It is idempotent: on a no-op re-run the running version already matches
+    # the desired version, so nothing is restarted and pipelines are undisturbed.
+    - name: Query the running Woodpecker server version
+      ansible.builtin.uri:
+        url: http://127.0.0.1:8000/version
+        return_content: true
+      register: _wp_running_version
+      changed_when: false
+      failed_when: false
+
+    # Only act when we positively read a running version that differs from the
+    # desired one. If the probe failed (server unreachable), do NOT assume drift
+    # and restart — that would cycle services on every provision and kill any
+    # running pipeline. A genuine upgrade is still covered: after the .deb swap
+    # the OLD server process keeps serving /version and reports the OLD version,
+    # so the mismatch is detected correctly.
+    - name: Restart Woodpecker (server then agent) when the running version is stale
+      when: >-
+        (_wp_running_version.status | default(0)) == 200
+        and (_wp_running_version.json.version | default('') | string) != ''
+        and (_wp_running_version.json.version | default('') | string)
+            != (woodpecker_version | string)
+      block:
+        - name: Restart woodpecker-server to load the upgraded binary
+          ansible.builtin.systemd:
+            name: woodpecker-server
+            state: restarted
+
+        - name: Wait until woodpecker-server reports the desired version
+          ansible.builtin.uri:
+            url: http://127.0.0.1:8000/version
+            return_content: true
+          register: _wp_post_restart_version
+          until: >-
+            (_wp_post_restart_version.json.version | default('') | string)
+            == (woodpecker_version | string)
+          retries: 24
+          delay: 5
+
+        - name: Restart woodpecker-agent so its GRPC version matches the server
+          ansible.builtin.systemd:
+            name: woodpecker-agent
+            state: restarted
 
     # ── Install Tailscale (mesh networking for SSH access) ─────────
     - name: Install Tailscale


### PR DESCRIPTION
## What

- Bump `woodpecker_version` `3.13.0` → `3.14.1` and `plugin_git_version` `2.8.1` → `2.9.1` in `ci/ansible/playbook.yml`.
- Add an idempotent **version-drift restart block** so future Woodpecker upgrades don't require a manual fire-drill.

## Why

Bumping only the version variable installs the new `.deb` (binary on disk) but **never restarts the running services** — a pure version bump changes no config file, so the existing `Restart Woodpecker server/agent` handlers are never notified. The old server process keeps running and the freshly-restarted agent **crash-loops on a GRPC version mismatch** against the stale server. This happened on this very upgrade and required manual recovery.

## Fix

After the `.deb` install, probe the running server's `/version` and **only when it positively differs** from the desired version:
1. restart `woodpecker-server`
2. wait until it reports the new version (retry/until)
3. restart `woodpecker-agent` (correct GRPC ordering)

A `status == 200 && non-empty version` guard ensures a probe failure does **not** trigger a restart — preventing a restart-storm that would kill running pipelines.

## Validation (empirical, on the live CI host)

- Upgrade applied: `woodpecker-server` + `woodpecker-agent` both report **3.14.1**; agent reconnected (`capacity=7`).
- No-op re-run proven idempotent: probe returned `status=200`/`version=3.14.1`, **both restart tasks `skipping`**, no restart handlers fired, `PLAY RECAP failed=0`.
- **A concurrently-running pipeline (#1321) ran through a full provision re-run completely untouched** and continued advancing through `deploy-prod` — the pipeline-safety property confirmed in the real world.

## OSS Compliance Review

**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0** — clean. All 9 categories checked. Only change is a version bump + a localhost-loopback (`127.0.0.1:8000`) drift block; no domains, PII, credentials, private registry refs, or tenant data.

## Security Review

**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 1**

- LOW — `ci/ansible/playbook.yml:88-89`: `get_url` downloads the pinned `.deb`/binary with no `checksum:` argument. **Pre-existing pattern, not a regression** — every tool download in this playbook (terraform, helmfile, yq, kustomize) follows the same model. Suggested hardening follow-up: add upstream `sha256` checksums.
- No command injection (modules only, no shell), no SSRF (hardcoded loopback), defensive `| default('') | string` coercion in `when`/`until` guards, no secret exposure, no new network/privilege exposure.

## Version Bump

No-op — no `admin-portal`/`account-portal` code changed; `VERSION` files and `image-versions.env` remain in sync. CI/infra-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)