### PR TITLE
feat(dns): external-DNS tenant enablement — cert-renewal fix, lb1.prod un-proxy, HTTP-01 multi-SAN TLS

### DIFF
--- a/apps/deploy-matrix.sh
+++ b/apps/deploy-matrix.sh
@@ -253,7 +253,12 @@ print_status "Synapse Admin deployed to https://$SYNAPSE_ADMIN_HOST"
 # =============================================================================
 # Matrix federation .well-known (prod only)
 # =============================================================================
-if [ -z "$TENANT_ENV_DNS_LABEL" ] || [ "$TENANT_ENV_DNS_LABEL" = "null" ]; then
+if [ "${DNS_EXTERNAL:-false}" = "true" ]; then
+  # The tenant owns its apex (their own website lives there) and we have no cert
+  # for it; an internal-only homeserver needs no federation .well-known delegation.
+  # Clients reach the HS directly at $MATRIX_HOST via Element's server config.
+  print_status "Skipping Matrix .well-known apex ingress (dns_external=true — tenant owns the apex)"
+elif [ -z "$TENANT_ENV_DNS_LABEL" ] || [ "$TENANT_ENV_DNS_LABEL" = "null" ]; then
   print_status "Deploying Matrix .well-known ingress for federation on $TENANT_DOMAIN..."
   envsubst < "$REPO_ROOT/apps/manifests/synapse-admin/matrix-wellknown.yaml.tpl" | kubectl apply -f -
   print_status "Matrix federation .well-known endpoints available at https://$TENANT_DOMAIN/.well-known/matrix/*"

--- a/apps/manifests/cert-manager/clusterissuer-http01.yaml.tpl
+++ b/apps/manifests/cert-manager/clusterissuer-http01.yaml.tpl
@@ -11,4 +11,10 @@ spec:
     solvers:
       - http01:
           ingress:
-            class: nginx
+            # Must be ingressClassName, NOT the legacy `class:` field. cert-manager
+            # >=1.12 maps `class:` to the deprecated kubernetes.io/ingress.class
+            # annotation, which our ingress-nginx (watching ingressClassName) ignores
+            # — the ACME solver Ingress then gets no backend and the self-check / LE
+            # fetch returns 404, deadlocking every HTTP-01 challenge. Validated on
+            # cert-manager v1.13.3 against the prod-eu ingress 2026-06-13.
+            ingressClassName: nginx

--- a/apps/manifests/wildcard/certificate-http01.yaml.tpl
+++ b/apps/manifests/wildcard/certificate-http01.yaml.tpl
@@ -1,0 +1,41 @@
+# Per-tenant TLS for externally-managed-DNS tenants (dns_external=true).
+#
+# We have no Cloudflare API access to the tenant's own zone, so DNS-01 (and thus
+# a wildcard cert) is impossible. Instead we issue ONE multi-SAN certificate via
+# the shared HTTP-01 ClusterIssuer (letsencrypt-prod) over the explicit list of
+# public, tenant-facing service hosts, and write it to the SAME secret name the
+# ingresses already reference (wildcard-tls-${TENANT_NAME}, reflected to every
+# tenant namespace) — so no ingress manifest has to change.
+#
+# Excluded by design:
+#   - the bare apex (.well-known) — the tenant's apex is their own website, and
+#     internal-only tenants don't need federation .well-known.
+#   - internal/operator-only hosts (e.g. synapse-admin) — not publicly reachable,
+#     so HTTP-01 (which needs LE to fetch /.well-known/acme-challenge over :80)
+#     cannot validate them, and HTTP-01 is all-or-nothing across SANs.
+#
+# Required environment variables:
+#   TENANT_NAME       - Tenant name
+#   NS_MATRIX         - Namespace where the Certificate + secret live
+#   TENANT_NAMESPACES - Comma-separated target namespaces for reflector mirroring
+#   CERT_SAN_LINES    - Pre-rendered YAML list items (one `    - "host"` per line),
+#                       built by create_env from the enabled public service hosts.
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-tls
+  namespace: ${NS_MATRIX}
+spec:
+  secretName: wildcard-tls-${TENANT_NAME}
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+${CERT_SAN_LINES}
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "${TENANT_NAMESPACES}"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "${TENANT_NAMESPACES}"

--- a/scripts/create_env
+++ b/scripts/create_env
@@ -191,6 +191,27 @@ fi
 export CLOUDFLARE_API_TOKEN="$TF_VAR_cloudflare_api_token"
 export TLS_EMAIL="$TF_VAR_tls_email"
 
+# Tenants whose DNS lives under the infra domain (i.e. TENANT_DOMAIN is a subdomain
+# of INFRA_DOMAIN) carry no Cloudflare credentials of their own — their records live
+# in the infra-owned parent zone. Without a token the per-tenant DNS-01 ClusterIssuer
+# is created
+# credential-less, so every ACME challenge fails with "no Cloudflare credential has
+# been given" and the cert silently deadlocks Ready=False until it expires. Fall back
+# to the infra zone token (deployed by deploy_infra into $NS_CERTMANAGER) for these
+# tenants. [ "$X" != "${X%suffix}" ] is true iff $X ends with suffix (POSIX-safe).
+if [ -z "${CLOUDFLARE_API_TOKEN}" ] && [ -n "${INFRA_DOMAIN:-}" ] && \
+   [ "${TENANT_DOMAIN}" != "${TENANT_DOMAIN%".${INFRA_DOMAIN}"}" ]; then
+  CLOUDFLARE_API_TOKEN="$(kubectl get secret cloudflare-api-token -n "$NS_CERTMANAGER" \
+    -o jsonpath='{.data.api-token}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+  if [ -n "$CLOUDFLARE_API_TOKEN" ]; then
+    print_status "Cloudflare token: tenant has none; using infra zone token for ${TENANT_DOMAIN} (under ${INFRA_DOMAIN})"
+  fi
+  export CLOUDFLARE_API_TOKEN
+fi
+
+# Fail fast rather than render an empty token Secret → credential-less DNS-01 issuer.
+: "${CLOUDFLARE_API_TOKEN:?No Cloudflare API token for DNS-01 (tenant '$TENANT_NAME' has none and infra secret cloudflare-api-token in '$NS_CERTMANAGER' is empty/missing). Refusing to deploy a credential-less issuer.}"
+
 print_status "Wildcard domains: external=$WILDCARD_DOMAIN_EXTERNAL, internal=$WILDCARD_DOMAIN_INTERNAL"
 print_status "Reflector target namespaces: $TENANT_NAMESPACES"
 

--- a/scripts/create_env
+++ b/scripts/create_env
@@ -187,6 +187,51 @@ if [ "$OFFICE_ENABLED" = "true" ]; then
   export TENANT_NAMESPACES="${TENANT_NAMESPACES},${NS_OFFICE}"
 fi
 
+if [ "${DNS_EXTERNAL:-false}" = "true" ]; then
+  # =========================================================================
+  # External-DNS tenant: multi-SAN HTTP-01 certificate (no Cloudflare access)
+  # =========================================================================
+  # We can't DNS-01 a zone we don't control (no wildcard possible). Issue ONE
+  # multi-SAN cert via the shared letsencrypt-prod HTTP-01 issuer over the
+  # enabled public service hosts, into the SAME secret the ingresses already
+  # reference (wildcard-tls-${TENANT_NAME}, reflected) -> no ingress changes.
+  # Internal/operator hosts and the bare apex are excluded by design (they are
+  # not publicly reachable for HTTP-01 / the apex is the tenant's own website).
+  print_status "Deploying HTTP-01 multi-SAN TLS certificate for $TENANT_NAME (dns_external=true)..."
+
+  # Build the SAN list from enabled, publicly-reachable services. HTTP-01 is
+  # all-or-nothing across SANs, so every included host's CNAME must resolve to us.
+  CERT_SAN_LINES=""
+  [ "$MATRIX_ENABLED" = "true" ]         && CERT_SAN_LINES+="    - \"${MATRIX_HOST}\""$'\n'
+  CERT_SAN_LINES+="    - \"${AUTH_HOST}\""$'\n'
+  [ "$JITSI_ENABLED" = "true" ]          && CERT_SAN_LINES+="    - \"${JITSI_HOST}\""$'\n'
+  [ "$DOCS_ENABLED" = "true" ]           && CERT_SAN_LINES+="    - \"${DOCS_HOST}\""$'\n'
+  [ "$FILES_ENABLED" = "true" ]          && CERT_SAN_LINES+="    - \"${FILES_HOST}\""$'\n'
+  [ "$CALENDAR_ENABLED" = "true" ]       && CERT_SAN_LINES+="    - \"${CALENDAR_HOST}\""$'\n'
+  [ "$OFFICE_ENABLED" = "true" ]         && CERT_SAN_LINES+="    - \"${OFFICE_HOST}\""$'\n'
+  [ "$ADMIN_PORTAL_ENABLED" = "true" ]   && CERT_SAN_LINES+="    - \"${ADMIN_HOST}\""$'\n'
+  [ "$ACCOUNT_PORTAL_ENABLED" = "true" ] && CERT_SAN_LINES+="    - \"${ACCOUNT_HOST}\""$'\n'
+  export CERT_SAN_LINES
+  print_status "HTTP-01 certificate SANs:"
+  printf '%s' "$CERT_SAN_LINES"
+
+  # Remove any pre-existing DNS-01 wildcard/apex Certificates so they don't fight
+  # over the shared wildcard-tls-${TENANT_NAME} secret (e.g. a tenant that moved
+  # from in-zone to external DNS). Safe no-op when absent.
+  kubectl delete certificate wildcard-tls apex-tls -n "$NS_MATRIX" --ignore-not-found 2>/dev/null || true
+
+  envsubst < "$REPO_ROOT/apps/manifests/wildcard/certificate-http01.yaml.tpl" | kubectl apply -f -
+  print_status "HTTP-01 certificate applied; waiting for issuance (up to 300s)..."
+  if kubectl wait --for=condition=Ready certificate/wildcard-tls -n "$NS_MATRIX" --timeout=300s 2>/dev/null; then
+    print_success "wildcard-tls (HTTP-01 multi-SAN) is ready"
+  else
+    print_warning "wildcard-tls (HTTP-01) not ready after 300s"
+    print_warning "  HTTP-01 is all-or-nothing: confirm every SAN host's CNAME resolves to our ingress."
+    print_warning "  Debug: kubectl describe certificate wildcard-tls -n $NS_MATRIX ; kubectl get challenge -n $NS_MATRIX"
+    print_warning "Continuing — ingresses will serve the cert once issued."
+  fi
+else
+
 # Export Cloudflare token and TLS email for the certificate template
 export CLOUDFLARE_API_TOKEN="$TF_VAR_cloudflare_api_token"
 export TLS_EMAIL="$TF_VAR_tls_email"
@@ -296,6 +341,7 @@ fi
 # certs with comfortable life left; no-op on prod / when the cert isn't ready.
 "$REPO_ROOT/scripts/dev-cert-cache.sh" backup "$NS_MATRIX" "$TENANT_NAME" \
   || print_warning "dev-cert-cache backup skipped (non-fatal)"
+fi  # end DNS_EXTERNAL cert branch (HTTP-01 multi-SAN vs DNS-01 wildcard+apex)
 
 # =============================================================================
 # Deploy NetworkPolicies for tenant isolation
@@ -317,6 +363,14 @@ fi
 # Validate Cloudflare IP ranges before creating DNS records (firewall depends on these)
 print_status "Validating Cloudflare IP ranges..."
 "$REPO_ROOT/scripts/check-cloudflare-ips" || { print_error "Cloudflare IPs changed. Run: ./scripts/check-cloudflare-ips --update"; exit 1; }
+
+if [ "${DNS_EXTERNAL:-false}" = "true" ]; then
+  # Tenant manages its own DNS zone — we have no Cloudflare API access to it, so
+  # skip all tenant DNS record creation (per-service CNAMEs, MX/SPF/DKIM/DMARC).
+  # The tenant points their service CNAMEs at our LB alias themselves.
+  # (dns_external is rejected with mail_enabled at config load — see config.sh.)
+  print_status "DNS managed externally by tenant (dns_external=true) — skipping Cloudflare tenant DNS record creation"
+else
 
 # Each tenant needs DNS records for their subdomains pointing to the ingress
 print_status "Creating tenant DNS records..."
@@ -478,6 +532,8 @@ else
     fi
   fi
 fi
+
+fi  # end DNS_EXTERNAL DNS-record guard
 
 # Apply PriorityClass for critical services (must exist before JVB/y-provider deploy)
 print_status "Applying PriorityClass for critical services..."

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -132,6 +132,7 @@ _mt_load_tenant_yaml() {
     "ROUNDCUBE_DB_NAME=" + (.database.roundcube_db // "" | @sh) + "\n" +
     "INFRA_DOMAIN=" + (.infra.domain // .dns.domain | @sh) + "\n" +
     "MAIL_SUBDOMAIN=" + (.dns.mail_subdomain // "mail" | @sh) + "\n" +
+    "DNS_EXTERNAL=" + (.dns.dns_external // false | tostring | @sh) + "\n" +
     "CALENDAR_ENABLED=" + (.features.calendar_enabled // false | tostring | @sh) + "\n" +
     "OFFICE_ENABLED=" + (.features.office_enabled // false | tostring | @sh) + "\n" +
     "MAIL_ENABLED=" + (.features.mail_enabled // false | tostring | @sh) + "\n" +
@@ -183,6 +184,17 @@ _mt_load_tenant_yaml() {
   done
   if [ "$LOGIN_PASSKEY_ENABLED" = "false" ] && [ "$LOGIN_MAGIC_LINK_ENABLED" = "false" ] && [ "$LOGIN_GOOGLE_SSO_ENABLED" = "false" ]; then
     echo "[ERROR] At least one features.login_methods entry must be true in $TENANT_CONFIG" >&2
+    exit 1
+  fi
+
+  # External-DNS tenants cannot run mail: our mail flow depends on MX/SPF/DKIM/DMARC
+  # records auto-created in OUR Cloudflare zone, which we can't create in a zone we
+  # don't control. Enforce at config load so EVERY entry point fails fast — not just
+  # create_env, but independently-run sub-scripts (e.g. deploy-stalwart.sh) too —
+  # rather than deploying unsigned/unroutable mail.
+  if [ "$DNS_EXTERNAL" = "true" ] && [ "$MAIL_ENABLED" = "true" ]; then
+    echo "[ERROR] dns.dns_external=true is incompatible with features.mail_enabled=true in $TENANT_CONFIG" >&2
+    echo "[ERROR]   Tenant mail requires MX/SPF/DKIM/DMARC records auto-created in our Cloudflare zone." >&2
     exit 1
   fi
 
@@ -585,7 +597,7 @@ _mt_export_all() {
   export S3_CLUSTER S3_BUCKET_PREFIX S3_DOCS_BUCKET S3_MATRIX_BUCKET S3_FILES_BUCKET S3_MAIL_BUCKET
   export DOCS_DB_NAME NEXTCLOUD_DB_NAME SYNAPSE_DB_NAME SYNAPSE_DB_USER
   export STALWART_DB_NAME STALWART_DB_USER ROUNDCUBE_DB_NAME ROUNDCUBE_DB_USER
-  export INFRA_DOMAIN MAIL_SUBDOMAIN
+  export INFRA_DOMAIN MAIL_SUBDOMAIN DNS_EXTERNAL
   export BUCKET_NAME BASE_DOMAIN COOKIE_DOMAIN KEYCLOAK_REALM
   export EMAIL_DOMAIN SMTP_DOMAIN DEFAULT_EMAIL_QUOTA_MB
   export PRIVACY_POLICY_URL TERMS_OF_USE_URL ACCEPTABLE_USE_POLICY_URL

--- a/scripts/manage-dns.sh
+++ b/scripts/manage-dns.sh
@@ -6,7 +6,7 @@
 #
 # Records managed:
 #   - lb2.prod.<domain> A     → Ingress LB IP (US prod, proxied)
-#   - lb1.prod.<domain> CNAME → lb1.prod-eu.<domain> (EU alias, proxied, prod only)
+#   - lb1.prod.<domain> CNAME → lb1.prod-eu.<domain> (EU alias, DNS-only, prod only; CNAME target for external-DNS tenants)
 #   - lb1.{dev|prod-eu}.<domain> A  → Ingress LB IP (dev/prod-eu, not proxied)
 #   - turn[.dev].<domain> A              → TURN server IP
 #   - hs-{prod|dev|prod-eu}.<domain> A   → Headscale server IP
@@ -124,9 +124,15 @@ else
   print_warning "Skipping LB A record — ingress LB IP not available (run deploy_infra first, then re-run with --dns)"
 fi
 
-# 1b. lb1.prod CNAME → lb1.prod-eu (prod only: EU alias pointing to prod-eu cluster)
+# 1b. lb1.prod CNAME → lb1.prod-eu (prod only: EU alias pointing to prod-eu cluster).
+# DNS-only (NOT proxied): this record is the CNAME target for tenants whose DNS is
+# managed externally (dns_external) on their own domains. Cloudflare's edge will only
+# serve a hostname whose zone lives in our account, so proxying this record makes the
+# edge reject foreign-zone hostnames (TLS handshake failure on 443, HTTP 409 on 80,
+# and ACME HTTP-01 challenges never reach our ingress). Leaving it grey-cloud routes
+# external-domain traffic straight to the prod-eu ingress, where our cert terminates.
 if [ -z "$INFRA_ENV_DNS_LABEL" ]; then
-  create_dns_record "lb1.prod.${DOMAIN}" "CNAME" "lb1.prod-eu.${DOMAIN}" "true"
+  create_dns_record "lb1.prod.${DOMAIN}" "CNAME" "lb1.prod-eu.${DOMAIN}" "false"
 fi
 
 # 2. TURN server A record


### PR DESCRIPTION
Enables hosting a tenant on its own externally-managed DNS zone (we have no Cloudflare API access to it), and fixes a latent cert-renewal deadlock for tenants whose DNS lives under the infra domain. Combines what were two stacked PRs (#458 folded in here).

## Commits
1. **fix(certs): infra Cloudflare token for infra-subdomain tenants; DNS-only LB alias** — tenants whose DNS is under the infra domain carry no Cloudflare token of their own, so `create_env` rendered an empty-token DNS-01 issuer → every renewal silently deadlocked `Ready=False` until expiry. Now falls back to the infra zone token (fail-fast if none). Also flips the `lb1.prod` CNAME (the alias external-DNS tenants point at) from Cloudflare-proxied to **DNS-only** — proxying made our edge reject foreign-zone hostnames (TLS handshake fail / HTTP 409 / ACME HTTP-01 blocked).
2. **fix(certs): http01 ClusterIssuer must use ingressClassName, not legacy class** — the LE HTTP-01 issuer used `class: nginx`, which cert-manager v1.13.3 maps to the deprecated annotation our ingress-nginx ignores → solver Ingress 404s → every HTTP-01 challenge deadlocks. **Validated live** on the prod-eu ingress (incl. coexistence with `force-ssl-redirect` app ingresses).
3. **feat(dns): HTTP-01 multi-SAN TLS path for externally-managed-DNS tenants** — adds a `dns_external` flag. When set, `create_env` skips Cloudflare tenant DNS creation and issues ONE multi-SAN cert via the shared `letsencrypt-prod` HTTP-01 issuer over the enabled PUBLIC service hosts into the SAME reflected secret the ingresses already use (`wildcard-tls-<tenant>`) → zero ingress changes. The apex `.well-known` ingress is skipped for `dns_external`. `dns_external`+`mail_enabled` is rejected at config load (every entry point fails fast). **Supersedes #346.**

## Safe to merge independently of any cutover
Merging this only *adds* the `dns_external` capability. No tenant has `dns_external: true` set, so `create_env` still takes the unchanged DNS-01 path for every current tenant. The actual cutover is gated on a separate private config-submodule flip + tenant DNS.

## Reviews (combined diff)
- **OSS compliance**: CLEAN (0 findings).
- **Security**: 0 critical/high. 2 LOW, both by-design/accepted: (a) `lb1.prod` loses Cloudflare edge WAF — forced by the architecture (its target `lb1.prod-eu` is already grey-cloud), TLS still terminates at our ingress; (b) operator-only `synapse-admin` would have a TLS name mismatch under `dns_external` (use port-forward/mesh). The earlier MEDIUM (mail×dns_external bypassable via sub-scripts) is **resolved** — enforced at config load.
- **Version bump**: no-op (no portal code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)