### PR TITLE
fix(ci): redeploy dev on main-push when reaper destroyed cluster

### DIFF
--- a/.woodpecker/deploy-dev-calendar.yaml
+++ b/.woodpecker/deploy-dev-calendar.yaml
@@ -16,8 +16,8 @@ clone:
 steps:
   - name: deploy-dev-calendar
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main so main-push can re-deploy the
+    # tenant when the idle reaper destroyed dev between PR and merge (#422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:

--- a/.woodpecker/deploy-dev-email-probe.yaml
+++ b/.woodpecker/deploy-dev-email-probe.yaml
@@ -15,8 +15,8 @@ clone:
 steps:
   - name: deploy-dev-email-probe
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main so main-push can re-deploy the
+    # tenant when the idle reaper destroyed dev between PR and merge (#422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:

--- a/.woodpecker/deploy-dev-finalize.yaml
+++ b/.woodpecker/deploy-dev-finalize.yaml
@@ -22,8 +22,8 @@ clone:
 steps:
   - name: deploy-dev-finalize
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main so main-push can re-deploy the
+    # tenant when the idle reaper destroyed dev between PR and merge (#422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:
@@ -48,8 +48,10 @@ steps:
   # Pipeline-scoped test users for E2E. Lives here so it runs AFTER the
   # tenant auth ingress is up (created in apps/deploy-matrix.sh, which
   # this workflow depends on). The step itself runs on both PR and push
-  # so users are provisioned for every pipeline; on main push the
-  # deploy-dev-finalize step above is a no-op but this one still runs.
+  # so users are provisioned for every pipeline. Since #422, the
+  # deploy-dev-finalize step above also runs on push:main (re-deploying
+  # tenant resources if the idle reaper destroyed the cluster); on a
+  # warm cluster it is a fast no-op via mt_apply / mt_restart_if_changed.
   - name: create-test-users
     image: bash
     environment:
@@ -142,9 +144,11 @@ steps:
   # the gate authenticates as that exact user (the calendar-external-invite
   # shards use it). Like create-test-users/remint-caldav-tokens this has NO
   # step-level `when:` override — it inherits the workflow-level
-  # `pull_request | push:main` so it runs for EVERY pipeline (gap-#18 lesson:
-  # the deploy steps are PR-only no-ops but these provisioning/gate steps are
-  # not; e2e shards run on the main-push pipeline too and gate deploy-prod).
+  # `pull_request | push:main` so it runs for EVERY pipeline. Historic
+  # gap-#18 lesson: e2e shards run on main-push too and gate deploy-prod,
+  # so any pre-e2e gate must also run on main-push. Since #422 the deploy
+  # steps themselves also run on push:main (warm-cluster fast-no-op or
+  # cold-cluster full redeploy after the idle reaper destroys the cluster).
   - name: imaps-readiness
     image: bash
     environment:

--- a/.woodpecker/deploy-dev-jitsi.yaml
+++ b/.woodpecker/deploy-dev-jitsi.yaml
@@ -15,8 +15,8 @@ clone:
 steps:
   - name: deploy-dev-jitsi
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main so main-push can re-deploy the
+    # tenant when the idle reaper destroyed dev between PR and merge (#422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:

--- a/.woodpecker/deploy-dev-matrix.yaml
+++ b/.woodpecker/deploy-dev-matrix.yaml
@@ -19,8 +19,8 @@ clone:
 steps:
   - name: deploy-dev-matrix
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main so main-push can re-deploy the
+    # tenant when the idle reaper destroyed dev between PR and merge (#422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:

--- a/.woodpecker/deploy-dev-nextcloud.yaml
+++ b/.woodpecker/deploy-dev-nextcloud.yaml
@@ -19,8 +19,8 @@ clone:
 steps:
   - name: deploy-dev-nextcloud
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main so main-push can re-deploy the
+    # tenant when the idle reaper destroyed dev between PR and merge (#422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:

--- a/.woodpecker/deploy-dev-portals.yaml
+++ b/.woodpecker/deploy-dev-portals.yaml
@@ -19,8 +19,8 @@ clone:
 steps:
   - name: deploy-dev-portals
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main so main-push can re-deploy the
+    # tenant when the idle reaper destroyed dev between PR and merge (#422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:

--- a/.woodpecker/deploy-dev-prep.yaml
+++ b/.woodpecker/deploy-dev-prep.yaml
@@ -18,8 +18,8 @@ clone:
 steps:
   - name: deploy-dev-prep
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main so main-push can re-deploy the
+    # tenant when the idle reaper destroyed dev between PR and merge (#422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:

--- a/.woodpecker/deploy-dev-roundcube.yaml
+++ b/.woodpecker/deploy-dev-roundcube.yaml
@@ -15,8 +15,8 @@ clone:
 steps:
   - name: deploy-dev-roundcube
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main so main-push can re-deploy the
+    # tenant when the idle reaper destroyed dev between PR and merge (#422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:

--- a/.woodpecker/deploy-dev-stalwart.yaml
+++ b/.woodpecker/deploy-dev-stalwart.yaml
@@ -15,8 +15,8 @@ clone:
 steps:
   - name: deploy-dev-stalwart
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main so main-push can re-deploy the
+    # tenant when the idle reaper destroyed dev between PR and merge (#422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:

--- a/.woodpecker/ensure-dev-cluster.yaml
+++ b/.woodpecker/ensure-dev-cluster.yaml
@@ -1,10 +1,11 @@
 # Workflow-level `when` MUST match `deploy-dev-prep.yaml` — that workflow lists
 # ensure-dev-cluster in its depends_on, and Woodpecker blocks a workflow if any
-# dependency is filtered out for the current event. On `push` to main the dev
-# bring-up is a no-op (the step-level `when` below gates the actual command),
-# but the workflow must still exist in the DAG so deploy-dev-prep can resolve.
-# Without this, the merge-to-main pipeline short-circuits BEFORE deploy-prod —
-# see pipelines #1216 / #1219 for the bug behaviour.
+# dependency is filtered out for the current event. The workflow must exist in
+# the DAG on both events so deploy-dev-prep can resolve — without this, the
+# merge-to-main pipeline short-circuits BEFORE deploy-prod (pipelines #1216 /
+# #1219). Per issue #422, the deploy step itself also runs on both events so
+# main-push can re-provision the cluster when the idle reaper has destroyed it
+# in the gap between PR pipeline completion and the merge.
 when:
   - event: pull_request
   - event: push
@@ -24,8 +25,7 @@ clone:
 steps:
   - name: ensure-dev-cluster
     image: bash
-    when:
-      - event: pull_request
+    # Runs on both pull_request and push:main — see workflow header (issue #422).
     environment:
       CI: "true"
       CI_VALKEY_PASSWORD:

--- a/ci/scripts/ci-lease-tenant.sh
+++ b/ci/scripts/ci-lease-tenant.sh
@@ -22,11 +22,12 @@ set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/ci-lib.sh"
 
 # ── Lease configuration ───────────────────────────────────────
-# Main merges use a longer TTL because deploy-dev is a no-op (no renewal
-# loop running). PR pipelines use a shorter TTL renewed by ci-deploy.sh,
-# ci-deploy-app.sh, and e2e shards.
+# Both PR and main-push pipelines now run deploy-dev-* (since #422), and
+# ci-deploy.sh's renewal loop is event-agnostic. The longer main-merge TTL
+# below is a safety net for the case where ci-release doesn't run (killed
+# pipeline, network blip), not a substitute for the renewal loop.
 if [[ "${CI_PIPELINE_EVENT:-}" != "pull_request" ]]; then
-  LEASE_TTL=7200  # 2 hours — no renewal loop on main merges, ci-release cleans up
+  LEASE_TTL=7200  # 2 hours — safety net for main merges; renewal loop also runs
 else
   LEASE_TTL=1000  # ~17 minutes (renewed by ci-deploy.sh, ci-deploy-app.sh, and e2e shards)
 fi

--- a/scripts/dev-bringup.sh
+++ b/scripts/dev-bringup.sh
@@ -55,19 +55,26 @@ if [ -n "$EXISTING_ID" ] && [ "$EXISTING_ID" != "null" ]; then
     # we capture stderr to a tempfile and surface it on final failure.
     print_status "dev-bringup: fetching fresh kubeconfig for cluster id=$EXISTING_ID"
     KCFG_STDERR=$(mktemp)
-    trap 'rm -f "$KCFG_STDERR"' EXIT
+    KCFG_RAW=$(mktemp)
+    trap 'rm -f "$KCFG_STDERR" "$KCFG_RAW"' EXIT
     KCFG_B64=""
     KCFG_RC=1
     for _attempt in 1 2 3; do
-        # `|| true` shields `set -e` so we can inspect the rc and stderr.
-        # Pipe rc comes from `jq` here (last cmd in pipeline) so we
-        # capture linode-cli's status via PIPESTATUS.
-        KCFG_OUT=$(linode-cli lke kubeconfig-view --json "$EXISTING_ID" 2>"$KCFG_STDERR" \
-            | jq -r '.[0].kubeconfig // empty') || true
-        KCFG_RC=${PIPESTATUS[0]}
-        if [ "$KCFG_RC" -eq 0 ] && [ -n "$KCFG_OUT" ]; then
-            KCFG_B64="$KCFG_OUT"
-            break
+        # Run linode-cli first and capture its rc directly. Don't pipe into jq
+        # here — command substitution would put the pipe in a subshell, after
+        # which PIPESTATUS in the parent shell reflects only the outer assign-
+        # ment (always 0) and the diagnostic "rc=$KCFG_RC" would lie. Using
+        # `&& KCFG_RC=0 || KCFG_RC=$?` keeps the test in a context where
+        # `set -e` does not fire, so KCFG_RC accurately reflects linode-cli's
+        # exit status.
+        linode-cli lke kubeconfig-view --json "$EXISTING_ID" \
+            >"$KCFG_RAW" 2>"$KCFG_STDERR" && KCFG_RC=0 || KCFG_RC=$?
+        if [ "$KCFG_RC" -eq 0 ]; then
+            KCFG_OUT=$(jq -r '.[0].kubeconfig // empty' "$KCFG_RAW" 2>/dev/null || true)
+            if [ -n "$KCFG_OUT" ]; then
+                KCFG_B64="$KCFG_OUT"
+                break
+            fi
         fi
         if [ "$_attempt" -lt 3 ]; then
             _backoff=$((_attempt * 5))
@@ -81,7 +88,7 @@ if [ -n "$EXISTING_ID" ] && [ "$EXISTING_ID" != "null" ]; then
         sed 's/^/  /' "$KCFG_STDERR" >&2 || true
         exit 1
     fi
-    rm -f "$KCFG_STDERR"
+    rm -f "$KCFG_STDERR" "$KCFG_RAW"
     trap - EXIT
     umask 077
     echo "$KCFG_B64" | base64 -d > "$REPO_ROOT/kubeconfig.${MT_ENV:-dev}.yaml"

--- a/scripts/dev-bringup.sh
+++ b/scripts/dev-bringup.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
-# dev-bringup.sh — Ensure the dev LKE cluster exists. Called from the
-# Woodpecker `ensure-dev-cluster` step on every PR. Idempotent:
-#   - If the cluster already exists: noop apart from a heartbeat touch.
+# dev-bringup.sh — Ensure the dev LKE cluster exists and is healthy.
+# Called from the Woodpecker `ensure-dev-cluster` step on every PR and
+# every push to main (#422). Idempotent:
+#   - If the cluster already exists and is healthy (ingress LB IP
+#     present): refresh kubeconfig, reconcile DNS, touch the heartbeat.
 #   - If missing: run `manage_infra -e dev --phase1-dev-only` (skips the
 #     local-state phase1 root — operator-managed always-up VMs are not
 #     touched from CI) and `deploy_infra -e dev`, then touch the heartbeat.
+#   - If the cluster exists but is degraded (no LB IP — pipeline #1333):
+#     fall through to the cold path to repair, rather than failing loudly.
 #
 # Required env (set by ci/scripts/ci-deploy.sh after vault decrypt):
 #   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY — for phase1-dev's S3 backend
@@ -33,6 +37,7 @@ EXISTING_ID=$(linode-cli lke clusters-list --json 2>/dev/null \
     | head -n1 || true)
 
 DID_PROVISION=false
+CLUSTER_DEGRADED=false
 if [ -n "$EXISTING_ID" ] && [ "$EXISTING_ID" != "null" ]; then
     print_success "dev-bringup: cluster exists (id=$EXISTING_ID); reusing"
 
@@ -43,21 +48,78 @@ if [ -n "$EXISTING_ID" ] && [ "$EXISTING_ID" != "null" ]; then
     # endpoint and the bringup aborted before DNS reconcile. Fetch a fresh
     # kubeconfig from Linode for the current cluster id and write it to
     # $REPO_ROOT — mirrors dev-reaper.sh's pattern for the destroy side.
+    #
+    # Retry on transient API errors (pipeline #1330: `linode-cli` exited
+    # nonzero with stderr swallowed by `2>/dev/null`, killing the script
+    # under `set -euo pipefail` BEFORE the explicit error block ran). Now
+    # we capture stderr to a tempfile and surface it on final failure.
     print_status "dev-bringup: fetching fresh kubeconfig for cluster id=$EXISTING_ID"
-    KCFG_B64=$(linode-cli lke kubeconfig-view --json "$EXISTING_ID" 2>/dev/null \
-        | jq -r '.[0].kubeconfig // empty')
+    KCFG_STDERR=$(mktemp)
+    trap 'rm -f "$KCFG_STDERR"' EXIT
+    KCFG_B64=""
+    KCFG_RC=1
+    for _attempt in 1 2 3; do
+        # `|| true` shields `set -e` so we can inspect the rc and stderr.
+        # Pipe rc comes from `jq` here (last cmd in pipeline) so we
+        # capture linode-cli's status via PIPESTATUS.
+        KCFG_OUT=$(linode-cli lke kubeconfig-view --json "$EXISTING_ID" 2>"$KCFG_STDERR" \
+            | jq -r '.[0].kubeconfig // empty') || true
+        KCFG_RC=${PIPESTATUS[0]}
+        if [ "$KCFG_RC" -eq 0 ] && [ -n "$KCFG_OUT" ]; then
+            KCFG_B64="$KCFG_OUT"
+            break
+        fi
+        if [ "$_attempt" -lt 3 ]; then
+            _backoff=$((_attempt * 5))
+            print_warning "dev-bringup: linode-cli kubeconfig-view attempt $_attempt failed (rc=$KCFG_RC); retrying in ${_backoff}s"
+            sleep "$_backoff"
+        fi
+    done
     if [ -z "$KCFG_B64" ]; then
-        print_error "dev-bringup: could not fetch kubeconfig from Linode API; aborting"
+        print_error "dev-bringup: could not fetch kubeconfig from Linode API after 3 attempts (rc=$KCFG_RC); aborting"
+        print_error "dev-bringup: linode-cli stderr was:"
+        sed 's/^/  /' "$KCFG_STDERR" >&2 || true
         exit 1
     fi
+    rm -f "$KCFG_STDERR"
+    trap - EXIT
     umask 077
     echo "$KCFG_B64" | base64 -d > "$REPO_ROOT/kubeconfig.${MT_ENV:-dev}.yaml"
     umask 022
     export KUBECONFIG="$REPO_ROOT/kubeconfig.${MT_ENV:-dev}.yaml"
     print_status "dev-bringup: KUBECONFIG repointed to $KUBECONFIG (fresh from Linode)"
-else
+
+    # Stale-warm-cluster recovery (pipeline #1333): a cluster id exists and
+    # the kubeconfig is fresh, but the cluster itself may be degraded — e.g.
+    # ingress-nginx has no LB IP because deploy_infra never finished. Probe
+    # the exact symptom that aborted #1333 (no LB IP on the ingress Service)
+    # and if it's missing, treat the cluster as cold by falling through to
+    # the provisioning branch below. Repair > fail-loud here: the issue
+    # explicitly recommends falling through, and the operator's only
+    # alternative (manual recovery) would just trigger this exact path.
+    print_status "dev-bringup: probing ingress-nginx LB IP for warm-cluster health..."
+    WARM_LB_IP=$(kubectl --kubeconfig="$KUBECONFIG" -n infra-ingress \
+        get svc ingress-nginx-controller \
+        -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+    if [ -z "$WARM_LB_IP" ]; then
+        print_warning "dev-bringup: cluster id=$EXISTING_ID exists but ingress-nginx has no LB IP"
+        print_warning "dev-bringup: treating as cold; running phase1-dev + deploy_infra to repair"
+        CLUSTER_DEGRADED=true
+    else
+        print_success "dev-bringup: warm cluster healthy (ingress LB IP=$WARM_LB_IP)"
+    fi
+fi
+
+# Cold or degraded path: provision phase1-dev + deploy_infra. Reached either
+# (a) when no cluster exists at all (post-reaper or first-run), or (b) when
+# the warm-cluster health check above detected a degraded cluster (#1333).
+if [ -z "$EXISTING_ID" ] || [ "$EXISTING_ID" = "null" ] || [ "$CLUSTER_DEGRADED" = "true" ]; then
     DID_PROVISION=true
-    print_status "dev-bringup: no cluster found; provisioning..."
+    if [ "$CLUSTER_DEGRADED" = "true" ]; then
+        print_status "dev-bringup: degraded warm cluster — re-running phase1-dev + deploy_infra to repair"
+    else
+        print_status "dev-bringup: no cluster found; provisioning..."
+    fi
 
     # phase1-dev's S3 backend needs these env vars. Fail fast if missing —
     # the alternative (silent local backend fallback) would diverge from
@@ -86,6 +148,9 @@ EOF
     # operator-managed always-up VMs (postgres-dev / headscale-dev /
     # turn-server-dev); CI doesn't have phase1's state and running
     # terraform there would try to recreate those VMs.
+    # On the degraded path the cluster itself already exists, so terraform
+    # finds it in state and no-ops; the value comes from deploy_infra
+    # re-reconciling infra-* namespaces (ingress, certs, Keycloak, ...).
     print_status "dev-bringup: running manage_infra --phase1-dev-only..."
     "$REPO_ROOT/scripts/manage_infra" -e dev --phase1-dev-only
 


### PR DESCRIPTION
## Summary

Drops the step-level `when: event: pull_request` from every `deploy-dev-*` workflow + `ensure-dev-cluster`, so main-push pipelines can re-provision the dev cluster and re-deploy tenants when the idle reaper destroyed dev in the gap between PR-pipeline completion and merge.

Plus two resilience fixes in `scripts/dev-bringup.sh` for the related failure modes observed today on pipelines #1330 and #1333.

Closes #422.

## Background

On 2026-05-18 pipeline #1327 (`Merge pull request #420`) failed at `deploy-dev-finalize` → `create-test-users` because the dev cluster had been reaped between the PR pipeline (finished 11:36 UTC) and the merge (~19:51 UTC) — an 8h gap, well past `reaper_idle_hours: 2`. The merge-to-main pipeline assumed cluster + leased-tenant state were still intact (the long-standing "deploy-dev no-op on main-push" pattern), and there was no recovery path. `deploy-prod` was skipped.

This is the same class of "PR-only gates hidden on main-push" pattern documented in `MEMORY.md` → `project_on_demand_dev.md`.

## What changes

### 11 Woodpecker workflow files (commit `9a3f2c7`)
Each loses its step-level `when: event: pull_request` on the deploy step (left with a one-line WHY comment referencing #422). Each gains the same comment header. Three workflows had stale prose elsewhere ("deploy steps are PR-only no-ops") which would have become lies — rewritten to match the new reality:

- `.woodpecker/ensure-dev-cluster.yaml`
- `.woodpecker/deploy-dev-prep.yaml`
- `.woodpecker/deploy-dev-matrix.yaml`
- `.woodpecker/deploy-dev-nextcloud.yaml`
- `.woodpecker/deploy-dev-jitsi.yaml`
- `.woodpecker/deploy-dev-stalwart.yaml`
- `.woodpecker/deploy-dev-roundcube.yaml`
- `.woodpecker/deploy-dev-portals.yaml`
- `.woodpecker/deploy-dev-calendar.yaml`
- `.woodpecker/deploy-dev-email-probe.yaml`
- `.woodpecker/deploy-dev-finalize.yaml`

Sibling provisioning steps (`create-test-users`, `remint-caldav-tokens`, `imaps-readiness`) already had no step-level `when:` — left unchanged.

### `scripts/dev-bringup.sh` resilience (commit `f46325b`)

- **linode-cli retry + stderr capture** (pipeline #1330 fix): `linode-cli lke kubeconfig-view` now runs in a 3-attempt loop (5s/10s backoff). Stderr is captured to a mktemp tempfile (0600 perms) and surfaced on final failure, replacing the previous silent `set -e` death under pipefail with `2>/dev/null` swallowing the error.

- **Warm-cluster health probe + degraded recovery** (pipeline #1333 fix): after fetching the fresh kubeconfig on the warm path, the script now probes `kubectl get svc ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}'` in `infra-ingress`. Empty result → `CLUSTER_DEGRADED=true` → falls through to the cold/repair path (re-runs `manage_infra --phase1-dev-only` + `deploy_infra -e dev`) rather than aborting. The issue explicitly called for repair over fail-loud; the operator's manual alternative would just trigger this same path.

## Idempotency audit

Documented in commit `9a3f2c7`'s message. Key findings (left as follow-up, NOT fixed in this PR — out of scope):

- Several deploy scripts mix `mt_apply` (tracked) with plain `kubectl apply` (untracked). Plain `kubectl apply` on identical YAML is a controller-level no-op (no rollout, no restart), so the tracking gap only bites when YAML content drifts.
- `apps/deploy-stalwart.sh:323` uses plain `kubectl apply` for the Stalwart Deployment — warm redeploy is fine; manifest is unchanged → no rollout.
- `apps/deploy-stalwart.sh:572` `kubectl rollout status ... --timeout=300s` returns immediately on a stable Deployment.
- `apps/deploy-matrix.sh`, `apps/deploy-calendar-automation.sh`, `apps/deploy-email-probe.sh` follow the same pattern.

Worth a separate follow-up issue if a warm redeploy ever does spuriously restart pods.

## Test plan

- [ ] Push to PR — confirm `ensure-dev-cluster` + every `deploy-dev-*` step runs (they're no longer skipped on a PR; they always did, but verify behavior unchanged).
- [ ] When this merges to main — confirm the main-push pipeline runs `ensure-dev-cluster` and the full `deploy-dev-*` chain (idempotently on a warm cluster, fully provisioning if reaped).
- [ ] Confirm `deploy-prod` runs after `mothertree-build` gate passes.
- [ ] On a future main-push that happens after >2h idle: confirm the cold path provisions cluster + tenants and `deploy-prod` still runs.

**Note**: #423 (Stalwart readiness regression) co-blocks this — if Stalwart's cold-start readiness is still failing when this PR's CI runs, `deploy-dev-stalwart` will time out and `mothertree-build` will be skipped. The two PRs touch different files and don't merge-conflict, but they share an operational dependency for end-to-end green CI.

## OSS Compliance Review

**CLEAN** — `oss-compliance` agent: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0. No tenant domains, credentials, personal info, or private registry references. Workflow comments reference public issue/pipeline numbers only.

## Security Review

`security-reviewer` agent: **CRITICAL 0 / HIGH 0 / MEDIUM 1 / LOW 2** — no blocking issues.

- **MEDIUM** (informational, intentional): blast-radius expansion — `deploy-dev-*` now runs on push:main. This is the PR's stated purpose, no new credential/auth boundary crossed, same Woodpecker secrets that were already in scope for push events. Operational risk noted.
- **LOW**: `linode-cli` stderr surfaced on failure — typical content is API state messages, not credentials. Worth a `sed` mask for tokens in the future but low risk on operator-only CI logs.
- **LOW**: `trap` is bounded to a single tempfile section — safe today; future edits should add new traps explicitly.

## Version Bump

`version-bump` agent: no portal code touched (only `.woodpecker/` + `scripts/`). No bump required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
