### PR TITLE
feat(dns): CI-reconcile external-DNS alias un-proxy + flip EU tenant to its own zone

### DIFF
--- a/scripts/deploy_infra
+++ b/scripts/deploy_infra
@@ -605,6 +605,48 @@ fi
 # NOTE: LKE firewall rules are now managed by manage_infra --firewall. See issue #244.
 
 # =============================================================================
+# External-DNS alias record — the ONE infra DNS record CI must own
+# =============================================================================
+# #244 moved infra DNS to the operator-run `manage_infra --dns` phase, but the
+# external-DNS CNAME alias is a special case that must be reconciled by code on
+# every deploy (no manual step): tenants whose DNS zone we do NOT control
+# (dns_external=true) point their service CNAMEs at
+# `lb1.prod.<infra-domain>`, which MUST be a DNS-only CNAME to the prod-eu
+# ingress alias `lb1.prod-eu.<infra-domain>`. If it is Cloudflare-proxied, the
+# foreign-zone TLS handshake fails (proxy serves the wrong cert) and ACME
+# HTTP-01 cannot reach our origin — so the un-proxy here is what makes a
+# dns_external tenant's traffic + cert issuance work. Reconciling it in CI means
+# the tenant's remaining CNAMEs are the only thing left for them to do.
+# Idempotent: create_dns_record PUTs the record and normalises a stale
+# proxied/A record into the DNS-only CNAME. Scoped to prod-eu (where
+# external-DNS tenants are hosted); manage-dns.sh still defines the same record
+# for the operator path, and both write the identical value.
+if [ "$MT_ENV" = "prod-eu" ]; then
+  print_status "Reconciling external-DNS alias: lb1.prod.${INFRA_DOMAIN} -> lb1.prod-eu.${INFRA_DOMAIN} (DNS-only)"
+
+  # Infra-zone Cloudflare creds. Prefer infra-config's exported values; fall
+  # back to the cluster cert-manager token (deployed earlier in this script) and
+  # a zone-id lookup, so this works even when the infra secrets carry no CF creds.
+  if [ -z "${TF_VAR_cloudflare_api_token:-}" ]; then
+    TF_VAR_cloudflare_api_token="$(kubectl get secret cloudflare-api-token -n "$NS_CERTMANAGER" \
+      -o jsonpath='{.data.api-token}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+  fi
+  : "${TF_VAR_cloudflare_api_token:?No Cloudflare API token for the infra zone (TF_VAR_cloudflare_api_token unset and cloudflare-api-token secret in $NS_CERTMANAGER empty/missing). Cannot reconcile the external-DNS alias.}"
+
+  if [ -z "${TF_VAR_cloudflare_zone_id:-}" ]; then
+    TF_VAR_cloudflare_zone_id="$(curl -s -X GET \
+      "https://api.cloudflare.com/client/v4/zones?name=${INFRA_DOMAIN}" \
+      -H "Authorization: Bearer ${TF_VAR_cloudflare_api_token}" \
+      -H "Content-Type: application/json" | jq -r '.result[0].id // empty')"
+  fi
+  : "${TF_VAR_cloudflare_zone_id:?Could not resolve the Cloudflare zone id for ${INFRA_DOMAIN}. Cannot reconcile the external-DNS alias.}"
+
+  export TF_VAR_cloudflare_api_token TF_VAR_cloudflare_zone_id
+  source "${REPO_ROOT}/scripts/lib/dns.sh"
+  create_dns_record "lb1.prod.${INFRA_DOMAIN}" "CNAME" "lb1.prod-eu.${INFRA_DOMAIN}" "false"
+fi
+
+# =============================================================================
 # Deploy K8s Postfix (ConfigMaps, Deployment, Services, NetworkPolicy)
 # =============================================================================
 # Gate on whether any tenant in this env has mail enabled — prod and dev both


### PR DESCRIPTION
## Summary

Two related changes that make an EU-prod `dns_external` tenant ready for cutover with **the tenant's remaining service CNAMEs as the only manual step left**:

1. **`deploy_infra` — make the external-DNS alias un-proxy code-driven in CI.**
   Issue #244 moved infra DNS to the operator-run `manage_infra --dns` phase, but the external-DNS CNAME alias is special: a `dns_external` tenant points its service CNAMEs at `lb1.prod.<infra-domain>`, which **must** be a DNS-only CNAME to the prod-eu ingress alias `lb1.prod-eu.<infra-domain>`. If it's Cloudflare-proxied, the foreign-zone TLS handshake fails and ACME HTTP-01 can't reach our origin. This adds a prod-eu-guarded block that reconciles that one record as DNS-only on every prod-eu deploy — no manual step.
   - Idempotent (`create_dns_record` PUTs and normalises a stale proxied/A record into the DNS-only CNAME).
   - Scoped to `prod-eu` (so `deploy_infra -e prod` doesn't claim it); `manage-dns.sh` still defines the identical record for the operator path.
   - Infra-zone Cloudflare creds: prefers `TF_VAR_cloudflare_api_token`, falls back to the in-cluster `cloudflare-api-token` secret + a zone-id lookup; **fail-fast** if neither resolves.

2. **`config/tenants` pointer bump — flip the EU tenant to its own externally-managed zone** (`dns_external: true`, own domain, HTTP-01 multi-SAN TLS). Builds on the cert-renewal fix + HTTP-01 work merged in #457.

### Effect on merge
`deploy-prod-eu` runs `deploy_infra` (un-proxies the alias) → `create_env` (reconfigures ingresses for the new zone + reissues TLS via HTTP-01 multi-SAN). HTTP-01 is all-or-nothing across SANs, so the cert issues once the tenant's remaining service CNAMEs resolve. The tenant's zone is not yet in use, so there's no disruption.

### Remaining manual gates (owner-action, not this PR)
- **Tenant**: add the remaining service CNAMEs (DNS-only, → `lb1.prod.<infra-domain>`). They've already added the first batch.
- **Operator**: add the flipped auth host's redirect URI to the Google OAuth app (or SSO breaks post-flip).

## OSS Compliance Review

`oss-compliance` agent: **1 HIGH found and fixed** before commit — a code comment in `scripts/deploy_infra` named a real tenant; replaced with a generic reference. Re-verified: the real tenant name appears in **no** tracked public file (outside `config/`), commit message, or this PR. The `config/tenants` bump is a SHA-only change in the public superproject; real-domain content lives only in the private submodule. All other checks (domains, credentials, personal info, private registry) clean.

## Security Review

`security-reviewer` agent: **No CRITICAL/HIGH/MEDIUM. 2 LOW, both informational:**
- Cloudflare bearer token visible in `curl` process args — pre-existing pattern in `scripts/lib/dns.sh`, not introduced here; CI container is single-purpose.
- Un-proxying exposes the origin IP for the alias — the deliberate, documented purpose of the change (foreign-zone TLS + HTTP-01 require a non-proxied record).

Verified clean: fail-closed credential handling (no silent skip), no secret leakage to logs (no `set -x`; `:?` guards print only their message), no command injection (`INFRA_DOMAIN` is operator-controlled and quoted), sound prod-eu scoping.

`version-bump` agent: no portal code changed — no bump needed.
