### PR TITLE
fix(keycloak): cap offline session max lifespan so Roundcube 1.7 stops logging users out

### DIFF
--- a/docs/keycloak-realm-config.json.tpl
+++ b/docs/keycloak-realm-config.json.tpl
@@ -16,6 +16,7 @@
   "ssoSessionMaxLifespanRememberMe": 2592000,
   "offlineSessionIdleTimeout": 2592000,
   "offlineSessionMaxLifespan": 2592000,
+  "offlineSessionMaxLifespanEnabled": true,
   "webAuthnPolicyPasswordlessRpEntityName": "${TENANT_DISPLAY_NAME}",
   "webAuthnPolicyPasswordlessSignatureAlgorithms": ["ES256", "RS256"],
   "webAuthnPolicyPasswordlessRpId": "${EMAIL_DOMAIN}",


### PR DESCRIPTION
## Problem

Since the Roundcube **1.7** cutover (prod, 2026-06-04), webmail users are logged out of previously long-running sessions every **~6 minutes**. Loki shows a machine-regular loop: user sits in inbox → `GET /?_task=login&_err=session` (302) → `GET /index.php/login/oauth?...code=...` (Keycloak SSO bounces them straight back). Keycloak's SSO session is stable across every bounce — **Roundcube is killing its own session.**

## Root cause

A Roundcube 1.7 OAuth bug in `program/include/rcmail_oauth.php`:

```php
// parse_tokens() — uses isset(), so 0 is treated as a real value
if (isset($data['refresh_expires_in'])) {
    $data['refresh_expires'] = time() + $data['refresh_expires_in'];   // = now + 0 = now
}
// check_token_validity() — fires once the 300s access token lapses
if (isset($token['refresh_expires']) && $token['refresh_expires'] < time()) {
    $this->rcmail->kill_session();
}
```

Keycloak returns **`refresh_expires_in: 0`** for **offline tokens** (the OIDC convention for "never expires") — which is exactly what the platform requests via `offline_access` for 30-day webmail sessions. Roundcube misreads `0` as "expired at issuance" and kills the session when the 5-minute access token expires. Roundcube **1.6 had no such enforcement**, so sessions lived the full `session_lifetime` (30 days) — hence the regression. The bug is **still present in Roundcube `master`**, so a version bump does not fix it.

### Evidence (prod, realm `docs`)
- Decoded a live authenticated session: `scope=…offline_access…`, `expires_in=300`, **`refresh_expires_in=0`**, `computed refresh_expires == created_at` (already "expired").
- Realm: `accessTokenLifespan=300`, `offlineSessionIdleTimeout=offlineSessionMaxLifespan=2592000` (30d), but `offlineSessionMaxLifespanEnabled=false` → that's why Keycloak reports `refresh_expires_in=0`.

## Fix

Enable `offlineSessionMaxLifespanEnabled` on the realm. With it on, Keycloak returns a **non-zero** `refresh_expires_in` (remaining offline max lifespan, up to the existing 30-day `offlineSessionMaxLifespan`) instead of `0`, so Roundcube computes a valid future expiry and refreshes normally. Sessions last ~30 days again, now with a hard 30-day cap on offline tokens (a tightening).

This template change persists the toggle so `docs/import-keycloak-realm.sh` (which PUTs the full realm template on every deploy) doesn't revert it. Applies to all tenants on next `create_env` (they share this template and the same Roundcube 1.7 setup).

## Verification (applied live in prod before this PR)
- Toggled `offlineSessionMaxLifespanEnabled=true` on realm `docs` live.
- The every-6-min `_err=session` re-login loop **stopped**; a post-toggle session survived **>9 min** with no forced re-login.
- Freshly minted sessions now carry **`refresh_expires_in ≈ 2591584`** (was `0`), `refresh_expires` ~30 days out.
- Cleaned up ~21.7k empty orphan session rows accrued during the loop.

## OSS Compliance Review
CLEAN — 0 findings. Single boolean realm flag; no domains, PII, credentials, or private registry references; `${VARIABLE}` placeholders intact.

## Security Review
APPROVE — 0 findings. Bounds a previously-unbounded offline/refresh token to a hard 30-day lifetime (a security improvement). Per-realm policy flag; no auth-bypass, network, TLS, RBAC, or tenant/realm-isolation surface affected. JSON well-formed; values internally consistent (idle == max == 2592000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)