### PR TITLE
chore(nextcloud): update app versions

### DIFF
--- a/apps/manifests/nextcloud/app-versions.json
+++ b/apps/manifests/nextcloud/app-versions.json
@@ -2,28 +2,28 @@
   "platform_version": "32.0.5",
   "apps": {
     "user_oidc": {
-      "version": "8.6.1",
-      "url": "https://github.com/nextcloud-releases/user_oidc/releases/download/v8.6.1/user_oidc-v8.6.1.tar.gz"
+      "version": "8.9.0",
+      "url": "https://github.com/nextcloud-releases/user_oidc/releases/download/v8.9.0/user_oidc-v8.9.0.tar.gz"
     },
     "calendar": {
-      "version": "6.2.1",
-      "url": "https://github.com/nextcloud-releases/calendar/releases/download/v6.2.1/calendar-v6.2.1.tar.gz"
+      "version": "6.4.2",
+      "url": "https://github.com/nextcloud-releases/calendar/releases/download/v6.4.2/calendar-v6.4.2.tar.gz"
     },
     "richdocuments": {
-      "version": "9.0.3",
-      "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v9.0.3/richdocuments-v9.0.3.tar.gz"
+      "version": "9.1.0",
+      "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v9.1.0/richdocuments-v9.1.0.tar.gz"
     },
     "external": {
-      "version": "7.0.0",
-      "url": "https://github.com/nextcloud-releases/external/releases/download/v7.0.0/external-v7.0.0.tar.gz"
+      "version": "7.0.1",
+      "url": "https://github.com/nextcloud-releases/external/releases/download/v7.0.1/external-v7.0.1.tar.gz"
     },
     "notify_push": {
-      "version": "1.3.1",
-      "url": "https://github.com/nextcloud-releases/notify_push/releases/download/v1.3.1/notify_push-v1.3.1.tar.gz"
+      "version": "1.3.3",
+      "url": "https://github.com/nextcloud-releases/notify_push/releases/download/v1.3.3/notify_push-v1.3.3.tar.gz"
     },
     "integration_google": {
-      "version": "4.3.0",
-      "url": "https://github.com/nextcloud-releases/integration_google/releases/download/v4.3.0/integration_google-v4.3.0.tar.gz"
+      "version": "4.4.0",
+      "url": "https://github.com/nextcloud-releases/integration_google/releases/download/v4.4.0/integration_google-v4.4.0.tar.gz"
     }
   }
 }


### PR DESCRIPTION
Automated weekly check found new compatible versions.

Changes:
calendar: 6.2.1 -> 6.4.2
external: 7.0.0 -> 7.0.1
integration_google: 4.3.0 -> 4.4.0
notify_push: 1.3.1 -> 1.3.3
richdocuments: 9.0.3 -> 9.1.0
user_oidc: 8.6.1 -> 8.9.0