### PR TITLE
feat(ci): dev-only vault password + tenant-secret patch mode

### DIFF
--- a/DEV_VAULT_ACCESS.md
+++ b/DEV_VAULT_ACCESS.md
@@ -1,0 +1,122 @@
+# Dev Vault Access — sharing dev secrets without exposing prod
+
+The CI deploy vaults (`config/platform/ci/deploy-vault-<env>.vault`) are
+Ansible Vault-encrypted tarballs holding kubeconfigs, terraform outputs, and
+per-tenant secrets. They are the **only** committed copy of secrets — the
+plaintext `*.secrets.yaml` files are gitignored.
+
+By default every vault (dev, prod, prod-eu) was encrypted with a **single**
+shared password, so handing that password to a contributor would expose prod.
+To let a contributor add/update **dev** secrets safely, the **dev vault is
+re-keyed with its own password**. That dev password unlocks *only*
+`deploy-vault-dev.vault`; prod/prod-eu stay under the shared operator password.
+
+- **dev** → its own password (LastPass note `mothertree-dev-vault-password`)
+- **prod / prod-eu** → the shared password (LastPass note `7375668101991863677`,
+  Woodpecker secret `deploy_vault_password`) — unchanged
+
+---
+
+## Part A — One-time operator setup (re-key dev)
+
+Run once, from an operator machine with LastPass + the repo checked out.
+
+1. **Generate a dev password and store it in LastPass.**
+   ```bash
+   openssl rand -base64 24            # copy the output
+   ```
+   Create a LastPass **Secure Note** named exactly `mothertree-dev-vault-password`
+   and paste the password as the note body.
+
+2. **Re-key the dev vault** (encrypts `deploy-vault-dev.vault` with the new
+   dev password; prod/prod-eu untouched):
+   ```bash
+   ./scripts/build-deploy-vaults.sh dev
+   ```
+
+3. **Acceptance test — prove the password is dev-only.** Both lines must behave
+   as labelled, against the real committed blobs:
+   ```bash
+   DEV_PW=$(lpass show --note mothertree-dev-vault-password)
+
+   # MUST FAIL — the dev password cannot open prod:
+   ansible-vault decrypt config/platform/ci/deploy-vault-prod.vault \
+     --vault-password-file <(printf '%s' "$DEV_PW") --output - >/dev/null \
+     && echo "DANGER: dev pw opened prod" || echo "OK: dev pw cannot open prod"
+
+   # MUST SUCCEED — the dev password opens dev:
+   ansible-vault decrypt config/platform/ci/deploy-vault-dev.vault \
+     --vault-password-file <(printf '%s' "$DEV_PW") --output - >/dev/null \
+     && echo "OK: dev pw opens dev" || echo "FAIL: dev pw cannot open dev"
+   ```
+
+4. **Let CI decrypt the re-keyed dev vault.** Add the dev password to the
+   **private, gitignored** `config/platform/ci/ansible-vars.yml`:
+   ```yaml
+   deploy_vault_password_dev: "<the dev password>"
+   ```
+   > Never commit the real value. It belongs only in the gitignored
+   > `ansible-vars.yml`. Ansible writes it to
+   > `/home/woodpecker/deploy-vaults/dev-vault-pass` (0600) with `no_log`.
+
+5. **Re-provision the CI host** (pushes the re-keyed dev vault + the dev-pass
+   file together):
+   ```bash
+   ./ci/scripts/provision-ci.sh --ansible-only
+   ```
+
+### Why there's no flag-day
+`ci_decrypt_vault` (in `ci/scripts/ci-lib.sh`) decrypts the dev vault by trying
+the dev password **first** and the shared password as a fallback. So dev
+deploys keep working even if steps 2 and 5 land out of order. Once stable, the
+shared fallback for dev can be dropped so a misconfigured dev vault fails loud
+instead of silently decrypting under the prod password.
+
+### Rotating the dev password later
+Update the LastPass note, repeat steps 2–5. Re-share with the contributor.
+
+---
+
+## Part B — Contributor workflow (add/update dev secrets)
+
+You need: the **dev vault password** (from the operator) and **write access to
+the `config/tenants` and `config/platform` submodules**. You do **not** need
+LastPass, the dev kubeconfig, terraform outputs, or tf-state credentials.
+
+You deploy via CI only — never directly.
+
+1. **Edit the plaintext dev secret** for your tenant (gitignored, never
+   committed):
+   ```bash
+   $EDITOR config/tenants/<tenant>/dev.secrets.yaml
+   ```
+
+2. **Patch it into the dev vault** — this decrypts the existing vault, swaps in
+   only the tenant(s) you name, preserves everything else, and re-encrypts with
+   the same dev password:
+   ```bash
+   MT_VAULT_PASSWORD='<dev-vault-password>' \
+     ./scripts/build-deploy-vaults.sh dev --update-secrets --tenant <tenant>
+   ```
+   `--tenant` is repeatable; at least one is required. Only the named tenants
+   are touched, so a stale local copy of another tenant can't overwrite the
+   vault.
+
+   > Prefer not to put the password in your shell history? Use a file:
+   > `MT_VAULT_PASSWORD_FILE=~/.mt-dev-vault-pass ./scripts/build-deploy-vaults.sh dev --update-secrets --tenant <tenant>`
+
+3. **Commit the updated vault blob** in the `config/platform` submodule and open
+   a PR:
+   ```bash
+   cd config/platform
+   git add ci/deploy-vault-dev.vault
+   git commit -m "dev: update <tenant> secrets"
+   ```
+   CI deploys the change to dev.
+
+### What the dev password actually grants
+The dev password decrypts the **entire** dev vault — the dev kubeconfig,
+terraform outputs, tf-state credentials, and **every** tenant's dev secrets —
+not just the tenant you edit. Patch mode also exposes all of that transiently
+in a temp staging dir on your machine while it runs. It does **not** grant any
+access to prod or prod-eu.

--- a/ci/ansible/playbook.yml
+++ b/ci/ansible/playbook.yml
@@ -9,6 +9,10 @@
 #
 # Optional vars for CI deploy vaults:
 #   ci_deploy_vaults — list of local paths to encrypted vault files to provision
+#   deploy_vault_password_dev — dev-only ansible-vault password. When set, it is
+#       written to /home/woodpecker/deploy-vaults/dev-vault-pass (0600) so CI can
+#       decrypt the re-keyed dev vault. Keep this ONLY in the private (gitignored)
+#       ansible-vars.yml — never commit the real value. See DEV_VAULT_ACCESS.md.
 
 - name: Configure Woodpecker CI Server
   hosts: ci_servers
@@ -582,6 +586,23 @@
         mode: "0600"
         decrypt: false
       loop: "{{ ci_deploy_vaults | default([]) }}"
+
+    # ── Dev vault password (dev-only re-key) ──────────────────────
+    # The dev vault is encrypted with its OWN password, separate from the
+    # shared DEPLOY_VAULT_PASSWORD used for prod/prod-eu, so it can be handed
+    # to a contributor without exposing prod secrets. ci_decrypt_vault (in
+    # ci/scripts/ci-lib.sh) reads this file for env=dev and tries it before
+    # falling back to DEPLOY_VAULT_PASSWORD. Optional: if the var is not set,
+    # dev keeps using the shared password (pre-re-key behaviour).
+    - name: Deploy dev-only vault password
+      ansible.builtin.copy:
+        content: "{{ deploy_vault_password_dev }}"
+        dest: /home/woodpecker/deploy-vaults/dev-vault-pass
+        owner: woodpecker
+        group: woodpecker
+        mode: "0600"
+      no_log: true
+      when: deploy_vault_password_dev is defined and deploy_vault_password_dev | length > 0
 
     - name: Clean up orphaned deploy temp dirs (cron)
       ansible.builtin.cron:

--- a/ci/scripts/ci-deploy-app.sh
+++ b/ci/scripts/ci-deploy-app.sh
@@ -68,9 +68,7 @@ _cleanup() {
 }
 trap _cleanup EXIT
 
-ansible-vault decrypt "$VAULT_FILE" \
-  --vault-password-file <(echo "$DEPLOY_VAULT_PASSWORD") \
-  --output "$WORK_DIR/secrets.tar.gz"
+ci_decrypt_vault "$VAULT_FILE" "$MT_ENV" "$WORK_DIR/secrets.tar.gz"
 tar xzf "$WORK_DIR/secrets.tar.gz" -C "$WORK_DIR"
 rm -f "$WORK_DIR/secrets.tar.gz"
 

--- a/ci/scripts/ci-deploy.sh
+++ b/ci/scripts/ci-deploy.sh
@@ -107,9 +107,7 @@ _start_lease_renewal() {
 }
 
 echo "Decrypting deploy vault ($MT_ENV) → $WORK_DIR"
-ansible-vault decrypt "$VAULT_FILE" \
-  --vault-password-file <(echo "$DEPLOY_VAULT_PASSWORD") \
-  --output "$WORK_DIR/secrets.tar.gz"
+ci_decrypt_vault "$VAULT_FILE" "$MT_ENV" "$WORK_DIR/secrets.tar.gz"
 tar xzf "$WORK_DIR/secrets.tar.gz" -C "$WORK_DIR"
 rm -f "$WORK_DIR/secrets.tar.gz"
 echo "Vault decrypted successfully"

--- a/ci/scripts/ci-lib.sh
+++ b/ci/scripts/ci-lib.sh
@@ -53,6 +53,54 @@ ci_fetch_dev_kubeconfig() {
   umask 022
 }
 
+# ── Deploy-vault decryption ─────────────────────────────────────
+# Path to the dev-only vault password, provisioned to the CI host by Ansible
+# (ci/ansible/playbook.yml, from the `deploy_vault_password_dev` var). Override
+# via CI_DEV_VAULT_PASS_FILE for testing.
+CI_DEV_VAULT_PASS_FILE="${CI_DEV_VAULT_PASS_FILE:-/home/woodpecker/deploy-vaults/dev-vault-pass}"
+
+# Decrypt a deploy vault into <out_tar>, choosing the right password per env.
+#
+#   ci_decrypt_vault <vault_file> <env> <out_tar>
+#
+# prod / prod-eu: use the shared DEPLOY_VAULT_PASSWORD (unchanged behaviour).
+# dev: the dev vault is re-keyed with its OWN password so it can be shared with
+#   a contributor without exposing prod/prod-eu. If the host has the dev
+#   password file, try the dev password FIRST and fall back to the shared one —
+#   ansible-vault tries each --vault-id until one decrypts, so this works whether
+#   or not the dev vault has been re-keyed yet (no migration flag-day). If the
+#   dev password file is absent (env not yet provisioned), dev falls through to
+#   the shared path unchanged.
+#
+# Requires DEPLOY_VAULT_PASSWORD in the environment (callers already enforce it).
+ci_decrypt_vault() {
+  local vault_file="${1:?ci_decrypt_vault: vault_file required}"
+  local env="${2:?ci_decrypt_vault: env required}"
+  local out_tar="${3:?ci_decrypt_vault: out_tar required}"
+  : "${DEPLOY_VAULT_PASSWORD:?DEPLOY_VAULT_PASSWORD is required}"
+
+  if [[ "$env" == "dev" && -s "$CI_DEV_VAULT_PASS_FILE" ]]; then
+    # Stage the shared password in a 0600 temp file so both passwords can be
+    # offered as labelled vault-ids. ansible-vault tries each until one opens.
+    # Write it inside the caller's output dir (its WORK_DIR), which the caller's
+    # EXIT trap scrubs — so a kill mid-decrypt can't orphan the password file.
+    local shared_pw_file rc=0
+    shared_pw_file=$(mktemp "$(dirname "$out_tar")/.vpw-XXXXXX")
+    chmod 600 "$shared_pw_file"
+    printf '%s\n' "$DEPLOY_VAULT_PASSWORD" > "$shared_pw_file"
+    ansible-vault decrypt "$vault_file" \
+      --vault-id "dev@${CI_DEV_VAULT_PASS_FILE}" \
+      --vault-id "shared@${shared_pw_file}" \
+      --output "$out_tar" || rc=$?
+    rm -f "$shared_pw_file"
+    return "$rc"
+  fi
+
+  ansible-vault decrypt "$vault_file" \
+    --vault-password-file <(echo "$DEPLOY_VAULT_PASSWORD") \
+    --output "$out_tar"
+}
+
 # ── Woodpecker API helpers ──────────────────────────────────────
 # Token is deployed to the CI host by Ansible (ci/ansible/playbook.yml).
 _WP_API_TOKEN_FILE="/home/woodpecker/.woodpecker-api-token"

--- a/scripts/build-deploy-vaults.sh
+++ b/scripts/build-deploy-vaults.sh
@@ -7,17 +7,39 @@ set -euo pipefail
 # tarballs, encrypts them with ansible-vault, and places the encrypted files
 # in config/platform/ci/ for provisioning to the CI host.
 #
+# Per-environment vault passwords
+# ───────────────────────────────
+# dev uses its OWN ansible-vault password, separate from prod/prod-eu, so the
+# dev vault password can be shared with a contributor without exposing prod
+# secrets. The dev password unlocks ONLY deploy-vault-dev.vault; the
+# prod/prod-eu vaults stay under the shared operator password.
+#
+#   Precedence for the password (highest first):
+#     1. $MT_VAULT_PASSWORD_FILE  — path to a file containing the password
+#     2. $MT_VAULT_PASSWORD       — the password value itself
+#     3. LastPass                 — dev: $LPASS_DEV_VAULT_ENTRY,
+#                                   prod/prod-eu: $LPASS_VAULT_ENTRY
+#
 # Usage:
-#   ./scripts/build-deploy-vaults.sh              # Build all envs
-#   ./scripts/build-deploy-vaults.sh dev           # Build dev only
-#   ./scripts/build-deploy-vaults.sh prod          # Build prod only
+#   ./scripts/build-deploy-vaults.sh                 # Full build, all envs
+#   ./scripts/build-deploy-vaults.sh dev             # Full build, dev only
+#   ./scripts/build-deploy-vaults.sh prod            # Full build, prod only
+#
+#   # Patch mode — update ONLY the named tenant secret(s) inside an existing
+#   # vault, preserving kubeconfig / terraform-outputs / tf-state untouched.
+#   # No LastPass needed; supply the dev password via MT_VAULT_PASSWORD.
+#   MT_VAULT_PASSWORD=<dev-pw> \
+#     ./scripts/build-deploy-vaults.sh dev --update-secrets --tenant acme
+#   ... --tenant acme --tenant beta   # repeatable; at least one required
 #
 # Prerequisites:
-#   - lpass CLI authenticated (lpass status)
-#   - ansible-vault installed
-#   - kubeconfig.<env>.yaml files at repo root
-#   - config/platform/infra/terraform-outputs.<env>.env files
-#   - config/tenants/<tenant>/<env>.secrets.yaml files
+#   - ansible-vault, tar installed
+#   - Full build: kubeconfig.<env>.yaml at repo root,
+#                 config/platform/infra/terraform-outputs.<env>.env,
+#                 config/tenants/<tenant>/<env>.secrets.yaml,
+#                 and a password source (LastPass login or MT_VAULT_PASSWORD*)
+#   - Patch mode: an existing config/platform/ci/deploy-vault-<env>.vault,
+#                 the matching vault password, and the local tenant secrets
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -30,8 +52,15 @@ print_status() { echo -e "${BLUE}[vault]${NC} $1"; }
 print_success() { echo -e "${GREEN}[vault]${NC} $1"; }
 print_error() { echo -e "${RED}[vault]${NC} $1" >&2; }
 
-# ── LastPass entry for the vault password ─────────────────────────
+# ── LastPass entry for the prod / prod-eu (shared) vault password ──
 LPASS_VAULT_ENTRY="7375668101991863677"
+
+# ── LastPass entry for the dev-only vault password ────────────────
+# Separate from the shared password above so the dev vault can be re-keyed
+# and its password handed to a contributor without granting prod/prod-eu
+# access. Create this LastPass note with a fresh random password before the
+# first dev re-key (see DEV_VAULT_ACCESS.md).
+LPASS_DEV_VAULT_ENTRY="mothertree-dev-vault-password"
 
 # ── LastPass entry for the phase1-dev Terraform-state bucket creds ─
 # Created during the phase1-dev migration (see phase1-dev/MIGRATION.md).
@@ -40,32 +69,42 @@ LPASS_VAULT_ENTRY="7375668101991863677"
 # Dev only — CI doesn't run terraform for prod or prod-eu.
 LPASS_TF_STATE_ENTRY="mothertree-tf-state-dev-s3-credentials"
 
-# ── Validate prerequisites ────────────────────────────────────────
-for cmd in ansible-vault lpass tar; do
+# ── Parse args ────────────────────────────────────────────────────
+ENV_ARG=""
+UPDATE_SECRETS=false
+PATCH_TENANTS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --update-secrets) UPDATE_SECRETS=true ;;
+    --tenant)
+      shift
+      [[ -n "${1:-}" ]] || { print_error "--tenant requires a tenant name"; exit 1; }
+      PATCH_TENANTS+=("$1")
+      ;;
+    --tenant=*) PATCH_TENANTS+=("${1#*=}") ;;
+    -h|--help)
+      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    -*) print_error "Unknown option: $1"; exit 1 ;;
+    *)
+      if [[ -n "$ENV_ARG" ]]; then
+        print_error "Unexpected argument: $1 (env already set to '$ENV_ARG')"
+        exit 1
+      fi
+      ENV_ARG="$1"
+      ;;
+  esac
+  shift
+done
+
+# ── Validate always-required prerequisites ────────────────────────
+for cmd in ansible-vault tar; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     print_error "$cmd is required but not found"
     exit 1
   fi
 done
-
-if ! lpass status -q 2>/dev/null; then
-  print_error "Not logged in to LastPass. Run: lpass login <email>"
-  exit 1
-fi
-
-# ── Fetch vault password ──────────────────────────────────────────
-print_status "Fetching vault password from LastPass..."
-VAULT_PASSWORD=$(lpass show --note "$LPASS_VAULT_ENTRY" 2>/dev/null)
-if [[ -z "$VAULT_PASSWORD" ]]; then
-  print_error "Failed to fetch vault password from LastPass entry: $LPASS_VAULT_ENTRY"
-  exit 1
-fi
-
-# ── Determine which envs to build ─────────────────────────────────
-ENVS=("${1:-dev}" "${1:-prod}" "${1:-prod-eu}")
-if [[ -n "${1:-}" ]]; then
-  ENVS=("$1")
-fi
 
 OUTPUT_DIR="$REPO_ROOT/config/platform/ci"
 if [[ ! -d "$OUTPUT_DIR" ]]; then
@@ -76,7 +115,182 @@ fi
 TENANTS_DIR="$REPO_ROOT/config/tenants"
 INFRA_DIR="$REPO_ROOT/config/platform/infra"
 
-# ── Build vault for each environment ──────────────────────────────
+# ── LastPass helpers (only required when LastPass is the password source) ──
+_require_lpass() {
+  if ! command -v lpass >/dev/null 2>&1; then
+    print_error "lpass is required to source the vault password from LastPass."
+    print_error "Either log in to LastPass, or pass MT_VAULT_PASSWORD / MT_VAULT_PASSWORD_FILE."
+    exit 1
+  fi
+  if ! lpass status -q 2>/dev/null; then
+    print_error "Not logged in to LastPass. Run: lpass login <email>"
+    print_error "(or pass the password via MT_VAULT_PASSWORD / MT_VAULT_PASSWORD_FILE)"
+    exit 1
+  fi
+}
+
+# Resolve the ansible-vault password for the given env, honouring the
+# MT_VAULT_PASSWORD_FILE > MT_VAULT_PASSWORD > LastPass precedence. Echoes the
+# password to stdout (capture with $(...)).
+_resolve_vault_password() {
+  local env="$1"
+  local override_set=false
+  [[ -n "${MT_VAULT_PASSWORD_FILE:-}" || -n "${MT_VAULT_PASSWORD:-}" ]] && override_set=true
+
+  # The direct-password override (MT_VAULT_PASSWORD[_FILE]) is DEV ONLY — it is
+  # the contributor patch-mode path. prod/prod-eu MUST be encrypted with the
+  # shared operator password from LastPass, so refuse the override there rather
+  # than silently honour it. This stops a stray MT_VAULT_PASSWORD (e.g. a dev
+  # password left exported in the shell) from re-encrypting prod/prod-eu under
+  # the wrong key — which would let the dev password decrypt the prod vault.
+  if [[ "$env" != "dev" && "$override_set" == "true" ]]; then
+    print_error "MT_VAULT_PASSWORD / MT_VAULT_PASSWORD_FILE is set, but env '$env' must use the shared operator vault password from LastPass."
+    print_error "The direct-password override applies to 'dev' only. Unset it, or build 'dev' explicitly."
+    exit 1
+  fi
+
+  if [[ "$env" == "dev" ]]; then
+    if [[ -n "${MT_VAULT_PASSWORD_FILE:-}" ]]; then
+      [[ -f "$MT_VAULT_PASSWORD_FILE" ]] || {
+        print_error "MT_VAULT_PASSWORD_FILE not found: $MT_VAULT_PASSWORD_FILE"; exit 1; }
+      # First line only, matching how ansible-vault reads a password file.
+      head -n1 "$MT_VAULT_PASSWORD_FILE"
+      return 0
+    fi
+    if [[ -n "${MT_VAULT_PASSWORD:-}" ]]; then
+      printf '%s\n' "$MT_VAULT_PASSWORD"
+      return 0
+    fi
+  fi
+  _require_lpass
+  local entry
+  if [[ "$env" == "dev" ]]; then
+    entry="$LPASS_DEV_VAULT_ENTRY"
+  else
+    entry="$LPASS_VAULT_ENTRY"
+  fi
+  local pw
+  pw=$(lpass show --note "$entry" 2>/dev/null)
+  if [[ -z "$pw" ]]; then
+    print_error "Failed to fetch vault password from LastPass entry: $entry"
+    if [[ "$env" == "dev" ]]; then
+      print_error "Create the dev vault-password note (see DEV_VAULT_ACCESS.md), or pass MT_VAULT_PASSWORD."
+    fi
+    exit 1
+  fi
+  printf '%s\n' "$pw"
+}
+
+# ═══════════════════════════════════════════════════════════════════
+#  Patch mode — update only the named tenant secret(s) in an existing
+#  vault, leaving infra artifacts (kubeconfig, terraform-outputs,
+#  tf-state-creds) exactly as they are. Lets a contributor add/update
+#  tenant secrets with ONLY the dev vault password — no LastPass, no
+#  kubeconfig, no terraform outputs, no tf-state credentials.
+# ═══════════════════════════════════════════════════════════════════
+if [[ "$UPDATE_SECRETS" == "true" ]]; then
+  : "${ENV_ARG:?--update-secrets requires an explicit env (e.g. dev)}"
+  env="$ENV_ARG"
+
+  if [[ ${#PATCH_TENANTS[@]} -eq 0 ]]; then
+    print_error "--update-secrets requires at least one --tenant <name>."
+    print_error "This scopes the update to exactly the tenants you intend to change,"
+    print_error "so an unrelated stale local secrets file can't silently overwrite the vault."
+    exit 1
+  fi
+
+  VAULT_FILE="$OUTPUT_DIR/deploy-vault-${env}.vault"
+  if [[ ! -f "$VAULT_FILE" ]]; then
+    print_error "Existing vault not found: $VAULT_FILE"
+    print_error "Patch mode updates an existing vault. Run a full build first (operator)."
+    exit 1
+  fi
+
+  print_status "Patch mode: updating tenant secret(s) in $(basename "$VAULT_FILE")"
+  print_status "  Tenants: ${PATCH_TENANTS[*]}"
+
+  VAULT_PASSWORD=$(_resolve_vault_password "$env")
+
+  STAGING=$(mktemp -d /tmp/mt-vault-patch-XXXXXX)
+  DEC_TAR=$(mktemp -u /tmp/mt-vault-patch-tar-XXXXXX.tar.gz)
+  NEWTAR=""
+  # NEWTAR is the plaintext re-tar of all dev secrets — track it so a kill or a
+  # failed encrypt can't orphan it in /tmp (it's a sibling of STAGING, not inside
+  # it, so `rm -rf "$STAGING"` would not catch it).
+  _patch_cleanup() { rm -rf "$STAGING" "$DEC_TAR" ${NEWTAR:+"$NEWTAR"}; }
+  trap _patch_cleanup EXIT
+
+  # Decrypt the existing vault into the staging dir.
+  print_status "  Decrypting existing vault..."
+  if ! ansible-vault decrypt "$VAULT_FILE" \
+        --vault-password-file <(printf '%s\n' "$VAULT_PASSWORD") \
+        --output "$DEC_TAR" 2>/dev/null; then
+    print_error "Failed to decrypt $VAULT_FILE — wrong vault password?"
+    exit 1
+  fi
+  tar xzf "$DEC_TAR" -C "$STAGING"
+  rm -f "$DEC_TAR"
+
+  if [[ ! -d "$STAGING/tenants" ]]; then
+    print_error "Decrypted vault has no tenants/ directory — unexpected layout, aborting."
+    exit 1
+  fi
+
+  # Overlay ONLY the named tenants' local secrets. Each must exist locally.
+  for tenant in "${PATCH_TENANTS[@]}"; do
+    src="$TENANTS_DIR/$tenant/${env}.secrets.yaml"
+    if [[ ! -f "$src" ]]; then
+      print_error "Local secrets file not found: $src"
+      print_error "Edit config/tenants/$tenant/${env}.secrets.yaml before patching."
+      exit 1
+    fi
+    mkdir -p "$STAGING/tenants/$tenant"
+    cp "$src" "$STAGING/tenants/$tenant/${env}.secrets.yaml"
+    print_status "  Updated tenants/$tenant/${env}.secrets.yaml"
+  done
+
+  # Re-tar and re-encrypt with the SAME password (overwrites the vault).
+  # umask 077 so the plaintext tarball is 0600, not world-readable, for the
+  # brief window before it's encrypted and removed.
+  NEWTAR="$STAGING.tar.gz"
+  ( umask 077; tar czf "$NEWTAR" -C "$STAGING" . )
+  print_status "  Re-encrypting → $VAULT_FILE"
+  ansible-vault encrypt "$NEWTAR" \
+    --vault-password-file <(printf '%s\n' "$VAULT_PASSWORD") \
+    --output "$VAULT_FILE"
+  rm -f "$NEWTAR"
+
+  VAULT_SIZE=$(du -h "$VAULT_FILE" | cut -f1)
+  print_success "Patched $VAULT_FILE ($VAULT_SIZE; tenants: ${PATCH_TENANTS[*]})"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Commit the updated vault file in config/platform/ci/"
+  echo "  2. Open a PR — CI deploys the change to dev."
+  exit 0
+fi
+
+# ═══════════════════════════════════════════════════════════════════
+#  Full build mode — rebuild the entire vault for each environment.
+# ═══════════════════════════════════════════════════════════════════
+ENVS=("dev" "prod" "prod-eu")
+if [[ -n "$ENV_ARG" ]]; then
+  ENVS=("$ENV_ARG")
+fi
+
+# Guard: the direct-password override is dev-only. Refuse it up-front if the
+# build set includes any non-dev env, BEFORE any vault is (re)written — so a
+# stray MT_VAULT_PASSWORD can't re-key dev with it and then fail partway, or
+# silently re-key prod/prod-eu.
+if [[ -n "${MT_VAULT_PASSWORD:-}${MT_VAULT_PASSWORD_FILE:-}" ]]; then
+  for _e in "${ENVS[@]}"; do
+    if [[ "$_e" != "dev" ]]; then
+      print_error "MT_VAULT_PASSWORD / MT_VAULT_PASSWORD_FILE is set, but this build includes non-dev env '$_e'."
+      print_error "The direct-password override applies to 'dev' only. Unset it, or build 'dev' explicitly."
+      exit 1
+    fi
+  done
+fi
+
 CLEANUP_DIRS=()
 _cleanup_all() {
   for d in "${CLEANUP_DIRS[@]}"; do
@@ -87,6 +301,9 @@ trap _cleanup_all EXIT
 
 for env in "${ENVS[@]}"; do
   print_status "Building deploy vault for env=$env..."
+
+  # Resolve the password for THIS env (dev uses its own password).
+  VAULT_PASSWORD=$(_resolve_vault_password "$env")
 
   STAGING=$(mktemp -d /tmp/mt-vault-build-XXXXXX)
   CLEANUP_DIRS+=("$STAGING")
@@ -116,6 +333,7 @@ for env in "${ENVS[@]}"; do
   # (bucket `mothertree-tf-state-dev`). The scoped access key for that bucket
   # is stored in LastPass and pulled into the vault on every rebuild.
   if [[ "$env" == "dev" ]]; then
+    _require_lpass
     print_status "  Fetching phase1-dev tf-state creds from LastPass ($LPASS_TF_STATE_ENTRY)..."
     TF_STATE_AK=$(lpass show --username "$LPASS_TF_STATE_ENTRY" 2>/dev/null || true)
     TF_STATE_SK=$(lpass show --password "$LPASS_TF_STATE_ENTRY" 2>/dev/null || true)
@@ -170,9 +388,12 @@ for env in "${ENVS[@]}"; do
     exit 1
   fi
 
-  # 5. Create tarball
+  # 5. Create tarball. Track it for cleanup (it's a sibling of STAGING, not
+  # inside it) and create it 0600 via umask so the plaintext secrets aren't
+  # world-readable in the window before encryption.
   TARBALL="$STAGING.tar.gz"
-  tar czf "$TARBALL" -C "$STAGING" .
+  CLEANUP_DIRS+=("$TARBALL")
+  ( umask 077; tar czf "$TARBALL" -C "$STAGING" . )
   rm -rf "$STAGING"
 
   # 6. Encrypt with ansible-vault
@@ -180,7 +401,7 @@ for env in "${ENVS[@]}"; do
   print_status "  Encrypting → $VAULT_FILE"
 
   ansible-vault encrypt "$TARBALL" \
-    --vault-password-file <(echo "$VAULT_PASSWORD") \
+    --vault-password-file <(printf '%s\n' "$VAULT_PASSWORD") \
     --output "$VAULT_FILE"
   rm -f "$TARBALL"
 
@@ -194,4 +415,6 @@ echo ""
 echo "Next steps:"
 echo "  1. Commit the vault files in config/platform/ci/"
 echo "  2. Re-provision the CI box: ./ci/scripts/provision-ci.sh --ansible-only"
-echo "  3. Add 'deploy_vault_password' secret in Woodpecker UI (same password as LastPass entry)"
+echo "  3. dev uses its own vault password (LastPass: $LPASS_DEV_VAULT_ENTRY) —"
+echo "     set the 'deploy_vault_password_dev' Ansible var so CI can decrypt it."
+echo "     prod/prod-eu use the shared 'deploy_vault_password' Woodpecker secret."


### PR DESCRIPTION
## Summary

Lets a fellow developer be given a vault password that decrypts **only the dev vault**, never prod/prod-eu — and lets them add/update **dev tenant secrets** themselves with nothing but that password.

Today a single Ansible Vault password encrypts all three deploy vaults (`config/platform/ci/deploy-vault-{dev,prod,prod-eu}.vault`), and the encrypted prod/prod-eu blobs are committed right next to dev's. So handing out "the vault password" hands out prod too. This PR re-keys **dev** with its own password and gives contributors a self-service path that doesn't touch prod, LastPass, kubeconfigs, terraform outputs, or tf-state creds.

## What changed

| File | Change |
|---|---|
| `scripts/build-deploy-vaults.sh` | Per-env password: **dev → its own LastPass note**, prod/prod-eu → the existing shared note. `MT_VAULT_PASSWORD[_FILE]` override **scoped to dev** with fail-fast guards (a stray export can't re-key prod). New **`--update-secrets --tenant <name>`** patch mode: decrypt existing vault → overlay only the named tenants' secrets → re-encrypt, leaving kubeconfig/tf-outputs/tf-state untouched. Plaintext tarballs created `0600` and tracked for cleanup. |
| `ci/scripts/ci-lib.sh` | New `ci_decrypt_vault` helper. For **dev**, if the host has the dev-pass file it tries the dev password first and falls back to the shared one (so the re-key has **no flag-day**). **prod/prod-eu path is byte-for-byte unchanged.** |
| `ci/scripts/ci-deploy.sh`, `ci-deploy-app.sh` | Call the helper instead of inline decrypt (the only two decrypt sites in the repo). |
| `ci/ansible/playbook.yml` | Gated, `no_log` task writing `deploy_vault_password_dev` → `/home/woodpecker/deploy-vaults/dev-vault-pass` (`0600`). No-op unless the var is set. |
| `DEV_VAULT_ACCESS.md` | Operator re-key runbook (with an isolation acceptance test) + the contributor guide. |

**Merge-safety:** nothing changes for CI until the operator re-keys — the helper falls back to the shared password and the Ansible task is gated on the var. prod/prod-eu encryption and decryption are untouched.

## Operator: one-time activation (after merge)

See `DEV_VAULT_ACCESS.md` for the full runbook. In short:

1. `openssl rand -base64 24` → store as LastPass note **`mothertree-dev-vault-password`**; share it with the dev.
2. `./scripts/build-deploy-vaults.sh dev` (re-keys dev; prod/prod-eu untouched).
3. Run the acceptance test in the runbook (dev password **must** open the dev blob and **must fail** on the prod blob).
4. Add `deploy_vault_password_dev: "<pw>"` to the **gitignored** `config/platform/ci/ansible-vars.yml`.
5. `./ci/scripts/provision-ci.sh --ansible-only`.

> After merge, `build-deploy-vaults.sh dev` requires that LastPass note — create it (step 1) before your next dev/all-env vault build, or it fails with an instructive error.

---

## 📨 Note to the contributing dev (and their AI agent)

You can now add or update **dev** tenant secrets yourself and ship them through CI. You **deploy via CI only — never directly.**

**You need:**
- The **dev vault password** (ask the operator for it — it's the LastPass note `mothertree-dev-vault-password`; you do **not** need LastPass access yourself).
- **Write access** to the `config/tenants` and `config/platform` git submodules.
- `ansible-vault` and `tar` installed locally (`pip install ansible` (or `ansible-core`) gives you `ansible-vault`).
- You do **not** need: LastPass, the dev kubeconfig, terraform outputs, tf-state credentials, or any prod access.

**To add/update a dev secret:**

```bash
# 1. Edit the plaintext secret (gitignored — never committed directly)
$EDITOR config/tenants/<tenant>/dev.secrets.yaml

# 2. Patch it into the dev vault. --tenant is repeatable; at least one is required.
#    Only the tenant(s) you name are touched.
MT_VAULT_PASSWORD='<dev-vault-password>' \
  ./scripts/build-deploy-vaults.sh dev --update-secrets --tenant <tenant>

# (prefer not to put the password in shell history? use a file instead:)
# MT_VAULT_PASSWORD_FILE=~/.mt-dev-vault-pass \
#   ./scripts/build-deploy-vaults.sh dev --update-secrets --tenant <tenant>

# 3. Commit the updated ENCRYPTED blob and open a PR
cd config/platform && git add ci/deploy-vault-dev.vault && git commit -m "dev: update <tenant> secrets"
```

CI deploys your change to dev automatically.

**Rules / gotchas for the AI agent:**
- This is the **public** OSS repo. The plaintext `*.secrets.yaml` files are **gitignored** — only the **encrypted** `deploy-vault-dev.vault` blob is ever committed. Never commit a plaintext secret, and never paste real secret values into code, logs, or PR text.
- `MT_VAULT_PASSWORD` is honoured **for `dev` only**. Running a `prod`/`prod-eu`/all-env build with it set will (intentionally) fail — that's a guard, not a bug. You cannot build or patch prod; you don't have its password.
- Always pass `--tenant <name>` explicitly. The tool refuses to run without it, so a stale local copy of some other tenant can't silently overwrite the vault.
- The dev vault password decrypts the **entire** dev vault (dev kubeconfig, tf-state creds, and every tenant's dev secrets), and patch mode exposes all of that transiently in a local temp dir while it runs. It grants **zero** prod/prod-eu access. Treat the password like any other secret — don't echo it, don't commit it, don't put it in PR descriptions.
- If `build-deploy-vaults.sh dev --update-secrets` errors with "wrong vault password", you have the wrong/old dev password — ask the operator; do not try other passwords.

---

## OSS Compliance Review

**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0 — clean.**

Scanned all 6 files (+440/-39). No real tenant domains, personal info, hardcoded credentials/secrets, private registry refs, or internal IPs/hostnames. Real values are sourced at runtime from LastPass / `MT_VAULT_PASSWORD[_FILE]` / the gitignored `ansible-vars.yml`. Whitelisted-and-expected items (not flagged): LastPass numeric ID `7375668101991863677` (policy: OK in public repo), LastPass note **names** (`mothertree-dev-vault-password`, `mothertree-tf-state-dev-s3-credentials`), `/home/woodpecker/...` paths, the `mothertree-tf-state-dev` bucket name, and doc placeholders (`acme`, `<tenant>`, `<pw>`).

## Security Review

**CRITICAL: 0 | HIGH: 0 | MEDIUM: 2 → fixed | LOW: 1 → resolved by the fixes.**

The primary objective — a dev-only password that **cannot** decrypt prod/prod-eu — was empirically verified with real `ansible-vault` (core 2.21.0): the dev password alone fails on the prod blob; the two-`--vault-id` form decrypts both a re-keyed and a not-yet-re-keyed dev vault (no flag-day); offering both ids to a prod blob leaks nothing the CI host doesn't already hold. Override-scoping, the `no_log` task, file modes, and the CI helper's temp-file trap were all reviewed clean.

Two MEDIUM temp-file-hygiene findings were raised **and fixed in this PR**:
- The plaintext re-tar (`NEWTAR`, and the pre-existing full-build `TARBALL`) was a sibling of the staging dir and **not** in the cleanup trap → could orphan plaintext secrets in `/tmp` on a kill/failed-encrypt. **Fixed:** both are now tracked and removed by the trap (verified: induced encrypt failure leaves zero leftover tarballs).
- Those tarballs were created `0644` (world-readable) under the default umask. **Fixed:** created under `umask 077` → `0600` (verified). The LOW (runbook wording) is moot now that exposure is confined and mode-restricted.

## Testing

All verified in isolated sandboxes (never against the real vaults), on `ansible-vault [core 2.21.0]`:
- Full build round-trips through the **unchanged** CI decrypt path (no prod regression); dev re-key uses its own LastPass note and the result opens with the dev password but **not** the shared one.
- Patch mode updates only named tenants, preserves kubeconfig/tf-outputs/tf-state, and is rejected without `--tenant` / on unknown tenant / on wrong password.
- `ci_decrypt_vault` branch matrix: dev re-keyed (dev@ matches), dev pre-rekey (shared fallback), dev re-keyed + no dev-pass file (**fails loud**, no silent prod-password fallback), prod (dev-pass ignored).
- Full end-to-end loop: operator re-key → contributor patch with **dev password only, lpass not on PATH** → CI sees the contributor's new value → dev password still can't open a prod vault.
- Override-scope guards + temp-file hardening (0600, no orphan on failure).

The acceptance test against the **real committed blobs** is intentionally deferred to operator runbook step 3 (needs the dev password generated at activation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
