### PR TITLE
chore(deps): stop pinning Roundcube in Dependabot — upgrade freely

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -135,11 +135,11 @@ updates:
     groups:
       base-images:
         patterns: ["*"]
-    ignore:
-      # Pinned to 1.6.x. 1.7.0 crash-loops in our custom image (entrypoint
-      # re-copies the stock app over our `mothertree` skin → health probe
-      # 404s) and its updatedb.sh forward-migrates the shared dev DB
-      # (session.changed→expires_at), breaking all 1.6.x branches. Remove
-      # when the deliberate 1.7 cutover lands — tracking issue #430.
-      - dependency-name: "roundcube/roundcubemail"
-        versions: [">= 1.7.0"]
+    # Roundcube is intentionally NOT pinned — upgrades (including majors) flow
+    # freely as Dependabot PRs. (Do not re-add an ignore here.) CI catches the
+    # common breakage: deploy-roundcube.sh fails fast if a new image's rollout
+    # doesn't go Ready (e.g. the 1.7 probe crash-loop fixed in #441) and e2e
+    # covers login. Residual risk a per-branch gate can NOT catch: a major bump's
+    # forward-only updatedb.sh migrating the SHARED dev Postgres and breaking
+    # other concurrent old-version branches (the session.changed→expires_at
+    # poison) — review major Roundcube bumps with issue #430 in mind.


### PR DESCRIPTION
## Summary

Removes the Dependabot `ignore` rule that pinned `roundcube/roundcubemail` below 1.7.0. Roundcube is now **intentionally unpinned** — Dependabot will propose future upgrades (including majors) as CI-gated PRs.

The pin existed because 1.7.0 crash-looped our custom image and its `updatedb.sh` poisoned the shared dev DB. The **1.7 cutover has since landed** (#441, on a now-working image), so the pin is obsolete.

## Why this is safe to unpin
- The **deployed image tag stays version-pinned in source** (the Dockerfile `FROM`). This change only widens the bot's *bump-proposal* window — it does not change what's deployed.
- Every bump is a **CI-gated PR**: `deploy-roundcube.sh` now **fails fast** if a new image's rollout doesn't go Ready (the gap that let the broken 1.7 image look "green" before — fixed in #441), and e2e covers login end-to-end.
- Merging is **human-gated** (no Dependabot auto-merge).

## Residual risk (documented inline, flagged for reviewers)
A per-branch readiness/login gate does **not** catch the shared-dev-DB class: a *major* bump whose forward-only `updatedb.sh` migrates the **shared dev Postgres** can silently break other concurrent old-version branches (the `session.changed → expires_at` poison, issue #430). The inline comment calls this out so major Roundcube bumps get reviewed with that in mind.

## OSS Compliance Review
**Verdict: CLEAN** — CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0. Single-file config change; no domains, PII, credentials, private-registry refs, or IPs. (`roundcube/roundcubemail` is a public upstream Docker Hub image; `#430`/`#441` are public issue refs.)

## Security Review
**Verdict: PASS** — CRITICAL 0 / HIGH 0 / MEDIUM 0 / **LOW 1** (informational). Unpinning widens the bump-proposal/supply-chain surface, but it's not the `:latest`/tag-drift class (deployed tag stays pinned in source), and every bump flows through CI fail-fast deploy + e2e login + human merge review (all verified). Config-only change to a proposal filter, not a security control. Not a blocker.

## Version bump
None required — no portal code or image content changed; `.github/dependabot.yml` is CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
