### PR TITLE
fix(ci): auto-recover Woodpecker from queue-zombie jam via cron

### DIFF
--- a/ci/ansible/playbook.yml
+++ b/ci/ansible/playbook.yml
@@ -654,6 +654,30 @@
         job: '/usr/local/bin/cleanup-stale-e2e-users.sh >> /var/log/e2e-cleanup.log 2>&1'
       when: e2e_cleanup_pools is defined
 
+    # ── Woodpecker queue-zombie auto-unjam ─────────────────────────
+    # Self-healing for the recurring queue-backup desync bug (3.14.x/3.15.x):
+    # superseded/cancelled pipelines leave phantom rows in the `tasks` queue
+    # table backed by already-finished workflows, starving all agent slots so
+    # "CI stops starting pipelines." The script acts ONLY on the bug's exact
+    # fingerprint (sustained "resubmitting expired task" loop AND live zombie
+    # task rows) and applies the validated stop->backup->surgical-delete->restart
+    # recovery; it is a silent no-op otherwise. See memory: woodpecker-queue-zombies.
+    - name: Deploy Woodpecker queue auto-unjam script
+      ansible.builtin.template:
+        src: woodpecker-queue-unjam.sh.j2
+        dest: /usr/local/bin/woodpecker-queue-unjam.sh
+        owner: root
+        group: root
+        mode: "0700"
+
+    - name: Schedule Woodpecker queue auto-unjam (cron)
+      # flock -n so a slow recovery tick (stop/restart) never overlaps the next.
+      ansible.builtin.cron:
+        name: "woodpecker-queue-unjam"
+        minute: "*/5"
+        user: root
+        job: 'flock -n /var/lock/woodpecker-queue-unjam /usr/local/bin/woodpecker-queue-unjam.sh >> /var/log/woodpecker-queue-unjam.log 2>&1'
+
     # ── On-demand-dev idle reaper ──────────────────────────────────
     # The reaper destroys the dev LKE cluster after IDLE_HOURS of no CI
     # activity. It runs every 15 minutes via cron, checks the heartbeat object

--- a/ci/ansible/templates/woodpecker-queue-unjam.sh.j2
+++ b/ci/ansible/templates/woodpecker-queue-unjam.sh.j2
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Woodpecker queue-zombie auto-unjam.
+#
+# Mitigates the recurring Woodpecker queue-backup desync bug (seen on 3.14.x and
+# 3.15.x): when a pipeline is superseded/cancelled (Dependabot bursts, force-
+# pushes), rows linger in the `tasks` queue table whose backing `workflows` row
+# has already reached a terminal state. The server then tight-loops
+#   "queue: resubmitting expired task <id>"
+#   "pull queue item: <id>: failed to remove from backup: sql: no rows in result set"
+#   "caught agent performing illegal instruction: workflow was already marked as finished"
+# saturating every agent worker slot with phantom tasks, so NEW pipelines never
+# get scheduled. User-visible symptom: "CI not starting pipelines" (it is — the
+# slots are just starved). Clearing the in-memory queue requires a server
+# restart, not just a DB delete, which is why this does delete + restart.
+#
+# This script detects that exact fingerprint and applies the validated recovery
+# (stop services -> backup DB -> delete ONLY the zombie task rows -> restart),
+# then exits. It is a SAFE no-op in healthy operation: it acts ONLY when BOTH
+# the error-loop journal signature AND live zombie task rows are present, so it
+# never touches a healthy queue with legitimately running work. The delete is
+# surgical and fails SAFE: it removes only tasks whose backing workflow is in a
+# known TERMINAL state (or is missing). Any non-terminal or unrecognised state
+# is preserved — validated against a live running pipeline.
+#
+# Deployed by Ansible, run every 5 minutes via cron under flock.
+# Managed by Ansible — do not edit manually on the CI server.
+# See memory: woodpecker-queue-zombies.
+
+set -euo pipefail
+umask 077   # DB backups are full copies of woodpecker.sqlite (holds CI secrets)
+
+LOG_PREFIX="[wp-unjam]"
+DB="{{ woodpecker_db_path | default('/var/lib/woodpecker/woodpecker.sqlite') }}"
+SERVER_UNIT="woodpecker-server"
+AGENT_UNIT="woodpecker-agent"
+
+# Detection thresholds. The bug produces a relentless loop (~24 resubmits / 2min
+# observed); healthy operation produces zero. Require BOTH signals so we never
+# act on the millisecond race where a task row briefly outlives its just-
+# finished workflow, nor on stale journal lines lingering after a prior unjam.
+LOOP_WINDOW_MIN={{ wp_unjam_loop_window_min | default(10) }}   # journal lookback (min)
+LOOP_THRESHOLD={{ wp_unjam_loop_threshold | default(20) }}     # min "resubmitting expired" lines in window
+ZOMBIE_THRESHOLD={{ wp_unjam_zombie_threshold | default(5) }}  # min zombie task rows to act on
+KEEP_BACKUPS={{ wp_unjam_keep_backups | default(5) }}          # auto-unjam DB backups to retain
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# Self-heal a prior botched recovery: if a unit is `failed` (crashed / failed to
+# start), bring it back before doing anything else. `is-failed` is true only for
+# failed units, NOT for a deliberate `systemctl stop` (which leaves `inactive`),
+# so this won't fight an operator doing maintenance.
+for _unit in "$SERVER_UNIT" "$AGENT_UNIT"; do
+  if systemctl is-failed --quiet "$_unit"; then
+    echo "$(ts) $LOG_PREFIX $_unit is failed — restarting"
+    systemctl restart "$_unit" || echo "$(ts) $LOG_PREFIX WARNING: could not restart $_unit"
+  fi
+done
+
+# A task is a ZOMBIE when no backing workflow is in a non-terminal state — i.e.
+# the workflow is missing, or has reached a TERMINAL state. Terminal states are
+# enumerated explicitly (DELETE allowlist) so any unknown/future or non-terminal
+# state (pending, running, created, blocked, ...) fails SAFE and is preserved.
+# Woodpecker terminal workflow states: success/failure/killed/canceled/error/
+# declined/skipped. tasks.id (TEXT) == workflows.id (INTEGER).
+ZOMBIE_PREDICATE="NOT EXISTS (
+  SELECT 1 FROM workflows w
+  WHERE CAST(w.id AS TEXT) = tasks.id
+    AND w.state NOT IN ('success','failure','killed','canceled','error','declined','skipped'))"
+
+# --- Signal 1: error-loop fingerprint in the server journal ---
+loop_count=$(journalctl -u "$SERVER_UNIT" --since "${LOOP_WINDOW_MIN} min ago" --no-pager 2>/dev/null \
+  | grep -c "resubmitting expired task" || true)
+loop_count=${loop_count:-0}
+
+# --- Signal 2: live zombie task rows ---
+# `.timeout` dot-command (not `PRAGMA busy_timeout`) so it sets the busy timeout
+# silently — a PRAGMA would emit its own result row and corrupt the count.
+zombie_count=$(sqlite3 -cmd ".timeout 5000" "$DB" "SELECT count(*) FROM tasks WHERE ${ZOMBIE_PREDICATE};" 2>/dev/null || echo 0)
+zombie_count=${zombie_count:-0}
+
+# Healthy: stay silent to keep the log clean.
+if [ "$loop_count" -lt "$LOOP_THRESHOLD" ] && [ "$zombie_count" -lt "$ZOMBIE_THRESHOLD" ]; then
+  exit 0
+fi
+
+# Exactly one signal — note it but do NOT act (transient race / stale journal).
+if [ "$loop_count" -lt "$LOOP_THRESHOLD" ] || [ "$zombie_count" -lt "$ZOMBIE_THRESHOLD" ]; then
+  echo "$(ts) $LOG_PREFIX partial signal only (loop=$loop_count/$LOOP_THRESHOLD zombies=$zombie_count/$ZOMBIE_THRESHOLD) — not acting"
+  exit 0
+fi
+
+# --- Both signals present: confirmed queue-zombie jam. Apply recovery. ---
+echo "$(ts) $LOG_PREFIX JAM DETECTED (loop=$loop_count in ${LOOP_WINDOW_MIN}m, zombies=$zombie_count) — applying recovery"
+
+echo "$(ts) $LOG_PREFIX stopping $AGENT_UNIT $SERVER_UNIT"
+systemctl stop "$AGENT_UNIT" "$SERVER_UNIT"
+
+backup="${DB}.bak-autounjam-$(date -u +%Y%m%dT%H%M%SZ)"
+echo "$(ts) $LOG_PREFIX backing up DB -> $backup"
+sqlite3 "$DB" ".backup '$backup'"
+chmod 600 "$backup"
+
+tasks_before=$(sqlite3 "$DB" "SELECT count(*) FROM tasks;" 2>/dev/null || echo '?')
+deleted=$(sqlite3 "$DB" "DELETE FROM tasks WHERE ${ZOMBIE_PREDICATE}; SELECT changes();" 2>/dev/null | tail -1)
+tasks_after=$(sqlite3 "$DB" "SELECT count(*) FROM tasks;" 2>/dev/null || echo '?')
+echo "$(ts) $LOG_PREFIX deleted ${deleted:-?} zombie task row(s) (tasks: $tasks_before -> $tasks_after)"
+
+# Resilient restart: attempt BOTH starts even if one fails, so the single-VM CI
+# host is never left half-down. A failed unit is re-attempted by the self-heal
+# block at the top of the next tick.
+echo "$(ts) $LOG_PREFIX restarting $SERVER_UNIT then $AGENT_UNIT"
+set +e
+systemctl start "$SERVER_UNIT"; srv_rc=$?
+sleep 4
+systemctl start "$AGENT_UNIT"; agt_rc=$?
+set -e
+if [ "$srv_rc" -ne 0 ] || [ "$agt_rc" -ne 0 ]; then
+  echo "$(ts) $LOG_PREFIX WARNING: start rc server=$srv_rc agent=$agt_rc — will self-heal next tick"
+fi
+
+# Prune old auto-unjam backups (keep newest $KEEP_BACKUPS).
+mapfile -t _old < <(ls -1t "${DB}".bak-autounjam-* 2>/dev/null | tail -n +$((KEEP_BACKUPS + 1)) || true)
+if [ "${#_old[@]}" -gt 0 ]; then
+  rm -f "${_old[@]}"
+  echo "$(ts) $LOG_PREFIX pruned ${#_old[@]} old backup(s)"
+fi
+
+echo "$(ts) $LOG_PREFIX recovery complete"


### PR DESCRIPTION
## Problem

The Woodpecker queue-backup desync bug (present on 3.14.x and 3.15.x) has jammed CI **three times** (twice on 2026-05-30, again 2026-06-04). When a pipeline is superseded/cancelled (Dependabot bursts, force-pushes), rows linger in the `tasks` queue table whose backing `workflows` row has already reached a terminal state. The server then tight-loops:

```
queue: resubmitting expired task <id>
pull queue item: <id>: failed to remove from backup: sql: no rows in result set
caught agent performing illegal instruction: workflow was already marked as finished
```

…saturating every agent worker slot with phantom tasks, so new pipelines never get scheduled. User-visible symptom: **"CI not starting pipelines"** (it is — the slots are just starved). The latest incident showed 71 phantom task rows starving all 7 workers. Clearing it requires a server restart (to flush the in-memory queue), not just a DB delete — which is why manual recovery has been the only fix so far.

## Fix

A guarded self-healing cron on the CI host (`*/5`, under `flock`), deployed via `ci/ansible/`:

- **Acts ONLY on the bug's exact fingerprint** — a dual-signal guard requiring BOTH a sustained `resubmitting expired task` server-journal loop (≥20 in 10 min) AND live zombie task rows (≥5). Healthy operation produces zero of either, so it's a silent no-op. The dual guard also prevents post-recovery oscillation (stale journal lines linger after a restart, but zombies drop to 0).
- **Validated recovery**: stop agent+server → back up the SQLite DB → surgically delete only zombie rows → restart server then agent → prune to newest 5 backups.
- **Fail-safe delete**: a task is a zombie only when its backing workflow is in a known *terminal* state (`success/failure/killed/canceled/error/declined/skipped`) or is missing. Any non-terminal or unrecognised state (`pending/running/created/blocked/`future) is **preserved**. Empirically validated against a live DB copy: `blocked`/`created` tasks preserved, terminal-backed + orphan tasks deleted, in-flight pipeline tasks untouched.
- **Hardening**: self-heal a unit left `failed` by a botched restart; resilient dual-start so the single-VM host is never left half-down; `umask 077` + `chmod 600` on DB backups (full copies of `woodpecker.sqlite`, which holds CI secrets).

Already front-installed on the CI box (with the exact `#Ansible:` cron marker, so the next provision is idempotent) to restore protection immediately; this PR makes it durable.

> Follow-up (not in this PR): reduce supersede pressure (stagger Dependabot / cap concurrent PR pipelines / consider disabling auto-cancel) and file the desync bug upstream — 3 recurrences qualifies as "frequent."

## OSS Compliance Review

**VERDICT: CLEAN** (CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0). No real tenant domains, personal info, hardcoded credentials, private registry references, or internal IPs/hostnames. All identifiers (systemd unit names, `/var/lib/woodpecker/` paths, the `template`+`cron` task pattern) already exist in the public repo at HEAD; the script is a generic recovery tool for a public upstream bug.

## Security Review

Initial review found **1 HIGH + 2 MEDIUM**, all fixed and re-verified clean (final: CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0):

- **HIGH (fixed)** — DELETE predicate was a fragile *preserve-denylist* that omitted the valid non-terminal states `blocked`/`created` and included a non-existent `started`, risking deletion of legitimate dependency-gated queued work during a jam. Inverted to an explicit *terminal-or-missing delete allowlist* so any unknown/future state fails **safe** (preserved). Re-verified against synthetic states including an unknown future state.
- **MEDIUM (fixed)** — restart-failure availability gap: added top-of-run self-heal of `failed` units (won't fight a deliberate `inactive` stop) + resilient dual-start in the recovery path.
- **MEDIUM (fixed)** — DB backups could be world-readable: added `umask 077` + explicit `chmod 600`.

Verified clean: correct `tasks.id`↔`workflows.id` join (confirmed against Woodpecker source), stop-before-delete quiescing (no TOCTOU), no shell/SQL injection (no untrusted input; SQL is a fixed predicate), `flock`-serialised, mode `0700` root, no secret exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)