### PR TITLE
fix(stalwart): fail loudly + dump diagnostics on rollout timeout

### DIFF
--- a/apps/deploy-stalwart.sh
+++ b/apps/deploy-stalwart.sh
@@ -572,8 +572,49 @@ print_status "Waiting for Stalwart Deployment to be ready..."
 if kubectl rollout status deployment/stalwart -n "$NS_MAIL" --timeout=300s; then
     print_success "Stalwart Deployment is ready"
 else
-    print_warning "Stalwart StatefulSet may not be fully ready"
-    print_status "Check logs with: kubectl logs -n $NS_MAIL -l app=stalwart"
+    # Fail loudly with a diagnostic dump so the next person sees the actual
+    # reason instead of the downstream "Port-forward to Stalwart failed".
+    # See gh#423 — pipeline #1329 timed out here, then exited 1 at the
+    # port-forward block below with no pod-level evidence captured.
+    print_error "Stalwart Deployment did not become Ready within 300s"
+    echo ""
+    print_error "=== Diagnostic dump (gh#423) ==="
+
+    # dump_pod_diagnostics handles describe-pod + recent events; all kubectl
+    # calls are guarded with `|| true` so a missing pod/secret doesn't short-
+    # circuit later dumps. Reset error mode briefly for the same reason —
+    # `set -euo pipefail` is active and we want every dump to fire.
+    set +e
+
+    dump_pod_diagnostics "$NS_MAIL" "app=stalwart"
+
+    echo ""
+    print_error "Diagnostics: deployment rollout state"
+    kubectl get deployment stalwart -n "$NS_MAIL" -o wide || true
+    kubectl describe deployment stalwart -n "$NS_MAIL" || true
+
+    echo ""
+    print_error "Diagnostics: stalwart pod logs (current, last 200 lines)"
+    kubectl logs -n "$NS_MAIL" -l app=stalwart --tail=200 --all-containers=true || true
+
+    echo ""
+    print_error "Diagnostics: stalwart pod logs (previous, last 200 lines — if CrashLoop)"
+    kubectl logs -n "$NS_MAIL" -l app=stalwart --previous --tail=200 --all-containers=true 2>/dev/null || \
+        echo "  (no previous container — pod did not restart)"
+
+    echo ""
+    print_error "Diagnostics: TLS secret presence in mail namespace"
+    # wildcard-tls-<tenant> is reflected from NS_MATRIX by emberstack/reflector
+    # and is a mount-time dependency of the Stalwart pod. Missing/late =
+    # ContainerCreating stall — a known hypothesis for the gh#423 cold-start
+    # failure (deploy-dev-prep on #1329 logged "wildcard-tls not ready
+    # after 120s" before continuing).
+    kubectl get secret -n "$NS_MAIL" "wildcard-tls-${TENANT_NAME}" -o jsonpath='{.metadata.name} (type={.type}, dataKeys={.data})' 2>&1 | head -c 400 || true
+    echo ""
+    kubectl get certificate -n "$NS_MATRIX" wildcard-tls -o wide 2>/dev/null || true
+
+    set -e
+    exit 1
 fi
 
 # =============================================================================

--- a/apps/deploy-stalwart.sh
+++ b/apps/deploy-stalwart.sh
@@ -609,8 +609,11 @@ else
     # ContainerCreating stall — a known hypothesis for the gh#423 cold-start
     # failure (deploy-dev-prep on #1329 logged "wildcard-tls not ready
     # after 120s" before continuing).
-    kubectl get secret -n "$NS_MAIL" "wildcard-tls-${TENANT_NAME}" -o jsonpath='{.metadata.name} (type={.type}, dataKeys={.data})' 2>&1 | head -c 400 || true
-    echo ""
+    # NEVER include `{.data}` here — this is a kubernetes.io/tls Secret whose
+    # .data contains base64-encoded tls.key (the WILDCARD PRIVATE KEY). CI logs
+    # on this public repo are not safe to leak even partial key material into.
+    # The default tabular `get secret` output shows name/type/data-count only.
+    kubectl get secret -n "$NS_MAIL" "wildcard-tls-${TENANT_NAME}" 2>&1 | head -3 || true
     kubectl get certificate -n "$NS_MATRIX" wildcard-tls -o wide 2>/dev/null || true
 
     set -e


### PR DESCRIPTION
## Summary

Hardens `apps/deploy-stalwart.sh`'s rollout-status path to fail loudly with a structured diagnostic dump when the Stalwart Deployment doesn't become Ready within 300s. Previously, a timeout printed only `WARNING` and continued; the downstream port-forward then exited 1 with no pod-level evidence — leaving CI logs with `Port-forward to Stalwart failed` and no clue why.

**Does NOT** ship a speculative readiness/probe/image change. The agent investigated 5 hypotheses against pipeline #1329's logs and the current manifest, found a strong **circumstantial** signal (`wildcard-tls` Certificate logged "not ready after 120s" in deploy-dev-prep, 3 seconds before Stalwart started), but could not pin a primary root cause without a live reproduction (dev cluster was destroyed and no fresh failure was available). The issue explicitly warned: "Don't ship a speculative readiness/probe change without evidence." Doing only the diagnostic improvement so the next reproduction yields actionable logs.

Closes #423 (partially — diagnostic landed; root-cause fix may follow once next reproduction pins the actual cause).

## Background

Pipeline #1329 (PR `chore(scripts): verify if 8080 is available before starting`) failed in `deploy-dev-stalwart` with:

```
[INFO] Waiting for Stalwart Deployment to be ready...
Waiting for deployment "stalwart" rollout to finish: 0 of 1 updated replicas are available...
error: timed out waiting for the condition
[WARNING] Stalwart StatefulSet may not be fully ready
[ERROR] Port-forward to Stalwart failed
```

No pod-level evidence (events, describe, logs) was captured before the script exited 1. Continuation of the Stalwart cold-start saga (gap #19 / PR #417 / PR #419 in repo history).

Investigation findings (primary-source):
1. Deploy-dev-prep on the same pipeline logged `[WARNING] wildcard-tls not ready after 120s` and `[WARNING] No stuck challenges found — certificates may still be validating`, then `Continuing deployment`.
2. `deploy-dev-stalwart` started 3 seconds later.
3. The Stalwart manifest (`apps/manifests/stalwart/stalwart.yaml.tpl`) still has #417's honest `tcpSocket:588` readiness, `startupProbe` (30×10s), and liveness `timeoutSeconds:5` intact. Image `stalwartlabs/stalwart:v0.15.5` unchanged.
4. The dev cluster is currently destroyed; pipelines #1330/#1331/#1333 all failed at `ensure-dev-cluster` (separate issues — tracked by #422). No live reproduction possible right now.

Leading hypothesis (UNCONFIRMED, advisor flagged as speculative): pod stuck in `ContainerCreating` because the `wildcard-tls-<tenant>` Secret hadn't been reflected from `NS_MATRIX` to `NS_MAIL` yet. Mount-time dependency → never Ready → tcpSocket:588 probe never gets a chance to flip true.

This PR ships JUST the instrumentation needed to confirm/refute that hypothesis on the next failure.

## What changes

### `apps/deploy-stalwart.sh:570-620` (commit `0fa1a25`, with security fix in `06b0c2b`)

On `kubectl rollout status` timeout, the script now:

1. Exits 1 immediately (was: warn-and-continue, then fail mysteriously at port-forward).
2. Dumps a structured diagnostic block before exit:
   - `dump_pod_diagnostics "$NS_MAIL" "app=stalwart"` (pod list + describe + recent events)
   - `kubectl get/describe deployment stalwart` (rollout state)
   - `kubectl logs --tail=200 --all-containers=true` (current containers)
   - `kubectl logs --previous --tail=200` (CrashLoop history, if any)
   - **TLS dependency check** — presence of the reflected `wildcard-tls-<tenant>` Secret in `NS_MAIL` and the source `wildcard-tls` Certificate in `NS_MATRIX`. Guard against the leading hypothesis above.
3. All `kubectl` calls guarded with `|| true` inside a temporarily-relaxed `set +e` so every dump fires even if earlier dumps fail. `set -e` is restored before `exit 1`.

### Security: drop `{.data}` from the TLS secret check (commit `06b0c2b`)

Caught by `security-reviewer` agent before push (**CRITICAL** severity). The first version used `-o jsonpath='...dataKeys={.data}'` on the wildcard-tls Secret, which for a `kubernetes.io/tls` Secret serializes the entire `.data` map — embedding base64-encoded `tls.key` (the **wildcard private key**) into the diagnostic line. The `head -c 400` truncation didn't help because Go's map iteration order is non-deterministic. The main repo is public; Woodpecker CI logs on public PRs would have leaked partial key material on every cold-start failure, forcing wildcard cert rotation.

Replaced with the default tabular `kubectl get secret ... | head -3` (NAME/TYPE/DATA-count only — never serializes secret values). Added a `NEVER include {.data}` comment so the next person doesn't reintroduce the regression.

## Test plan

- [ ] Next time `deploy-dev-stalwart` fails on cold-start, CI logs should contain pod events + describe + container logs + TLS dependency presence — actionable for pinning root cause.
- [ ] On a successful run, the new code path is not taken (script still hits the `Stalwart Deployment is ready` success branch).
- [ ] If/when the wildcard-tls-reflection hypothesis is confirmed by the diagnostic, follow-up PR adds an explicit gate before the rollout-status call.

## OSS Compliance Review

**CLEAN** — `oss-compliance` agent: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0. All cluster-specific values come from env vars exported by `mt_load_tenant_config`. No tenant data, credentials, registry refs, or PII.

## Security Review

`security-reviewer` agent first pass: **CRITICAL 1 / LOW 2** — see CRITICAL detail above (jsonpath `{.data}` leak). Fixed in commit `06b0c2b`. Other findings:

- **LOW**: Stalwart container logs may include credentials at INFO level. Standard diagnostic pattern, not new risk. Worth verifying Stalwart never logs secrets at INFO/WARN (separate audit).
- **LOW**: `set +e` / `set -e` block is `exit 1`-safe but structurally fragile. Future edits adding code between `set -e` and `exit 1` could leak relaxed error mode. Consider wrapping in a subshell `( set +e; ... )` in a follow-up.

## Version Bump

`version-bump` agent: deploy script change, not portal code. No bump required.

## Co-dependency

#424 (`fix/redeploy-dev-on-main-push`, closing #422) is being merged in parallel. The two PRs touch different files but share an operational dependency: #422 exercises the same Stalwart cold-start path that this PR diagnoses, so green CI on #424's main-merge depends on either (a) the leading hypothesis here being right and getting fixed, or (b) the cold-start path stabilizing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
