### PR TITLE
feat(ci): decrypt deploy vault from committed config submodule (#463)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,10 +95,10 @@ deploy-prod → deploy_infra -e prod + create_env -e prod -t <all tenants>
 ```
 
 **Secrets architecture**:
-- Kubeconfigs, terraform outputs, and tenant secrets are stored as **Ansible Vault-encrypted archives** on the CI host (`/home/woodpecker/deploy-vaults/{dev,prod}.vault`)
+- Kubeconfigs, terraform outputs, and tenant secrets are stored as **Ansible Vault-encrypted archives committed in the `config/platform` submodule** (`config/platform/ci/deploy-vault-{dev,prod,prod-eu}.vault`). The deploy scripts decrypt **from the cloned committed copy** — so a merged vault change deploys on the next pipeline run with no operator reprovision (GitHub issue #463). There is no fallback to the old host-provisioned copy under `/home/woodpecker/deploy-vaults`; a missing committed vault is a hard error.
 - Decrypted into temp dirs at build time, cleaned up on exit
-- Private config submodules cloned via GitHub PAT (fine-grained, read-only)
-- Vault password stored as Woodpecker secret `deploy_vault_password`
+- Private config submodules cloned via GitHub PAT (fine-grained, read-only) **before** vault decryption (the committed vault lives inside `config/platform`)
+- Vault password stored as Woodpecker secret `deploy_vault_password` (prod/prod-eu); dev uses its own password provisioned to the host as `dev-vault-pass` (see `DEV_VAULT_ACCESS.md`)
 - Build vaults with `scripts/build-deploy-vaults.sh` (uses `lpass` for vault password)
 
 **Key files**: `ci/scripts/ci-deploy.sh` (deploy wrapper), `.woodpecker/deploy-dev.yaml`, `.woodpecker/deploy-prod.yaml`, `ci/ansible/playbook.yml` (CI box provisioning), `scripts/build-deploy-vaults.sh` (vault assembly)

--- a/DEV_VAULT_ACCESS.md
+++ b/DEV_VAULT_ACCESS.md
@@ -33,6 +33,18 @@ Run once, from an operator machine with LastPass + the repo checked out.
    ```bash
    ./scripts/build-deploy-vaults.sh dev
    ```
+   Then **commit the re-keyed blob** in the `config/platform` submodule — CI
+   decrypts the vault from this committed copy, so the re-key isn't live until
+   it's merged:
+   ```bash
+   cd config/platform && git add ci/deploy-vault-dev.vault && git commit -m "dev: re-key vault" && git push
+   cd ../.. && git add config/platform && git commit -m "chore(config): bump platform — dev vault re-key"
+   ```
+   > The second commit is required: CI clones with `git submodule update --init`
+   > (no `--remote`), so it checks out the config/platform commit **pinned in the
+   > mothertree-oss tree**. Bumping that pointer in a mothertree-oss PR is what
+   > makes the new vault live — committing inside config/platform alone is not
+   > enough.
 
 3. **Acceptance test — prove the password is dev-only.** Both lines must behave
    as labelled, against the real committed blobs:
@@ -59,8 +71,11 @@ Run once, from an operator machine with LastPass + the repo checked out.
    > `ansible-vars.yml`. Ansible writes it to
    > `/home/woodpecker/deploy-vaults/dev-vault-pass` (0600) with `no_log`.
 
-5. **Re-provision the CI host** (pushes the re-keyed dev vault + the dev-pass
-   file together):
+5. **Re-provision the CI host** to push the **dev password file**
+   (`dev-vault-pass`). The vault *blob* is no longer pushed to the host — CI
+   reads it from the committed copy (step 2) — but the password that unlocks it
+   still comes from the host file written by Ansible, so reprovision whenever
+   the dev password changes:
    ```bash
    ./ci/scripts/provision-ci.sh --ansible-only
    ```
@@ -117,14 +132,25 @@ You deploy via CI only — never directly.
    > Prefer not to put the password in your shell history? Use a file:
    > `MT_VAULT_PASSWORD_FILE=~/.mt-dev-vault-pass ./scripts/build-deploy-vaults.sh dev --update-secrets --tenant <tenant>`
 
-3. **Commit the updated vault blob** in the `config/platform` submodule and open
-   a PR:
+3. **Commit the updated vault blob** in the `config/platform` submodule, then
+   **bump the submodule pointer** in the mothertree-oss superproject and open a
+   PR there:
    ```bash
    cd config/platform
    git add ci/deploy-vault-dev.vault
    git commit -m "dev: update <tenant> secrets"
+   git push                                   # push the config/platform commit
+   cd ../..
+   git add config/platform                    # record the new pointer
+   git commit -m "chore(config): update <tenant> dev secrets"
    ```
-   CI deploys the change to dev.
+   The second commit (the pointer bump) is the one that matters: CI clones with
+   `git submodule update --init` (no `--remote`), so it checks out the
+   config/platform commit **pinned in the mothertree-oss tree** — not the tip of
+   the submodule branch. Open the **mothertree-oss** PR with that pointer bump.
+   Once merged, the **next pipeline run decrypts this committed vault directly**
+   and deploys the change to dev — no operator reprovision of the CI host is
+   needed (GitHub issue #463).
 
 ### What the dev password actually grants
 The dev password decrypts the **entire** dev vault — the dev kubeconfig,

--- a/ci/scripts/ci-deploy-app.sh
+++ b/ci/scripts/ci-deploy-app.sh
@@ -44,13 +44,6 @@ MODE="${2:?Usage: ci-deploy-app.sh <env> <mode>}"
 
 echo "=== CI Deploy App: env=$MT_ENV mode=$MODE pipeline=#${CI_PIPELINE_NUMBER:-unknown} ==="
 
-# ── Decrypt vault ────────────────────────────────────────────────
-VAULT_FILE="/home/woodpecker/deploy-vaults/deploy-vault-${MT_ENV}.vault"
-if [[ ! -f "$VAULT_FILE" ]]; then
-  echo "ERROR: Deploy vault not found: $VAULT_FILE"
-  exit 1
-fi
-
 WORK_DIR=$(mktemp -d /tmp/mt-deploy-XXXXXX)
 chmod 0700 "$WORK_DIR"
 
@@ -68,7 +61,14 @@ _cleanup() {
 }
 trap _cleanup EXIT
 
-ci_decrypt_vault "$VAULT_FILE" "$MT_ENV" "$WORK_DIR/secrets.tar.gz"
+# ── Clone private config submodules (provides the committed vault) ──
+# config/platform carries the committed deploy vaults, so the submodules MUST be
+# cloned before decryption (GitHub issue #463 — committed copy is the source of
+# truth, no operator reprovision needed for a vault change).
+ci_clone_config_submodules "$REPO_ROOT"
+
+# ── Decrypt vault (from the committed config/platform copy) ───────
+ci_decrypt_committed_vault "$REPO_ROOT" "$MT_ENV" "$WORK_DIR/secrets.tar.gz"
 tar xzf "$WORK_DIR/secrets.tar.gz" -C "$WORK_DIR"
 rm -f "$WORK_DIR/secrets.tar.gz"
 
@@ -97,16 +97,6 @@ set -a
 # shellcheck disable=SC1090
 source "$MT_TERRAFORM_OUTPUTS_FILE"
 set +a
-
-# ── Clone private config submodules ───────────────────────────────
-cd "$REPO_ROOT"
-if [[ -n "${GITHUB_PAT:-}" ]]; then
-  git config --global url."https://x-access-token:${GITHUB_PAT}@github.com/".insteadOf "git@github.com:"
-fi
-git submodule update --init config/platform config/tenants || {
-  echo "ERROR: Failed to init config submodules"
-  exit 1
-}
 
 # ── Copy secrets from vault ──────────────────────────────────────
 if [[ -d "$WORK_DIR/tenants" ]]; then

--- a/ci/scripts/ci-deploy.sh
+++ b/ci/scripts/ci-deploy.sh
@@ -40,14 +40,6 @@ done
 
 echo "=== CI Deploy: env=$MT_ENV all_tenants=$ALL_TENANTS pipeline=#${CI_PIPELINE_NUMBER:-unknown} ==="
 
-# ── Decrypt vault ────────────────────────────────────────────────
-VAULT_FILE="/home/woodpecker/deploy-vaults/deploy-vault-${MT_ENV}.vault"
-if [[ ! -f "$VAULT_FILE" ]]; then
-  echo "ERROR: Deploy vault not found: $VAULT_FILE"
-  echo "Run Ansible to provision vault files to the CI host."
-  exit 1
-fi
-
 WORK_DIR=$(mktemp -d /tmp/mt-deploy-XXXXXX)
 chmod 0700 "$WORK_DIR"
 
@@ -106,8 +98,16 @@ _start_lease_renewal() {
   echo "Started lease renewal background process (PID: $_LEASE_RENEWAL_PID)"
 }
 
+# ── Clone private config submodules (provides the committed vault) ──
+# config/platform carries the committed deploy vaults, so the submodules MUST be
+# cloned before decryption. This used to happen AFTER the decrypt, when the vault
+# came from the CI host; GitHub issue #463 moved the source of truth to the
+# committed copy so a merged vault change deploys with no operator reprovision.
+ci_clone_config_submodules "$REPO_ROOT"
+
+# ── Decrypt vault (from the committed config/platform copy) ───────
 echo "Decrypting deploy vault ($MT_ENV) → $WORK_DIR"
-ci_decrypt_vault "$VAULT_FILE" "$MT_ENV" "$WORK_DIR/secrets.tar.gz"
+ci_decrypt_committed_vault "$REPO_ROOT" "$MT_ENV" "$WORK_DIR/secrets.tar.gz"
 tar xzf "$WORK_DIR/secrets.tar.gz" -C "$WORK_DIR"
 rm -f "$WORK_DIR/secrets.tar.gz"
 echo "Vault decrypted successfully"
@@ -163,22 +163,6 @@ if [[ -f "$WORK_DIR/tf-state-creds.env" ]]; then
   set +a
   echo "Loaded phase1-dev tf-state credentials"
 fi
-
-# ── Clone private config submodules ───────────────────────────────
-# Use GitHub PAT to authenticate SSH-based submodule URLs via URL rewriting.
-# Must be --global so child git processes (spawned by submodule update) inherit it.
-cd "$REPO_ROOT"
-if [[ -n "${GITHUB_PAT:-}" ]]; then
-  git config --global url."https://x-access-token:${GITHUB_PAT}@github.com/".insteadOf "git@github.com:"
-  echo "Configured git URL rewriting for private submodule access"
-fi
-
-echo "Initializing config submodules..."
-git submodule update --init config/platform config/tenants || {
-  echo "ERROR: Failed to init config submodules."
-  echo "Ensure GITHUB_PAT secret is set and has access to the private config repos."
-  exit 1
-}
 
 # ── Copy secrets from vault into workspace ────────────────────────
 # Config files come from submodules; secrets come from the encrypted vault.

--- a/ci/scripts/ci-lib.sh
+++ b/ci/scripts/ci-lib.sh
@@ -101,6 +101,60 @@ ci_decrypt_vault() {
     --output "$out_tar"
 }
 
+# ── Config submodule clone ──────────────────────────────────────
+# Clone the private config submodules (config/platform, config/tenants) into
+# the checkout. config/platform carries the committed, encrypted deploy vaults
+# (config/platform/ci/deploy-vault-<env>.vault) that ci_decrypt_committed_vault
+# reads, so this MUST run BEFORE vault decryption — not after, as it did when
+# the vault was sourced from the CI host (GitHub issue #463). Uses GITHUB_PAT
+# (a Woodpecker pipeline secret, not something stored in the vault, so there is
+# no chicken-and-egg) to rewrite the SSH submodule URLs to authenticated HTTPS;
+# --global so the child git processes spawned by `submodule update` inherit it.
+# Leaves the cwd at <repo_root>.
+#
+#   ci_clone_config_submodules <repo_root>
+ci_clone_config_submodules() {
+  local repo_root="${1:?ci_clone_config_submodules: repo_root required}"
+  cd "$repo_root" || return 1
+  if [[ -n "${GITHUB_PAT:-}" ]]; then
+    git config --global url."https://x-access-token:${GITHUB_PAT}@github.com/".insteadOf "git@github.com:"
+    echo "Configured git URL rewriting for private submodule access"
+  fi
+  echo "Initializing config submodules..."
+  git submodule update --init config/platform config/tenants || {
+    echo "ERROR: Failed to init config submodules." >&2
+    echo "Ensure GITHUB_PAT secret is set and has access to the private config repos." >&2
+    return 1
+  }
+}
+
+# ── Committed deploy-vault decryption ───────────────────────────
+# Decrypt the env's deploy vault from the COMMITTED copy inside the cloned
+# config/platform submodule (config/platform/ci/deploy-vault-<env>.vault) — the
+# single source of truth. A merged vault change is therefore picked up by the
+# next pipeline run with no operator reprovision (GitHub issue #463).
+#
+# There is deliberately NO fallback to the old host-provisioned copy under
+# /home/woodpecker/deploy-vaults: a missing committed vault is a hard error, not
+# a silent downgrade to a possibly-stale host copy (project rule: fail fast,
+# never silently skip). Password selection is unchanged — delegated to
+# ci_decrypt_vault (dev-only password for dev, shared operator password for
+# prod/prod-eu). Requires ci_clone_config_submodules to have run first.
+#
+#   ci_decrypt_committed_vault <repo_root> <env> <out_tar>
+ci_decrypt_committed_vault() {
+  local repo_root="${1:?ci_decrypt_committed_vault: repo_root required}"
+  local env="${2:?ci_decrypt_committed_vault: env required}"
+  local out_tar="${3:?ci_decrypt_committed_vault: out_tar required}"
+  local vault_file="$repo_root/config/platform/ci/deploy-vault-${env}.vault"
+  if [[ ! -f "$vault_file" ]]; then
+    echo "ERROR: Committed deploy vault not found: $vault_file" >&2
+    echo "       Expected it in the config/platform submodule — run ci_clone_config_submodules first." >&2
+    return 1
+  fi
+  ci_decrypt_vault "$vault_file" "$env" "$out_tar"
+}
+
 # ── Woodpecker API helpers ──────────────────────────────────────
 # Token is deployed to the CI host by Ansible (ci/ansible/playbook.yml).
 _WP_API_TOKEN_FILE="/home/woodpecker/.woodpecker-api-token"


### PR DESCRIPTION
## Summary

Closes #463. CI deploy pipelines now decrypt the per-environment deploy vault from the **committed** copy inside the cloned `config/platform` submodule (`config/platform/ci/deploy-vault-<env>.vault`) instead of the host-provisioned copy under `/home/woodpecker/deploy-vaults/`.

A merged vault change is therefore used directly by the next pipeline run — no operator reprovision over SSH. This completes the contributor self-service story from #459: a contributor who can edit dev secrets can now also get their vault change deployed without CI-host access.

## What changed

- **`ci/scripts/ci-lib.sh`** — two new helpers so both deploy scripts share one correct implementation:
  - `ci_clone_config_submodules <repo_root>` — the PAT setup + `git submodule update` (lifted verbatim from the two scripts).
  - `ci_decrypt_committed_vault <repo_root> <env> <out_tar>` — resolves the committed vault path and **hard-fails if absent**. Password selection is unchanged — it delegates to the existing `ci_decrypt_vault` (dev-first → shared fallback for dev; shared for prod/prod-eu).
- **`ci/scripts/ci-deploy.sh` / `ci-deploy-app.sh`** — moved the config-submodule clone to **before** decryption (the committed vault lives inside `config/platform`), swapped the host path for the committed one, and removed the now-redundant later clone block.
- **`CLAUDE.md` / `DEV_VAULT_ACCESS.md`** — reworded to the committed-source model, including the superproject **submodule-pointer bump** CI requires (it clones with `git submodule update --init`, no `--remote`/`branch=`, so it checks out the SHA pinned in mothertree-oss — committing inside `config/platform` alone is not enough).

## Design decisions

- **No silent fallback to the host copy** (per maintainer choice): a missing committed vault is a hard error, matching the repo's "fail fast, never silently skip" rule. A silent fallback would let prod quietly keep using a stale host copy and mask a bug in the new path.
- **Host-copy Ansible provisioning kept** (`Deploy encrypted vault files` task) as an operator safety net for now; the `dev-vault-pass` password task stays (password source is unchanged). **Removing the vestigial host-copy task is a deferred follow-up.**

## Verification

- `bash -n` clean; `shellcheck -S error` (the CI gate) clean on all three scripts.
- Smoke-tested the new helper against the **real committed blobs**: dev decrypts via the dev-first password path, prod via the shared path, and a missing vault fails loud with a clear message.
- Scope note: the smoke test exercised `ci_decrypt_committed_vault` directly. The clone-first **reorder** is safe by reasoning (clone logic unchanged, just moved earlier; nothing between decrypt and the old clone site depended on ordering) — not run in a live pipeline.

## OSS Compliance Review

**Result: clean — 0 findings (CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0).**

- No hardcoded credentials — every reference is an env-var name, Woodpecker secret name, host file path, or documented placeholder.
- No real tenant domains or PII; tenant references are the generic `<tenant>` placeholder. Only filesystem path is the `woodpecker` service-account home.
- No private-submodule content leaked into the public tree. The encrypted `.vault` blobs are **not** in this diff — only references to their committed path inside the private `config/platform` submodule (their correct location).
- Pre-existing LastPass numeric ID in `DEV_VAULT_ACCESS.md` is unchanged and allowed per project convention.

## Security Review

**Result: 0 critical / 0 high; 2 LOW (both pre-existing or the deliberate fail-fast tradeoff — no action required).**

- **Clone-before-decrypt / PAT exposure** — Clean. `GITHUB_PAT` is a Woodpecker pipeline secret (`from_secret: github_pat`, verified across every deploy pipeline incl. prod/prod-eu), not stored in the vault, so there's no chicken-and-egg. The PAT-in-gitconfig handling is byte-for-byte the prior logic, just relocated into the shared helper.
- **No host fallback / fail-fast** — Clean. File path and password are both keyed off the **same** `env`, so a missing/renamed file is a hard failure, never a silent downgrade to the wrong password/env. All three committed vaults confirmed present at the constructed path, so the hard-fail won't spuriously brick prod.
- **dev↔prod password isolation** — Clean. `ci_decrypt_vault` is unchanged; the dev password is never offered against a prod vault (prod offers only the shared `DEPLOY_VAULT_PASSWORD`). Vault-at-rest exposure is unchanged (blobs were already committed).
- LOW-1: `GITHUB_PAT` persisted in `~/.gitconfig` with no cleanup — pre-existing, relocated not introduced; acceptable on the single-tenant CI box.
- LOW-2: prod decrypt now depends on a successful submodule clone (GitHub/PAT availability) — a deliberate availability tradeoff of the single-source-of-truth design, not a confidentiality/integrity weakness.

## Version Bump

No-op — no portal application code (`apps/admin-portal/`, `apps/account-portal/`) changed, so no VERSION / `image-versions.env` bump is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
