### PR TITLE
fix(roundcube): probe app root not skin asset so 1.7 doesn't crashloop

### DIFF
--- a/apps/deploy-roundcube.sh
+++ b/apps/deploy-roundcube.sh
@@ -222,8 +222,28 @@ if mt_has_changes; then
     if kubectl rollout status deployment/roundcube -n "$NS_WEBMAIL" --timeout=180s; then
         print_success "Roundcube Deployment is ready"
     else
-        print_warning "Roundcube Deployment may not be fully ready"
-        print_status "Check logs with: kubectl logs -n $NS_WEBMAIL -l app=roundcube"
+        # Fail loudly. A rollout timeout means the new pods never became Ready
+        # (e.g. CrashLoopBackOff on a failing health probe). This was previously
+        # only a warning + exit 0, so a broken image — e.g. the Roundcube 1.7
+        # docroot change that 404'd the old skin-asset probe and crashlooped the
+        # pod — deployed "successfully" and was only caught later by e2e, and
+        # only when no healthy old replica happened to keep serving. Fail fast
+        # per CLAUDE.md so a broken deploy can never report success.
+        print_error "Roundcube Deployment did not become Ready within 180s"
+        echo ""
+        print_error "=== Diagnostic dump ==="
+        # Guard every kubectl call so one missing object doesn't skip later dumps
+        # (set -euo pipefail is active).
+        set +e
+        dump_pod_diagnostics "$NS_WEBMAIL" "app=roundcube"
+        echo ""
+        print_error "Diagnostics: roundcube pod logs (current, last 200 lines)"
+        kubectl logs -n "$NS_WEBMAIL" -l app=roundcube --tail=200 --all-containers=true || true
+        echo ""
+        print_error "Diagnostics: roundcube pod logs (previous, last 200 lines — if CrashLoop)"
+        kubectl logs -n "$NS_WEBMAIL" -l app=roundcube --previous --tail=200 --all-containers=true 2>/dev/null || \
+            echo "  (no previous container — pod did not restart)"
+        exit 1
     fi
 fi
 

--- a/apps/manifests/roundcube/roundcube.yaml.tpl
+++ b/apps/manifests/roundcube/roundcube.yaml.tpl
@@ -237,15 +237,23 @@ spec:
             cpu: "${ROUNDCUBE_CPU_REQUEST}"
           limits:
             memory: "${ROUNDCUBE_MEMORY_LIMIT}"
+        # Probe the app root, NOT a raw skin asset path. Roundcube 1.7 moved the
+        # web docroot to public_html/ and serves all skin/program/plugin assets
+        # through public_html/static.php (e.g. "static.php/skins/mothertree/...").
+        # A raw GET /skins/mothertree/images/logo.svg therefore 404s on 1.7
+        # (it 404s for the built-in elastic skin too) → probe fails → CrashLoop.
+        # GET / returns 200 (the login page) on both 1.6.x and 1.7.x, so it is a
+        # version-stable liveness/readiness signal. The skin still renders via
+        # static.php; e2e covers that the UI actually works.
         livenessProbe:
           httpGet:
-            path: /skins/mothertree/images/logo.svg
+            path: /
             port: 80
           initialDelaySeconds: 30
           periodSeconds: 30
         readinessProbe:
           httpGet:
-            path: /skins/mothertree/images/logo.svg
+            path: /
             port: 80
           initialDelaySeconds: 10
           periodSeconds: 10


### PR DESCRIPTION
## Summary

Fixes the Roundcube **1.7** crashloop that broke `main` after #440 merged. Two changes:

1. **`roundcube.yaml.tpl`** — liveness/readiness probes `GET /skins/mothertree/images/logo.svg` → `GET /`.
2. **`deploy-roundcube.sh`** — on rollout timeout, dump diagnostics and `exit 1` instead of warning + `exit 0`.

This builds on #440 (1.7.x, image `0.3.4`) — merging it turns `main` green **with working 1.7**.

## Root cause

Roundcube **1.7 moved the web docroot to `public_html/`** and now serves all skin/program/plugin assets through `public_html/static.php` (e.g. `static.php/skins/mothertree/images/logo.svg?s=…`). A **raw** `GET /skins/mothertree/images/logo.svg` therefore **404s on 1.7** — verified against the official `roundcube/roundcubemail:1.7.x-apache` image, where it 404s for the built-in `elastic` skin too. Our hardcoded health probe hit that raw path → 404 → kubelet killed the pod → **CrashLoopBackOff**.

`GET /` returns **200** (the login page) on **both 1.6.x and 1.7.x**, so it's a version-stable liveness/readiness signal. The skin still renders — the app generates `static.php/...` URLs for whatever skin is active, which is skin-agnostic; only the raw-path probe was broken.

### Why this slipped through as a green PR (#440 / pipeline 1406)
`deploy-roundcube.sh` ran `kubectl rollout status`, it **timed out** (pod never Ready), but the script only logged `[WARNING] may not be fully ready` and still reported `[SUCCESS]` / `exit 0`. And because it's a 1-replica RollingUpdate where the new pod never went Ready, the **old working 1.6.x replica kept serving**, so e2e "SSO to Roundcube" passed against the *old* pod. The merge pipeline (1408) had no healthy old pod to fall back on, so e2e finally caught it. Change #2 closes that gap (fail-fast per CLAUDE.md) so a broken image can never deploy "successfully" again.

## Verified vs. what CI confirms
- ✅ **Verified locally** against the real 1.7.x image: `GET /` = 200 on 1.7 and 1.6; raw `/skins/...` = 404 on 1.7; docroot is `public_html` (`000-default.conf`); assets serve via `static.php`.
- ⏳ **This PR's e2e (shard-10) confirms** 1.7 *login* works end-to-end — OIDC via `oauth_name`, the session-DB schema migration, and the other custom plugins (`nextcloud_calendar`, `mailvelope_client`, `managesieve`, `keyboard_shortcuts`) under 1.7. The probe fix makes the pod healthy; e2e proves the UI works.

## ⚠️ Merging = the prod 1.7 cutover
On merge, `deploy-prod` runs Roundcube 1.7's **forward-only** `updatedb.sh` against each tenant's **persistent prod** Roundcube DB (`session.changed` → `expires_at`, schema `2025092300`) — **one-way, no rollback without a DB restore**. Prod is currently safe on 1.6.15 (`0.3.3`, untouched — the gate skipped `deploy-prod` on the broken pipeline). No image/portal version bump in this PR (deploy-time manifest/script only).

## OSS Compliance Review
**Verdict: CLEAN** — CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0. No real domains, PII, credentials, private-registry refs, or internal IPs in the staged diff. The only org token is `mothertree` (the theme/skin name — an allowed exception); the manifest uses `${VAR}` substitution and the deploy script uses `$NS_WEBMAIL` + the shared `dump_pod_diagnostics` helper.

## Security Review
**Verdict: APPROVE** — CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0.
- Probing `/` (the unauthenticated login page, already public) discloses nothing new, requires/establishes no session, and isn't expensive; it's a strictly better signal than a static asset (exercises the PHP runtime).
- The diagnostic dump leaks no secrets (verified empirically): all secrets are injected via `secretKeyRef`, so `kubectl describe` renders `<set to the key … in secret …>` placeholders; a simulated DB-connection failure produced a clean PDO error with no DSN/credentials; pod stdout is Apache access logs only. `set +e` + `|| true` guards + explicit `exit 1` are correct.

## Version bump
No portal code or image content changed (deploy-time manifest + script only) — no `admin-portal`/`account-portal` VERSION or `image-versions.env` bump required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
