### PR TITLE
feat(dns): HTTP-01 multi-SAN TLS for externally-managed-DNS tenants (cutover)

### DIFF
--- a/apps/deploy-matrix.sh
+++ b/apps/deploy-matrix.sh
@@ -253,7 +253,12 @@ print_status "Synapse Admin deployed to https://$SYNAPSE_ADMIN_HOST"
 # =============================================================================
 # Matrix federation .well-known (prod only)
 # =============================================================================
-if [ -z "$TENANT_ENV_DNS_LABEL" ] || [ "$TENANT_ENV_DNS_LABEL" = "null" ]; then
+if [ "${DNS_EXTERNAL:-false}" = "true" ]; then
+  # The tenant owns its apex (their own website lives there) and we have no cert
+  # for it; an internal-only homeserver needs no federation .well-known delegation.
+  # Clients reach the HS directly at $MATRIX_HOST via Element's server config.
+  print_status "Skipping Matrix .well-known apex ingress (dns_external=true — tenant owns the apex)"
+elif [ -z "$TENANT_ENV_DNS_LABEL" ] || [ "$TENANT_ENV_DNS_LABEL" = "null" ]; then
   print_status "Deploying Matrix .well-known ingress for federation on $TENANT_DOMAIN..."
   envsubst < "$REPO_ROOT/apps/manifests/synapse-admin/matrix-wellknown.yaml.tpl" | kubectl apply -f -
   print_status "Matrix federation .well-known endpoints available at https://$TENANT_DOMAIN/.well-known/matrix/*"

--- a/apps/manifests/wildcard/certificate-http01.yaml.tpl
+++ b/apps/manifests/wildcard/certificate-http01.yaml.tpl
@@ -1,0 +1,41 @@
+# Per-tenant TLS for externally-managed-DNS tenants (dns_external=true).
+#
+# We have no Cloudflare API access to the tenant's own zone, so DNS-01 (and thus
+# a wildcard cert) is impossible. Instead we issue ONE multi-SAN certificate via
+# the shared HTTP-01 ClusterIssuer (letsencrypt-prod) over the explicit list of
+# public, tenant-facing service hosts, and write it to the SAME secret name the
+# ingresses already reference (wildcard-tls-${TENANT_NAME}, reflected to every
+# tenant namespace) — so no ingress manifest has to change.
+#
+# Excluded by design:
+#   - the bare apex (.well-known) — the tenant's apex is their own website, and
+#     internal-only tenants don't need federation .well-known.
+#   - internal/operator-only hosts (e.g. synapse-admin) — not publicly reachable,
+#     so HTTP-01 (which needs LE to fetch /.well-known/acme-challenge over :80)
+#     cannot validate them, and HTTP-01 is all-or-nothing across SANs.
+#
+# Required environment variables:
+#   TENANT_NAME       - Tenant name
+#   NS_MATRIX         - Namespace where the Certificate + secret live
+#   TENANT_NAMESPACES - Comma-separated target namespaces for reflector mirroring
+#   CERT_SAN_LINES    - Pre-rendered YAML list items (one `    - "host"` per line),
+#                       built by create_env from the enabled public service hosts.
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-tls
+  namespace: ${NS_MATRIX}
+spec:
+  secretName: wildcard-tls-${TENANT_NAME}
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+${CERT_SAN_LINES}
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "${TENANT_NAMESPACES}"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "${TENANT_NAMESPACES}"

--- a/scripts/create_env
+++ b/scripts/create_env
@@ -187,6 +187,51 @@ if [ "$OFFICE_ENABLED" = "true" ]; then
   export TENANT_NAMESPACES="${TENANT_NAMESPACES},${NS_OFFICE}"
 fi
 
+if [ "${DNS_EXTERNAL:-false}" = "true" ]; then
+  # =========================================================================
+  # External-DNS tenant: multi-SAN HTTP-01 certificate (no Cloudflare access)
+  # =========================================================================
+  # We can't DNS-01 a zone we don't control (no wildcard possible). Issue ONE
+  # multi-SAN cert via the shared letsencrypt-prod HTTP-01 issuer over the
+  # enabled public service hosts, into the SAME secret the ingresses already
+  # reference (wildcard-tls-${TENANT_NAME}, reflected) -> no ingress changes.
+  # Internal/operator hosts and the bare apex are excluded by design (they are
+  # not publicly reachable for HTTP-01 / the apex is the tenant's own website).
+  print_status "Deploying HTTP-01 multi-SAN TLS certificate for $TENANT_NAME (dns_external=true)..."
+
+  # Build the SAN list from enabled, publicly-reachable services. HTTP-01 is
+  # all-or-nothing across SANs, so every included host's CNAME must resolve to us.
+  CERT_SAN_LINES=""
+  [ "$MATRIX_ENABLED" = "true" ]         && CERT_SAN_LINES+="    - \"${MATRIX_HOST}\""$'\n'
+  CERT_SAN_LINES+="    - \"${AUTH_HOST}\""$'\n'
+  [ "$JITSI_ENABLED" = "true" ]          && CERT_SAN_LINES+="    - \"${JITSI_HOST}\""$'\n'
+  [ "$DOCS_ENABLED" = "true" ]           && CERT_SAN_LINES+="    - \"${DOCS_HOST}\""$'\n'
+  [ "$FILES_ENABLED" = "true" ]          && CERT_SAN_LINES+="    - \"${FILES_HOST}\""$'\n'
+  [ "$CALENDAR_ENABLED" = "true" ]       && CERT_SAN_LINES+="    - \"${CALENDAR_HOST}\""$'\n'
+  [ "$OFFICE_ENABLED" = "true" ]         && CERT_SAN_LINES+="    - \"${OFFICE_HOST}\""$'\n'
+  [ "$ADMIN_PORTAL_ENABLED" = "true" ]   && CERT_SAN_LINES+="    - \"${ADMIN_HOST}\""$'\n'
+  [ "$ACCOUNT_PORTAL_ENABLED" = "true" ] && CERT_SAN_LINES+="    - \"${ACCOUNT_HOST}\""$'\n'
+  export CERT_SAN_LINES
+  print_status "HTTP-01 certificate SANs:"
+  printf '%s' "$CERT_SAN_LINES"
+
+  # Remove any pre-existing DNS-01 wildcard/apex Certificates so they don't fight
+  # over the shared wildcard-tls-${TENANT_NAME} secret (e.g. a tenant that moved
+  # from in-zone to external DNS). Safe no-op when absent.
+  kubectl delete certificate wildcard-tls apex-tls -n "$NS_MATRIX" --ignore-not-found 2>/dev/null || true
+
+  envsubst < "$REPO_ROOT/apps/manifests/wildcard/certificate-http01.yaml.tpl" | kubectl apply -f -
+  print_status "HTTP-01 certificate applied; waiting for issuance (up to 300s)..."
+  if kubectl wait --for=condition=Ready certificate/wildcard-tls -n "$NS_MATRIX" --timeout=300s 2>/dev/null; then
+    print_success "wildcard-tls (HTTP-01 multi-SAN) is ready"
+  else
+    print_warning "wildcard-tls (HTTP-01) not ready after 300s"
+    print_warning "  HTTP-01 is all-or-nothing: confirm every SAN host's CNAME resolves to our ingress."
+    print_warning "  Debug: kubectl describe certificate wildcard-tls -n $NS_MATRIX ; kubectl get challenge -n $NS_MATRIX"
+    print_warning "Continuing — ingresses will serve the cert once issued."
+  fi
+else
+
 # Export Cloudflare token and TLS email for the certificate template
 export CLOUDFLARE_API_TOKEN="$TF_VAR_cloudflare_api_token"
 export TLS_EMAIL="$TF_VAR_tls_email"
@@ -296,6 +341,7 @@ fi
 # certs with comfortable life left; no-op on prod / when the cert isn't ready.
 "$REPO_ROOT/scripts/dev-cert-cache.sh" backup "$NS_MATRIX" "$TENANT_NAME" \
   || print_warning "dev-cert-cache backup skipped (non-fatal)"
+fi  # end DNS_EXTERNAL cert branch (HTTP-01 multi-SAN vs DNS-01 wildcard+apex)
 
 # =============================================================================
 # Deploy NetworkPolicies for tenant isolation
@@ -317,6 +363,14 @@ fi
 # Validate Cloudflare IP ranges before creating DNS records (firewall depends on these)
 print_status "Validating Cloudflare IP ranges..."
 "$REPO_ROOT/scripts/check-cloudflare-ips" || { print_error "Cloudflare IPs changed. Run: ./scripts/check-cloudflare-ips --update"; exit 1; }
+
+if [ "${DNS_EXTERNAL:-false}" = "true" ]; then
+  # Tenant manages its own DNS zone — we have no Cloudflare API access to it, so
+  # skip all tenant DNS record creation (per-service CNAMEs, MX/SPF/DKIM/DMARC).
+  # The tenant points their service CNAMEs at our LB alias themselves.
+  # (dns_external is rejected with mail_enabled at config load — see config.sh.)
+  print_status "DNS managed externally by tenant (dns_external=true) — skipping Cloudflare tenant DNS record creation"
+else
 
 # Each tenant needs DNS records for their subdomains pointing to the ingress
 print_status "Creating tenant DNS records..."
@@ -478,6 +532,8 @@ else
     fi
   fi
 fi
+
+fi  # end DNS_EXTERNAL DNS-record guard
 
 # Apply PriorityClass for critical services (must exist before JVB/y-provider deploy)
 print_status "Applying PriorityClass for critical services..."

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -132,6 +132,7 @@ _mt_load_tenant_yaml() {
     "ROUNDCUBE_DB_NAME=" + (.database.roundcube_db // "" | @sh) + "\n" +
     "INFRA_DOMAIN=" + (.infra.domain // .dns.domain | @sh) + "\n" +
     "MAIL_SUBDOMAIN=" + (.dns.mail_subdomain // "mail" | @sh) + "\n" +
+    "DNS_EXTERNAL=" + (.dns.dns_external // false | tostring | @sh) + "\n" +
     "CALENDAR_ENABLED=" + (.features.calendar_enabled // false | tostring | @sh) + "\n" +
     "OFFICE_ENABLED=" + (.features.office_enabled // false | tostring | @sh) + "\n" +
     "MAIL_ENABLED=" + (.features.mail_enabled // false | tostring | @sh) + "\n" +
@@ -183,6 +184,17 @@ _mt_load_tenant_yaml() {
   done
   if [ "$LOGIN_PASSKEY_ENABLED" = "false" ] && [ "$LOGIN_MAGIC_LINK_ENABLED" = "false" ] && [ "$LOGIN_GOOGLE_SSO_ENABLED" = "false" ]; then
     echo "[ERROR] At least one features.login_methods entry must be true in $TENANT_CONFIG" >&2
+    exit 1
+  fi
+
+  # External-DNS tenants cannot run mail: our mail flow depends on MX/SPF/DKIM/DMARC
+  # records auto-created in OUR Cloudflare zone, which we can't create in a zone we
+  # don't control. Enforce at config load so EVERY entry point fails fast — not just
+  # create_env, but independently-run sub-scripts (e.g. deploy-stalwart.sh) too —
+  # rather than deploying unsigned/unroutable mail.
+  if [ "$DNS_EXTERNAL" = "true" ] && [ "$MAIL_ENABLED" = "true" ]; then
+    echo "[ERROR] dns.dns_external=true is incompatible with features.mail_enabled=true in $TENANT_CONFIG" >&2
+    echo "[ERROR]   Tenant mail requires MX/SPF/DKIM/DMARC records auto-created in our Cloudflare zone." >&2
     exit 1
   fi
 
@@ -585,7 +597,7 @@ _mt_export_all() {
   export S3_CLUSTER S3_BUCKET_PREFIX S3_DOCS_BUCKET S3_MATRIX_BUCKET S3_FILES_BUCKET S3_MAIL_BUCKET
   export DOCS_DB_NAME NEXTCLOUD_DB_NAME SYNAPSE_DB_NAME SYNAPSE_DB_USER
   export STALWART_DB_NAME STALWART_DB_USER ROUNDCUBE_DB_NAME ROUNDCUBE_DB_USER
-  export INFRA_DOMAIN MAIL_SUBDOMAIN
+  export INFRA_DOMAIN MAIL_SUBDOMAIN DNS_EXTERNAL
   export BUCKET_NAME BASE_DOMAIN COOKIE_DOMAIN KEYCLOAK_REALM
   export EMAIL_DOMAIN SMTP_DOMAIN DEFAULT_EMAIL_QUOTA_MB
   export PRIVACY_POLICY_URL TERMS_OF_USE_URL ACCEPTABLE_USE_POLICY_URL


### PR DESCRIPTION
## Status: DRAFT — do not merge until validated end-to-end

Stacked on #457 (base = `fix/external-dns-cert-token-unproxy`). Implements the cutover machinery for a tenant that runs its own DNS zone. The HTTP-01 ACME path itself is **validated live** (see #457); the multi-SAN cutover needs the tenant's service CNAMEs in place before it can issue (HTTP-01 is all-or-nothing across SANs).

## What this does

Adds a `dns_external` tenant flag and the TLS path it needs:

- **config.sh**: export `DNS_EXTERNAL`; reject `dns_external` + `mail_enabled` **at config load** so every entry point fails fast (not just `create_env` — an independently-run `deploy-stalwart.sh` can't ship unsigned mail).
- **create_env**: when `dns_external`, skip all Cloudflare tenant DNS record creation, and issue **one multi-SAN cert** via the shared `letsencrypt-prod` HTTP-01 issuer over the enabled **public** service hosts, into the **same reflected secret** the ingresses already reference (`wildcard-tls-<tenant>`) → **zero ingress-template changes**. Deletes any prior DNS-01 wildcard/apex certs first. In-zone tenants keep the DNS-01 wildcard+apex path unchanged.
- **certificate-http01.yaml.tpl**: the multi-SAN HTTP-01 Certificate, reflected. Internal/operator hosts (`synapse-admin`) and the bare apex are **excluded by design** (not publicly reachable for HTTP-01 / the apex is the tenant's own website).
- **deploy-matrix.sh**: skip the apex `.well-known` ingress for `dns_external` (tenant owns the apex; an internal-only homeserver needs no federation delegation).

**Supersedes #346** (which had the `dns_external` flag but deferred the TLS path).

## Blockers before merge / deploy
1. Merge #457 first (this provides the lb1.prod un-proxy + HTTP-01 issuer fix this path relies on), then rebase onto main.
2. Tenant adds the remaining service CNAMEs (jitsi, admin, account, calendar, office → our LB alias).
3. Apply the un-proxy: `manage_infra -e prod --dns`.
4. Validate the multi-SAN cert issues once all CNAMEs resolve.
5. Config submodule flip (separate, private): `domain` → external domain, `dns_external: true`, `cookie_domain`. **Note:** changing `server_name` on the (empty) Synapse may need the synapse DB reinitialized — verify Synapse starts clean.
6. Keycloak realm redirect URIs + Google Cloud Console OAuth redirect URI (manual, before cutover).

## Verification done
- `bash -n` clean (create_env, config.sh, deploy-matrix.sh).
- HTTP-01 cert template renders to valid YAML (parsed); SAN list built from enabled-feature flags.
- HTTP-01 ACME path validated live on the prod-eu ingress (real LE cert issued for a throwaway host; see #457).

## OSS Compliance Review
CLEAN (0 findings) — generic env-var scaffolding only; no client names/domains/credentials.

## Security Review
1 MEDIUM (addressed), 1 LOW (known/accepted):
- **MEDIUM (fixed in this PR)**: the `dns_external`+`mail_enabled` invariant is now enforced at config load (`config.sh`), so self-contained sub-scripts can't bypass it and deploy unsigned mail.
- **LOW (accepted)**: under `dns_external`, the operator-only `synapse-admin` ingress references the shared secret which no longer covers its internal hostname → TLS mismatch on that Tailscale-only surface. Functional, not a security weakening; operators use port-forward/mesh. Documented.
- HTTP-01 is the correct ACME method for a zone we don't own (not a downgrade); no injection risk in `CERT_SAN_LINES` (envsubst value-substitution, `@sh`-quoted, `set -e`-safe).

## Version bump
No-op (no portal code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)