### PR TITLE
fix(dev): drop roundcube_* DBs on cluster destroy to kill the Roundcube session-schema poison

### DIFF
--- a/scripts/destroy-dev-cluster.sh
+++ b/scripts/destroy-dev-cluster.sh
@@ -279,45 +279,63 @@ if [ "$CLUSTER_EXISTS" = "true" ]; then
     sleep 2
   done
 
-  # 2c — Drop tenant Nextcloud databases via the in-cluster PgBouncer.
+  # 2c — Drop tenant Nextcloud + Roundcube databases via the in-cluster PgBouncer.
   # The postgres-dev VM is preserved across destroy/recreate cycles (always-up),
-  # which means the tenant DBs persist too. For Nextcloud specifically this
-  # breaks cold-start: the DB has tables + appconfig from the previous cycle,
-  # but the K8s `nextcloud-identity` Secret (which encodes config.php identity
-  # values) is destroyed with the cluster. The new pods can't replay the prior
-  # install state, the entrypoint sees the existing DB and skips install, and
-  # the deploy script then fails on `occ config:system:set` because Nextcloud
-  # reports installed=false. Dropping the DB lets the next deploy reinstall
-  # cleanly from an empty schema. (See PR notes for the full incident.)
+  # which means the tenant DBs persist too. Two services break when their schema
+  # is allowed to outlive the cluster that created it:
+  #
+  #   Nextcloud — the DB has tables + appconfig from the previous cycle, but the
+  #   K8s `nextcloud-identity` Secret (which encodes config.php identity values)
+  #   is destroyed with the cluster. The new pods can't replay the prior install
+  #   state, the entrypoint sees the existing DB and skips install, and the
+  #   deploy script then fails on `occ config:system:set` because Nextcloud
+  #   reports installed=false.
+  #
+  #   Roundcube — the image's entrypoint runs the forward-only `updatedb.sh`,
+  #   which is gated by a `system.roundcube-version` stamp. Once the persistent
+  #   DB has been migrated forward by one image version (or hand-patched during
+  #   an incident), a later image can neither re-migrate nor roll back: e.g. the
+  #   1.6↔1.7 `session.changed`/`session.expires_at` rename leaves the session
+  #   table mismatched against the deployed code, every session write errors, the
+  #   OAuth state is lost across the Keycloak redirect, and Roundcube login hangs
+  #   ("OIDC redirect timed out"). Because the lease randomly picks one of the
+  #   pool tenants, this manifested as a deterministic per-pool e2e failure that
+  #   survived every cluster rebuild (the cluster is ephemeral; this DB was not).
+  #
+  # Dropping both lets the next deploy recreate an empty DB (the idempotent
+  # roundcube-db-init / nextcloud install Jobs do this), so the schema is always
+  # rebuilt fresh from the deployed image — no cross-version drift can persist.
+  # Session/contact/cache data in the roundcube DB is disposable login state.
   #
   # We run this BEFORE terraform destroy because PgBouncer is in-cluster — once
   # the cluster is gone, the only path to postgres-dev is via direct Tailscale,
   # which the operator's local machine doesn't always have.
-  print_status "Dropping tenant Nextcloud databases via in-cluster PgBouncer..."
+  print_status "Dropping tenant Nextcloud + Roundcube databases via in-cluster PgBouncer..."
   PG_PASSWORD=$("${KUBECTL[@]}" get secret postgres-credentials -n infra-db \
     -o jsonpath='{.data.postgres-password}' 2>/dev/null | base64 -d || true)
   if [ -z "$PG_PASSWORD" ]; then
     print_error "Could not load postgres-credentials secret — refusing to continue."
-    print_error "Cold-start of Nextcloud on the next cycle would fail. Either drop the DBs"
-    print_error "manually before re-running this script, or fix the postgres-credentials Secret."
+    print_error "Cold-start of Nextcloud/Roundcube on the next cycle would fail. Either drop the"
+    print_error "DBs manually before re-running this script, or fix the postgres-credentials Secret."
     exit 4
   fi
-  # Discover nextcloud_<tenant> databases. Output one name per line.
+  # Discover nextcloud_<tenant> + roundcube_<tenant> databases. One name per line.
   TENANT_DBS=$("${KUBECTL[@]}" run psql-list-tenants --rm -i --restart=Never \
     --image=postgres:16 --quiet -n default \
     --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
     --env "PGUSER=postgres" \
     --env "PGPASSWORD=$PG_PASSWORD" \
-    -- psql -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'nextcloud\\_%' ESCAPE '\\';" \
+    -- psql -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'nextcloud\\_%' ESCAPE '\\' OR datname LIKE 'roundcube\\_%' ESCAPE '\\';" \
     2>/dev/null | grep -E '^[a-z0-9_-]+$' || true)
   if [ -z "$TENANT_DBS" ]; then
-    echo "  No nextcloud_* databases found, skipping drop"
+    echo "  No nextcloud_* / roundcube_* databases found, skipping drop"
   else
     while IFS= read -r db; do
       # Allowlist regex defends against SQL identifier injection. tenant DB names
-      # are operator-controlled via deploy scripts and always match `nextcloud_<tenant>`
-      # with lowercase + digits + underscore/hyphen; anything else is suspicious.
-      if [[ ! "$db" =~ ^nextcloud_[a-z0-9][a-z0-9_-]*$ ]]; then
+      # are operator-controlled via deploy scripts and always match
+      # `nextcloud_<tenant>` / `roundcube_<tenant>` with lowercase + digits +
+      # underscore/hyphen; anything else is suspicious.
+      if [[ ! "$db" =~ ^(nextcloud|roundcube)_[a-z0-9][a-z0-9_-]*$ ]]; then
         print_error "  Refusing to drop suspicious DB name: $db"
         exit 5
       fi

--- a/scripts/dev-bringup.sh
+++ b/scripts/dev-bringup.sh
@@ -201,6 +201,70 @@ if [ -z "$NEW_LB_IP" ]; then
     print_error "DNS may be stale (pointing at a destroyed cluster's IP)."
     exit 1
 fi
+
+# Reset persistent Roundcube tenant DBs so their schema always matches the
+# deployed image. postgres-dev is an always-up VM, so roundcube_<tenant> DBs
+# survive every cluster rebuild; Roundcube's forward-only, version-stamp-gated
+# updatedb.sh means a schema migrated forward by one image version (or
+# hand-patched during an incident) can neither re-migrate nor roll back — the
+# mismatch (e.g. the 1.6<->1.7 session.changed/expires_at rename) breaks OIDC
+# login ("OIDC redirect timed out") on whichever pool tenant carries the stale
+# DB. Dropping here on every bringup makes the next deploy recreate an empty DB
+# (via the idempotent roundcube-db-init Job) whose schema the entrypoint rebuilds
+# fresh from the deployed image — clearing any existing poison AND closing the
+# warm-cluster cross-version drift case. Session/contact/cache data on dev is
+# disposable login state. This is the bringup-side companion to the destroy-time
+# drop in scripts/destroy-dev-cluster.sh (Step 2c) — keep the two in sync.
+#
+# Bounded to dev: $KUBECONFIG points at the dev cluster (kubeconfig.dev.yaml),
+# whose in-cluster PgBouncer fronts the dev postgres VM only. Unlike the
+# best-effort destroy-side drop, this fails fast if the DB query errors — a
+# silent skip would leave webmail login broken for the whole pipeline.
+if [ "${MT_ENV:-dev}" = "dev" ]; then
+    print_status "dev-bringup: resetting persistent Roundcube tenant DBs (schema-vs-image drift guard)"
+    RC_PG_PASSWORD=$(kubectl --kubeconfig="$KUBECONFIG" get secret postgres-credentials -n infra-db \
+        -o jsonpath='{.data.postgres-password}' 2>/dev/null | base64 -d || true)
+    if [ -z "$RC_PG_PASSWORD" ]; then
+        print_error "dev-bringup: could not load postgres-credentials secret in infra-db"
+        print_error "Cannot reset the Roundcube DBs; a stale schema would break webmail OIDC login. Aborting."
+        exit 1
+    fi
+    RC_LIST_OUT=$(kubectl --kubeconfig="$KUBECONFIG" run rc-db-list --rm -i --restart=Never \
+        --image=postgres:16 --quiet -n default \
+        --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+        --env "PGUSER=postgres" \
+        --env "PGPASSWORD=$RC_PG_PASSWORD" \
+        -- psql -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'roundcube\\_%' ESCAPE '\\';" 2>&1) || {
+            print_error "dev-bringup: failed to query roundcube_* DBs via PgBouncer — cannot guarantee a clean schema"
+            sed 's/^/  /' <<< "$RC_LIST_OUT" >&2
+            exit 1
+        }
+    RC_DBS=$(echo "$RC_LIST_OUT" | grep -E '^[a-z0-9_-]+$' || true)
+    if [ -z "$RC_DBS" ]; then
+        echo "  No roundcube_* databases found, nothing to reset"
+    else
+        while IFS= read -r db; do
+            # Allowlist regex defends against SQL identifier injection; tenant DB
+            # names are operator-controlled and always match roundcube_<tenant>
+            # (lowercase + digits + underscore/hyphen). Anything else is suspicious.
+            if [[ ! "$db" =~ ^roundcube_[a-z0-9][a-z0-9_-]*$ ]]; then
+                print_error "dev-bringup: refusing to drop suspicious DB name: $db"
+                exit 1
+            fi
+            print_status "  Dropping $db (roundcube-db-init recreates it empty on next deploy)"
+            # DROP DATABASE cannot run in a transaction block, so one psql -c each.
+            kubectl --kubeconfig="$KUBECONFIG" run rc-db-drop --rm -i --restart=Never \
+                --image=postgres:16 --quiet -n default \
+                --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+                --env "PGUSER=postgres" \
+                --env "PGPASSWORD=$RC_PG_PASSWORD" \
+                -- psql -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS \"$db\" WITH (FORCE);" 2>&1 \
+                | sed 's/^/    /' \
+                || { print_error "dev-bringup: failed to drop $db — aborting"; exit 1; }
+        done <<< "$RC_DBS"
+    fi
+fi
+
 # secrets.tfvars.env is required by manage_infra; write it if absent
 # (reuse path doesn't run the cold-start block above).
 if [ ! -f "$REPO_ROOT/secrets.tfvars.env" ]; then

--- a/scripts/dev-bringup.sh
+++ b/scripts/dev-bringup.sh
@@ -219,7 +219,13 @@ fi
 # Bounded to dev: $KUBECONFIG points at the dev cluster (kubeconfig.dev.yaml),
 # whose in-cluster PgBouncer fronts the dev postgres VM only. Unlike the
 # best-effort destroy-side drop, this fails fast if the DB query errors — a
-# silent skip would leave webmail login broken for the whole pipeline.
+# silent skip would leave webmail login broken for the whole pipeline. But it
+# only fails after (a) waiting for PgBouncer to be ready and (b) retrying the
+# throwaway psql pod: pipeline #1519 hit `error: timed out waiting for the
+# condition` because the diagnostic pod couldn't reach Running within kubectl's
+# default 60s `--pod-running-timeout` (cold/autoscaling node). Mitigations:
+# reuse the small postgres:15-alpine image db-init already pulls (warm cache),
+# raise the pod-running-timeout, and retry with backoff.
 if [ "${MT_ENV:-dev}" = "dev" ]; then
     print_status "dev-bringup: resetting persistent Roundcube tenant DBs (schema-vs-image drift guard)"
     RC_PG_PASSWORD=$(kubectl --kubeconfig="$KUBECONFIG" get secret postgres-credentials -n infra-db \
@@ -229,21 +235,46 @@ if [ "${MT_ENV:-dev}" = "dev" ]; then
         print_error "Cannot reset the Roundcube DBs; a stale schema would break webmail OIDC login. Aborting."
         exit 1
     fi
-    RC_LIST_OUT=$(kubectl --kubeconfig="$KUBECONFIG" run rc-db-list --rm -i --restart=Never \
-        --image=postgres:16 --quiet -n default \
-        --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
-        --env "PGUSER=postgres" \
-        --env "PGPASSWORD=$RC_PG_PASSWORD" \
-        -- psql -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'roundcube\\_%' ESCAPE '\\';" 2>&1) || {
-            print_error "dev-bringup: failed to query roundcube_* DBs via PgBouncer — cannot guarantee a clean schema"
-            sed 's/^/  /' <<< "$RC_LIST_OUT" >&2
-            exit 1
-        }
-    RC_DBS=$(echo "$RC_LIST_OUT" | grep -E '^[a-z0-9_-]+$' || true)
+
+    # Wait for PgBouncer to be ready before querying. On the cold path
+    # deploy_infra just created it and its pods may still be rolling; on the
+    # warm path this returns immediately. Best-effort — the retry loop below is
+    # the real guard, so a flaky rollout-status read shouldn't abort the run.
+    kubectl --kubeconfig="$KUBECONFIG" -n infra-db rollout status deploy/pgbouncer --timeout=180s 2>/dev/null \
+        || print_warning "dev-bringup: pgbouncer rollout status not confirmed; proceeding (retries will guard)"
+
+    # postgres:15-alpine matches roundcube-db-init, so it is already cached on
+    # warm nodes and small to pull on cold ones. --pod-running-timeout absorbs a
+    # node autoscale event; the retry loop absorbs transient scheduling/API
+    # hiccups. Unique pod names per attempt avoid a leftover-pod name collision
+    # if a timed-out `--rm` pod hasn't been GC'd yet.
+    RC_LIST_OUT=""
+    RC_QUERY_OK=false
+    for _rc_attempt in 1 2 3; do
+        if RC_LIST_OUT=$(kubectl --kubeconfig="$KUBECONFIG" run "rc-db-list-${_rc_attempt}" --rm -i --restart=Never \
+            --image=postgres:15-alpine --quiet -n default --pod-running-timeout=240s \
+            --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+            --env "PGUSER=postgres" \
+            --env "PGPASSWORD=$RC_PG_PASSWORD" \
+            -- psql -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'roundcube\\_%' ESCAPE '\\';" 2>&1); then
+            RC_QUERY_OK=true
+            break
+        fi
+        print_warning "dev-bringup: roundcube DB query attempt ${_rc_attempt}/3 failed; retrying in $((_rc_attempt * 15))s"
+        sleep "$((_rc_attempt * 15))"
+    done
+    if [ "$RC_QUERY_OK" != "true" ]; then
+        print_error "dev-bringup: failed to query roundcube_* DBs via PgBouncer after 3 attempts — cannot guarantee a clean schema"
+        printf '%s\n' "$RC_LIST_OUT" >&2
+        exit 1
+    fi
+    RC_DBS=$(grep -E '^[a-z0-9_-]+$' <<< "$RC_LIST_OUT" || true)
     if [ -z "$RC_DBS" ]; then
         echo "  No roundcube_* databases found, nothing to reset"
     else
+        _rc_i=0
         while IFS= read -r db; do
+            _rc_i=$((_rc_i + 1))
             # Allowlist regex defends against SQL identifier injection; tenant DB
             # names are operator-controlled and always match roundcube_<tenant>
             # (lowercase + digits + underscore/hyphen). Anything else is suspicious.
@@ -253,8 +284,10 @@ if [ "${MT_ENV:-dev}" = "dev" ]; then
             fi
             print_status "  Dropping $db (roundcube-db-init recreates it empty on next deploy)"
             # DROP DATABASE cannot run in a transaction block, so one psql -c each.
-            kubectl --kubeconfig="$KUBECONFIG" run rc-db-drop --rm -i --restart=Never \
-                --image=postgres:16 --quiet -n default \
+            # Node + image are warm now (the list query just ran here), so a single
+            # attempt with a generous timeout suffices; fail fast if it errors.
+            kubectl --kubeconfig="$KUBECONFIG" run "rc-db-drop-${_rc_i}" --rm -i --restart=Never \
+                --image=postgres:15-alpine --quiet -n default --pod-running-timeout=240s \
                 --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
                 --env "PGUSER=postgres" \
                 --env "PGPASSWORD=$RC_PG_PASSWORD" \

--- a/scripts/dev-bringup.sh
+++ b/scripts/dev-bringup.sh
@@ -243,11 +243,17 @@ if [ "${MT_ENV:-dev}" = "dev" ]; then
     kubectl --kubeconfig="$KUBECONFIG" -n infra-db rollout status deploy/pgbouncer --timeout=180s 2>/dev/null \
         || print_warning "dev-bringup: pgbouncer rollout status not confirmed; proceeding (retries will guard)"
 
-    # postgres:15-alpine matches roundcube-db-init, so it is already cached on
-    # warm nodes and small to pull on cold ones. --pod-running-timeout absorbs a
-    # node autoscale event; the retry loop absorbs transient scheduling/API
-    # hiccups. Unique pod names per attempt avoid a leftover-pod name collision
-    # if a timed-out `--rm` pod hasn't been GC'd yet.
+    # postgres:15-alpine is ~80MB, so it pulls in seconds even UNcached; it also
+    # matches roundcube-db-init, so it's additionally warm-cached on the
+    # warm-reuse path. Cold-path safety does NOT rely on that cache (db-init runs
+    # later, in create_env's deploy-roundcube step, not here): deploy_infra has
+    # already brought a node Ready before this block runs, so the throwaway pod
+    # schedules immediately and an uncached alpine pull stays well within
+    # --pod-running-timeout (240s, vs kubectl's 60s default that timed out in
+    # #1519 pulling the heavier postgres:16). The timeout also absorbs a node
+    # autoscale event; the retry loop absorbs transient scheduling/API hiccups.
+    # Unique pod names per attempt avoid a leftover-pod name collision if a
+    # timed-out `--rm` pod hasn't been GC'd yet.
     RC_LIST_OUT=""
     RC_QUERY_OK=false
     for _rc_attempt in 1 2 3; do


### PR DESCRIPTION
## What & why

The recurring **\"echo group\" e2e failures** (e.g. pipeline [1516](https://ci.mother-tree.org/repos/1/pipeline/1516), 1502 — shard-5 + shard-10) are **not** an echo-group / spam / delivery problem. The round-trip test never sends a single email: it dies at `roundcubeLogin()` (`email-roundtrip.spec.ts:33`) because **Roundcube's OIDC login hangs** ("OIDC redirect timed out") — the inbox selector never appears. Every Roundcube-dependent test fails the same way; the "echo group" label is collateral.

### Root cause (deterministic, pool-specific)

| Evidence | |
|---|---|
| pool2 runs (1516, 1502) | **fail** — all Roundcube tests time out at login |
| pool1 runs (1504, 1508, 1509) | **green** |
| same pipeline, shard-10 | admin-portal SSO ✓, Files SSO ✓, sign-out ✓ — **only "SSO to Roundcube" fails** → Keycloak realm healthy |
| pool2 roundcube pods | deployed **Ready**, image `0.3.5` (`roundcube/roundcubemail:1.7.1-apache`), no crashloop |
| pool2 Stalwart | principals provisioned `ok`; IMAPS readiness LOGIN+SELECT INBOX `ok` |

So pods, Keycloak, and Stalwart are all healthy — the only differentiator is **persistent per-tenant state**. The on-demand dev cluster is ephemeral, but **`postgres-dev` is an always-up VM**, so the `roundcube_<tenant>` DBs persist across every reap/rebuild. `destroy-dev-cluster.sh` already drops `nextcloud_<tenant>` for exactly this reason, but **left `roundcube_<tenant>` behind**. A Roundcube schema migrated forward by one image version (or hand-patched during an incident — the 1.6↔1.7 `session.changed`/`session.expires_at` rename, gated by the forward-only `updatedb.sh` version stamp) therefore outlives the cluster forever: session writes error → OAuth state lost across the Keycloak redirect → login hangs. The lease randomly picks one of two pool tenants, so only the poisoned pool failed — a deterministic per-pool "flake" that survived every rebuild.

### Fix

Generalize the Step-2c drop block to cover **both** `nextcloud_*` and `roundcube_*` (same in-cluster PgBouncer path, same allowlist regex `^(nextcloud|roundcube)_[a-z0-9][a-z0-9_-]*$`, same `DROP ... WITH (FORCE)`). On the next deploy the idempotent `roundcube-db-init` job recreates an empty DB and the entrypoint rebuilds the schema fresh from the deployed image — **no cross-version drift can persist**. Roundcube session/contact/cache data on dev is disposable login state.

Dev-only by construction: the script has a hard `MT_ENV != dev` guard and operates solely on the always-up dev postgres VM (KUBECTL pinned to `kubeconfig.dev.yaml`).

### ⚠️ Clearing the *current* poison

This drop fires at **destroy** time, so it prevents recurrence on every future cycle. The **already-poisoned** DB on `postgres-dev` will not clear until a destroy runs with this code (next idle-reap) — i.e. the very next pipeline could still fail if it leases the poisoned pool. To clear it immediately, drop the poisoned `roundcube_<tenant>` DB once via the in-cluster PgBouncer while dev is up (then redeploy), or trigger `scripts/destroy-dev-cluster.sh -e dev` once after the next bringup.

### Residual gap (out of scope)

Destroy-time reset guarantees freshness on cold bringup. A Roundcube **major** bump landing on a *warm* cluster (no destroy in between) could still drift; that path should remain a deliberate, gated cutover (snapshot/reset roundcube DBs as part of it).

## OSS Compliance Review

`oss-compliance` agent: **CRITICAL 0 · HIGH 0 · MEDIUM 0 · LOW 0** — clean. No domains, personal info, credentials (PG password loaded at runtime from the `postgres-credentials` Secret), private registry refs, or tenant data; all identifiers are generic placeholders.

## Security Review

`security-reviewer` agent: **CRITICAL 0 · HIGH 0 · MEDIUM 0 · LOW 1 (informational, pre-existing)**.
- SQL identifier injection **closed**: two-stage filter (discovery grep `^[a-z0-9_-]+$` + anchored allowlist) before interpolation; injection payloads verified rejected.
- Blast radius **bounded**: hard `MT_ENV != dev` guard, KUBECTL pinned to dev kubeconfig, `LIKE` cannot enumerate system/shared DBs (`postgres`/`keycloak`/`docs`/`template*`).
- LOW (pre-existing, not introduced here): postgres superuser password passed via `kubectl run --env` is visible in the pod spec for its lifetime — unchanged context; cleaner pattern would be a transient Secret + `envFrom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)