### PR TITLE
chore(ci): upgrade Woodpecker 3.14.1 → 3.15.0

### DIFF
--- a/ci/ansible/playbook.yml
+++ b/ci/ansible/playbook.yml
@@ -17,7 +17,7 @@
     - "{{ vars_file | default('ansible-vars.yml') }}"
 
   vars:
-    woodpecker_version: "{{ woodpecker_version_override | default('3.14.1') }}"
+    woodpecker_version: "{{ woodpecker_version_override | default('3.15.0') }}"
     plugin_git_version: "{{ plugin_git_version_override | default('2.9.1') }}"
     # Path to tenant config submodule (relative to playbook)
     _tenants_dir: "{{ playbook_dir }}/../../config/tenants"


### PR DESCRIPTION
## Summary

- Bumps Woodpecker CI server + agent + cli from **3.14.1 → 3.15.0** (released 2026-05-28) via `ci/ansible/playbook.yml` default.
- Applied to the live CI VM on 2026-05-30 alongside a manual queue cleanup that broke a stuck-pipeline error loop in 3.14.1.

## Why

3.14.1 leaked queue rows from cancelled pipelines (Dependabot supersedes on PRs #427/#428) into the queue-backup table. The server kept resubmitting them while the agent rejected with `workflow was already marked as finished`, locking the 3 worker slots and starving all new work. Symptoms: queue.info reported 92 `waiting_on_deps` + 20 "running", no new pipelines started, agent process had consumed 1h16m CPU + 4.1 GB RSS on the retry loop alone. PR #420 upgrading 3.13.0 → 3.14.1 (2026-05-20) is the most likely trigger.

## What was done on the live VM (manual, one-shot)

1. `systemctl stop woodpecker-agent woodpecker-server`
2. Backup: `/var/lib/woodpecker/woodpecker.sqlite.bak-pre-3.15.0-20260530T163507Z` (653 MB)
3. `DELETE FROM tasks;` (92 rows from pipeline_ids 2146/2148/2150/2152 = #1352/1353/1355/1356)
4. `UPDATE workflows SET state='killed', finished=now WHERE state='running';` (341 zombies)
5. `UPDATE pipelines SET status='killed' WHERE status IN ('running','pending','started');` (none — defensive)
6. Restart services on 3.14.1: clean, no error loop
7. `./ci/scripts/provision-ci.sh --ansible-only` → playbook's drift-detection restart cycled server then agent to 3.15.0

## Post-upgrade state (verified)

- `GET /version` → `3.15.0`
- Agent registered: `version=3.15.0`, `backend=local`, `worker_count=7`
- Queue: `pending=0`, `waiting_on_deps=0`, `running=0`
- Server + agent journals clean (no error spam)

## 3.15.0 security fixes (none affect us, all positive)

- #6653 GitLab username sanitization (we use GitHub forge)
- #6647 uuid dep bump
- #6569 server stores extracted agentID in gRPC context (server-side hardening)

## OSS Compliance Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0
No secrets, tenant data, or private registry references. Single-line version pin bump.

## Security Review

**CRITICAL**: 0 | **HIGH**: 0 | **MEDIUM**: 0 | **LOW**: 0
Routine patch upgrade; no surface-area changes; ships three upstream security fixes that don't affect our deployment.

## Version Bump

No portal code changes — `admin-portal`/`account-portal` VERSION + `image-versions.env` not affected.

## Test plan

- [x] Server + agent both report 3.15.0
- [x] Queue cleared (0/0/0)
- [x] No error spam in journals
- [ ] This PR's own CI pipeline runs cleanly (canary) — visible in the green/red of this PR
- [ ] First main-merge after this lands runs deploy-dev-* + deploy-prod cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)