### PR TITLE
fix(ci): make nextcloud version-check --update exit 0 on success

### DIFF
--- a/scripts/check-nextcloud-app-versions.sh
+++ b/scripts/check-nextcloud-app-versions.sh
@@ -118,6 +118,10 @@ with open(manifest_path, 'w') as f:
 
 print('Manifest updated successfully')
 PYEOF
+    # The update we were asked to perform succeeded. Exit 2 means "updates
+    # pending" — that's the check-mode contract, not an error here. Reporting
+    # success keeps the CI step (which runs under `bash -e`) from failing.
+    exit 0
 elif [ "$RESULT_EXIT" -eq 2 ]; then
     echo ""
     echo "Run with --update to update the manifest file"


### PR DESCRIPTION
## Summary

The weekly **Nextcloud App Version Check** workflow ([example failing run](https://github.com/mothertree-labs/mothertree-oss/actions/runs/27345878514/job/80794276306)) fails every time updates are actually found — so the automation it exists for (opening an app-update PR) never runs.

### Root cause

`scripts/check-nextcloud-app-versions.sh` uses **exit code 2 as its "updates pending" signal**. It returned `2` even in `--update` mode, *after* successfully rewriting the manifest:

```bash
exit "${RESULT_EXIT}"   # RESULT_EXIT=2 when updates were found
```

The workflow's `Update manifest` step runs `./scripts/check-nextcloud-app-versions.sh --update` under GitHub Actions' default `bash -e` shell. The exit-2 failed the step → the job went red → the downstream `Create PR` step (gated on `if: steps.check.outputs.exit_code == '2'`, which carries an implicit `success()`) was **skipped**. Net effect: updates were detected and the manifest was written, but **no PR was ever created**. This is deterministic on any week with updates available; it only "passes" when everything is already up to date.

### Fix

In `--update` mode, `exit 0` after a successful manifest write. Exit-2-means-"changes pending" is the *check-mode* contract; once `--update` has applied the changes, the requested work succeeded. The `Create PR` step keys off the **check** step's captured exit code (not the update step's), so this has no downside.

`set -e` is active when the manifest-write block runs, so a genuine write failure still aborts before reaching the new `exit 0` — real errors are not masked.

## Test plan

- [x] `bash -n` syntax check passes
- [ ] Next scheduled (or `workflow_dispatch`) run opens an update PR instead of failing

## OSS Compliance Review

**Verdict: CLEAN.** 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW. No tenant domains, personal info, credentials, or private registry references. Only the tracked `.sh` script is staged; the unrelated `config/platform` submodule edit was excluded.

## Security Review

**Verdict: APPROVE — clean.** 0 findings. The new `exit 0` cannot mask a real error: it sits inside the `RESULT_EXIT -eq 2 && UPDATE_MODE = true` branch, after a `python3` write block that runs under active `set -e`, so any write/parse failure aborts before reaching it. The check-mode contract (`set +e`, explicit `$?` capture, `exit_code == '2'` gating) is untouched. No secrets, injection, or fail-fast violations — it suppresses a *false* failure signal while leaving real failure propagation intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)