### PR TITLE
chore(deps): pin Roundcube to 1.6.x, ignore 1.7.x in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -135,3 +135,11 @@ updates:
     groups:
       base-images:
         patterns: ["*"]
+    ignore:
+      # Pinned to 1.6.x. 1.7.0 crash-loops in our custom image (entrypoint
+      # re-copies the stock app over our `mothertree` skin → health probe
+      # 404s) and its updatedb.sh forward-migrates the shared dev DB
+      # (session.changed→expires_at), breaking all 1.6.x branches. Remove
+      # when the deliberate 1.7 cutover lands — tracking issue #430.
+      - dependency-name: "roundcube/roundcubemail"
+        versions: [">= 1.7.0"]


### PR DESCRIPTION
Pins `roundcube/roundcubemail` to `< 1.7.0` in Dependabot until the deliberate 1.7 cutover.

## Why
Roundcube **1.7.0** is broken in our deployment (validated live on dev pipeline #1367, image `mothertree-roundcube:0.3.4`):
1. **Crash-loop** — 1.7.0's entrypoint re-copies the stock app into `/var/www/html` at runtime, shadowing our custom `mothertree` skin. Apache starts, but the health probe `GET /skins/mothertree/images/logo.svg` → 404 → k8s kills the pod → `CrashLoopBackOff` → Roundcube never serves.
2. **Shared-DB poisoning** — 1.7.0's `updatedb.sh` (forward-only) migrated the shared persistent dev Postgres (`session.changed → expires_at`), which broke Roundcube login on every 1.6.x branch (main + all PRs) until the dev table was patched back.

1.6.x patch updates still flow (only `>= 1.7.0` is ignored). The deliberate upgrade is tracked in **#430**, which also covers the fix ideas.

## OSS Compliance Review
**Verdict: CLEAN.** 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW. Single change to `.github/dependabot.yml`; no domains, personal info, credentials, private-registry refs, or tenant data. The one "mothertree" mention is the product/image skin name (explicitly allowed).

## Security Review
**Verdict: APPROVED — no security concerns.** CI/dependency-metadata only; no code, secrets, manifests, network/auth/TLS touched. Pinning does **not** strand security patches — the 1.6.x stream stays open (Dependabot will still bump 1.6.15→1.6.16, already published). Deferring a known crash-looping major is the safer choice.

## Version Bump
No portal code touched (`apps/admin-portal`, `apps/account-portal` unchanged) → no version bump needed.

Tracking: #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)