### PR TITLE
fix(ci): provision fixed e2e mail principals in Stalwart at deploy

### DIFF
--- a/.woodpecker/deploy-dev-finalize.yaml
+++ b/.woodpecker/deploy-dev-finalize.yaml
@@ -79,6 +79,13 @@ steps:
         from_secret: e2e_pool2_kc_realm
       E2E_POOL2_KC_CLIENT_SECRET:
         from_secret: e2e_pool2_kc_client_secret
+      # Needed to deploy-provision the fixed mail users' Stalwart mailbox
+      # principals (e2e-mailrt/e2e-mailrcv) so inbound round-trip mail doesn't
+      # 550-bounce before the user's first login. See ci-create-test-users.sh.
+      E2E_POOL1_STALWART_ADMIN_PASSWORD:
+        from_secret: e2e_pool1_stalwart_admin_password
+      E2E_POOL2_STALWART_ADMIN_PASSWORD:
+        from_secret: e2e_pool2_stalwart_admin_password
     commands:
       - ci/scripts/ci-create-test-users.sh
 

--- a/ci/scripts/ci-create-test-users.sh
+++ b/ci/scripts/ci-create-test-users.sh
@@ -51,6 +51,7 @@ resolve_var E2E_TENANT
 resolve_var E2E_BASE_DOMAIN
 resolve_var E2E_KC_REALM
 resolve_var E2E_KC_CLIENT_SECRET
+resolve_var E2E_STALWART_ADMIN_PASSWORD
 
 if [[ -z "${E2E_BASE_DOMAIN:-}" ]]; then
   echo "WARNING: E2E_BASE_DOMAIN not resolved — skipping user creation"
@@ -323,6 +324,108 @@ for user_spec in "${FIXED_USERS[@]}"; do
   IFS=: read -r username password is_admin <<< "$user_spec"
   create_user "$username" "$password" "$is_admin"
 done
+
+# ── Provision the fixed mail users' Stalwart mailbox principals ───────────────
+# Keycloak account != deliverable mailbox. Under Stalwart's OIDC directory the
+# mailbox principal is otherwise created ONLY on the user's first Roundcube
+# login, so inbound mail (e.g. the echoed reply in the email round-trip test)
+# bounces 550 "undeliverable" until then. The round-trip test sends *before* the
+# receiver has logged in, so on a freshly leased tenant it loses that race and
+# times out. Deploy-provisioning the mailbox here (the same /api/principal/deploy
+# call dev-test-users.sh / provision-smtp.js use) removes the race.
+# See memory: e2e-roundtrip-missing-principals. NOTE: this fixes the *delivery*
+# (550) cause of the shard-5 flake only — the bare networkidle login in
+# email-roundtrip.spec.ts is a separate, still-open cause.
+if [[ -z "${E2E_STALWART_ADMIN_PASSWORD:-}" ]]; then
+  echo ""
+  echo "WARNING: E2E_STALWART_ADMIN_PASSWORD not resolved for pool '${LEASED_POOL}' —"
+  echo "         skipping Stalwart mailbox provisioning. The email round-trip test"
+  echo "         (shard-5) will 550-bounce until first login. Wire the"
+  echo "         e2e_pool*_stalwart_admin_password secret into the create-test-users step."
+else
+  STALWART_NS="tn-${E2E_TENANT}-mail"
+  STALWART_URL="http://localhost:18090"
+  STALWART_AUTH="Basic $(printf 'admin:%s' "$E2E_STALWART_ADMIN_PASSWORD" | base64 | tr -d '\n')"
+  echo ""
+  echo "--- Provisioning Stalwart mailbox principals in ${STALWART_NS}"
+
+  # Port-forward to the tenant's Stalwart REST API (8080). KUBECONFIG is the live
+  # dev kubeconfig fetched above; tear the forward down on exit with the kubeconfig.
+  kubectl -n "$STALWART_NS" port-forward svc/stalwart 18090:8080 \
+    > /tmp/ci-stalwart-pf.log 2>&1 &
+  STALWART_PF_PID=$!
+  trap 'rm -f "$KCFG_PATH"; kill "${STALWART_PF_PID:-}" 2>/dev/null || true' EXIT
+
+  # Wait for the forward + REST API to actually answer before provisioning — a
+  # fixed sleep races the forward coming up, which would time out every call.
+  STALWART_READY=0
+  for _ in $(seq 1 20); do
+    if curl -s --max-time 3 -o /dev/null "${STALWART_URL}/api/principal/__probe__" \
+         -H "Authorization: ${STALWART_AUTH}" 2>/dev/null; then
+      STALWART_READY=1; break
+    fi
+    sleep 1
+  done
+
+  if [[ "$STALWART_READY" == 0 ]]; then
+    echo "  WARNING: Stalwart REST API not reachable via port-forward within 20s —"
+    echo "           skipping mailbox provisioning (round-trip may bounce until first login)."
+  else
+    for user_spec in "${FIXED_USERS[@]}"; do
+      IFS=: read -r username _password _is_admin <<< "$user_spec"
+      email="${username}@${EMAIL_DOMAIN}"
+      # Principal name = username (no domain), matching Stalwart's OIDC
+      # auto-provisioner (which names principals from the token preferred_username).
+      payload=$(CI_NAME="$username" CI_EMAIL="$email" python3 -c "
+import json, os
+print(json.dumps({
+  'type': 'individual',
+  'name': os.environ['CI_NAME'],
+  'emails': [os.environ['CI_EMAIL']],
+  'description': os.environ['CI_NAME'],
+  'roles': ['user'],
+  'secrets': []
+}))")
+
+      echo -n "  ${username}: "
+      provisioned=0
+      verdict=""
+      for attempt in 1 2 3; do
+        # /api/principal/deploy has been observed to hang (17/30 calls >120s in a
+        # prior run); cap each attempt and retry instead of blocking the pipeline.
+        resp=$(curl -s --max-time 30 -X POST "${STALWART_URL}/api/principal/deploy" \
+          -H "Authorization: ${STALWART_AUTH}" \
+          -H "Content-Type: application/json" \
+          -d "$payload" 2>/dev/null || true)
+        verdict=$(STALW_RESP="${resp}" python3 -c "
+import json, os
+raw = os.environ.get('STALW_RESP', '')
+try:
+    d = json.loads(raw)
+except Exception:
+    print('timeout'); raise SystemExit
+err = d.get('error') if isinstance(d, dict) else None
+print('ok' if err in (None, 'fieldAlreadyExists') else 'apierror:' + str(err))" 2>/dev/null || echo timeout)
+        case "$verdict" in
+          ok) echo "ok"; provisioned=1; break ;;
+          apierror:*) echo "Stalwart rejected (${verdict#apierror:})"; break ;;
+          *) echo -n "timeout(${attempt}) "; sleep 3 ;;
+        esac
+      done
+      if [[ "$provisioned" == 0 && "$verdict" == "timeout" ]]; then
+        echo "FAILED after retries — round-trip will bounce until first login"
+      fi
+    done
+
+    # Clear Stalwart's negative-RCPT cache so the new mailboxes accept mail now.
+    # (dev-test-users.sh uses GET /api/reload; the e2e shards also start minutes
+    # later, after any short negative-cache TTL would have lapsed anyway.)
+    curl -s --max-time 15 "${STALWART_URL}/api/reload" \
+      -H "Authorization: ${STALWART_AUTH}" > /dev/null 2>&1 || true
+  fi
+
+  kill "${STALWART_PF_PID:-}" 2>/dev/null || true
+fi
 
 echo ""
 echo "Test users created."


### PR DESCRIPTION
## Problem

The email round-trip test (**e2e shard-5**, `tests/email/email-roundtrip.spec.ts`) intermittently times out waiting for the echoed reply in the receiver's inbox. Root cause: under Stalwart's OIDC directory, a mailbox **principal is created only on the user's first Roundcube login**. The round-trip test *sends before* the receiver (`e2e-mailrcv`) has logged in, so on a freshly-leased tenant the echoed reply hits Stalwart before the mailbox exists and **`550`-bounces** — the receiver never gets it.

`ci-create-test-users.sh` created `e2e-mailrt`/`e2e-mailrcv` **in Keycloak only**; nothing deploy-provisioned their Stalwart mailbox. (Diagnosis confirmed against the external echo server's mail log: `dev.mother-tree.org` delivered `250`, the other pool tenant bounced `550 undeliverable` for both fixed users.)

## Change

- **`ci/scripts/ci-create-test-users.sh`** — after the Keycloak `FIXED_USERS` loop, deploy-provision the mailboxes for the leased tenant: port-forward to `svc/stalwart` in `tn-${E2E_TENANT}-mail`, **poll the REST API until it answers** (no fixed-sleep race), `POST /api/principal/deploy` for both fixed mail users (idempotent — `fieldAlreadyExists` treated as success; `--max-time 30` + 3 retries for the known `/deploy` hang), then `GET /api/reload` to flush the negative-RCPT cache. **Non-fatal and loud** on any failure (missing secret / unreachable API / exhausted retries each print a clear `WARNING`/`FAILED`). Reuses the exact mechanism in `dev-test-users.sh` / `provision-smtp.js`.
- **`.woodpecker/deploy-dev-finalize.yaml`** — wire `e2e_pool{1,2}_stalwart_admin_password` into the `create-test-users` step (it didn't have them).

## Scope / caveat

This fixes the **`550`/delivery** cause only. shard-5 also has a separate, still-open cause: a bare `waitForLoadState('networkidle')` login in `email-roundtrip.spec.ts:23` (the robust `navigateToRoundcube()` race pattern in `roundcube-basic.ts` avoids it). Left as a follow-up — **do not treat shard-5 as fully green on this PR alone.**

## Verification

- [ ] CI `create-test-users` log shows `e2e-mailrt: ok` / `e2e-mailrcv: ok`
- [ ] e2e shard-5 (email round-trip) passes
- [ ] (gold standard, fast-follow) live check: provision `e2e-mailrcv` on a fresh tenant, send one mail, confirm `250` not `550`

## OSS Compliance Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0** — clean. Change is entirely env-var/secret-driven: no literal domains, email addresses, credential values, registry references, or personal info. The Stalwart admin password is consumed only via `$E2E_STALWART_ADMIN_PASSWORD` (pool-keyed `resolve_var`); namespace/domain are templated from `e2e_pool*_*` secrets.

## Security Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0** — clean. Admin password is base64'd into a Basic-auth header and **never echoed, written to a file, placed in a cleartext arg, or logged** (no `set -x`; the port-forward log captures only `kubectl` output). `tr -d '\n'` prevents header corruption. JSON payloads/responses are handled via `python3` + env vars (`CI_NAME`/`CI_EMAIL`/`STALW_RESP`) — no shell/JSON injection; inputs come from the hardcoded `FIXED_USERS` array. Transport is localhost over a `kubectl port-forward` tunnel. Non-fatal error handling is intentional and bypasses no security control. EXIT trap preserves kubeconfig temp-file cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)