### PR TITLE
fix(docs): harden cold-start — raise CPU requests + widen deploy/probe windows

### DIFF
--- a/apps/deploy-docs.sh
+++ b/apps/deploy-docs.sh
@@ -260,7 +260,7 @@ fi
 
 kubectl -n "$NS_DOCS" delete job/docs-db-init --ignore-not-found=true || true
 envsubst '${DOCS_DB_NAME} ${TENANT_DB_USER} ${PG_HOST} ${KEYCLOAK_DB_PASSWORD}' < "$REPO_ROOT/docs/db-init-job.yaml.tpl" | sed "s/namespace: docs/namespace: $NS_DOCS/g" | kubectl apply -f -
-if ! poll_job_complete "$NS_DOCS" "docs-db-init" 180 5; then
+if ! poll_job_complete "$NS_DOCS" "docs-db-init" 300 5; then
     print_error "Database initialization failed"
     exit 1
 fi
@@ -276,7 +276,11 @@ cat "$REPO_ROOT/docs/migrations-job.yaml" | \
   sed "s/namespace: docs/namespace: $NS_DOCS/g" | \
   sed "s/docs-postgresql.docs.svc/${PG_SERVICE_NAME}.$NS_DB.svc/g" | \
   kubectl apply -f -
-if ! poll_job_complete "$NS_DOCS" "docs-migrations" 300 5; then
+# Widened 300s→900s: a cold/contended dev cluster has stretched the Django
+# app-import in this job to ~3.5min (CPU starvation during concurrent tenant
+# deploys), and the job completed at ~520s — past the old 300s poll, which then
+# failed the deploy while the migration was still running. 900s tolerates that.
+if ! poll_job_complete "$NS_DOCS" "docs-migrations" 900 5; then
     print_error "Database migrations failed"
     exit 1
 fi

--- a/docs/migrations-job.yaml
+++ b/docs/migrations-job.yaml
@@ -73,13 +73,17 @@ spec:
             - name: storage-backends
               mountPath: /app/storage_backends.py
               subPath: storage_backends.py
-          # Memory tuned - migrations are short-lived jobs
+          # Short-lived job, but it runs the full Django app-import (boto3 +
+          # malware_detection). On a cold/contended dev cluster a 100m CPU request
+          # got starved during concurrent tenant deploys, stretching the import
+          # from ~3s to ~3.5min and blowing the deploy poll. Give it real CPU so it
+          # boots fast under contention; memory floor raised off the anomalous 64Mi.
           resources:
             requests:
-              cpu: 100m
-              memory: 64Mi
-            limits:
+              cpu: 500m
               memory: 256Mi
+            limits:
+              memory: 512Mi
           securityContext:
             runAsUser: 0
       volumes:

--- a/docs/y-provider-deployment.yaml
+++ b/docs/y-provider-deployment.yaml
@@ -51,14 +51,19 @@ spec:
             - name: http
               containerPort: 4444
           # Liveness: is the y-provider process alive?
+          # Widened for cold-start: on a contended dev cluster the node server
+          # needed >40s to bind :4444, so the old 10s+3x10s/1s-timeout window
+          # killed it before "App listening on port : 4444" → crashloop. ~30s+6x10s
+          # grace and a 3s timeout tolerate a slow cold boot; steady-state detection
+          # is still well within ~90s.
           livenessProbe:
             httpGet:
               path: /ping
               port: 4444
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 10
-            timeoutSeconds: 1
-            failureThreshold: 3
+            timeoutSeconds: 3
+            failureThreshold: 6
           # Readiness: can y-provider talk to backend? (checked by sidecar)
           readinessProbe:
             httpGet:
@@ -70,7 +75,9 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 100m  # Minimum 100m to prevent HPA triggering on idle fluctuations
+              cpu: 250m  # Raised from 100m: gives CPU shares to bind :4444 quickly
+                         # under cold-start contention. Still well under the HPA 80%
+                         # target at idle, so no scaling on idle fluctuations.
               memory: 128Mi
             limits:
               memory: 256Mi


### PR DESCRIPTION
## Summary

Fixes the intermittent **docs-migrations deploy timeout** and **y-provider crashloop** that have been red-lighting main-push pipelines (e.g. #1395 / #1396). Root cause was found by following a fresh run live and A/B-comparing two identically-cold dev clusters running the same commit.

**These are not deterministic defects — they're CPU contention during concurrent cold-start on the shared on-demand dev cluster.** When multiple tenant deploys cold-start at once, the `100m`-CPU-request docs-migrations job and y-provider pods get starved:

| | Failed run (cluster 612660) | Solo run (cluster 612871) |
|---|---|---|
| Django app-import in migration job | **3m 39s** | **~3s** |
| docs-migrations total | **8m 41s → timed out at 300s** | **~4s → Succeeded** |
| y-provider | never bound `:4444`, liveness-killed ~41s, **36× crashloop** | `App listening on :4444`, 2/2, 0 restarts |
| impress image pull | n/a (non-factor) | **~10s** |

A ~73× swing in pure-compute import time on identical image/limits/code ⇒ contention, not image-pull and not inherent slowness.

## Changes

- **`docs/migrations-job.yaml`** — CPU request `100m → 500m`; memory `64Mi → 256Mi` request, `256Mi → 512Mi` limit (short-lived job, so no steady-state cost).
- **`docs/y-provider-deployment.yaml`** — CPU request `100m → 250m` (still well under the HPA 80% idle target); liveness probe `initialDelaySeconds 10→30`, `timeoutSeconds 1→3`, `failureThreshold 3→6` (cold-boot grace ~40s → ~90s).
- **`apps/deploy-docs.sh`** — `docs-migrations` poll `300s → 900s`; `docs-db-init` poll `180s → 300s`.

**Deliberately NOT included (yet):** a dev-cluster concurrency cap / deploy stagger (the "option 3" lever). Monitoring whether the resource + timeout changes alone hold before adding scheduling complexity.

**Validation caveat:** because the failure is contention-triggered and intermittent, a green run on this PR's own pipeline is *necessary but not sufficient* proof — it may simply have run uncontended. The real test is sustained green across concurrent main-push + PR pipelines.

**Follow-up option:** the y-provider cold-start could alternatively be handled with a `startupProbe` (generous boot grace) while keeping liveness tight for steady-state hang detection — see Security Review LOW finding below.

## OSS Compliance Review

**Verdict: CLEAN.** 0 findings across all categories. Changes are pure K8s resource/timeout tuning plus descriptive comments. Only "domain-like" match is the `app.kubernetes.io/part-of: mother-tree` label (product name, allowed). No secrets, registries, PII, or tenant data.

## Security Review

**Verdict: Clean — 0 CRITICAL / 0 HIGH, 2 LOW (non-blocking).**

- **LOW** — Widening `failureThreshold` 3→6 extends hung-but-alive y-provider detection from ~30s to ~60s. Readiness (`:8081` sidecar) doesn't backstop the `:4444` process, so liveness is the sole detector. Bounded & deliberate: negligible in **prod** (`min_replicas: 2`, peers absorb traffic), tolerable in **dev** (`min_replicas: 1`, dev-only, ≤60s). A `startupProbe` would eliminate this tradeoff if desired.
- **LOW** — Higher CPU requests on the shared dev+prod manifest are scheduling *reservations*, so they **reduce** overcommit/DoS risk; the migration job's reservation is transient. HPA math: 250m request raises the absolute idle-scale threshold (80m→200m), making idle-fluctuation scaling *less* likely. No exhaustion concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)