### PR TITLE
fix(deploy): tolerate unresolved admin host in dns_external health check

### DIFF
--- a/scripts/create_env
+++ b/scripts/create_env
@@ -880,7 +880,20 @@ fi
 # (ingress + wildcard TLS + portal pod). Final "everything's up" assertion
 # before the cleanup/probe phase. Skipped when admin-portal isn't enabled.
 if [ "$ADMIN_PORTAL_ENABLED" = "true" ]; then
-  mt_wait_for_admin_portal
+  if [ "${DNS_EXTERNAL:-false}" = "true" ] && ! mt_host_resolves "$ADMIN_HOST"; then
+    # For dns_external tenants the admin host only resolves (and serves valid TLS)
+    # once the TENANT adds its service CNAMEs and the all-or-nothing HTTP-01 cert
+    # issues over them. While the host is still unresolved this end-to-end check
+    # legitimately cannot pass — it is gated on DNS we do not control — so failing
+    # the deploy on it would keep deploy-prod-eu red for the entire pre-cutover
+    # window (potentially weeks). Skip-with-warning ONLY while the host does not
+    # resolve; the moment it does (post-cutover) the normal fatal gate below runs,
+    # so a real admin-portal regression is still caught. NOT a silent skip — the
+    # warning states exactly what is pending and why.
+    print_warning "admin-portal /version check skipped: ${ADMIN_HOST} does not resolve yet — EXPECTED for dns_external until the tenant adds its remaining CNAMEs. Deploy is applied; this gate re-arms (fatal) automatically once the host resolves."
+  else
+    mt_wait_for_admin_portal
+  fi
 fi
 
 # ── END app deploys ──────────────────────────────────────────────────

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -583,6 +583,24 @@ mt_wait_for_admin_portal() {
     return 1
 }
 
+# Returns 0 if $1 currently resolves in DNS, 1 if it does not (e.g. NXDOMAIN).
+# If no resolver tool is available, returns 0 (assume resolvable) so callers
+# never skip a real check merely because resolution could not be tested.
+# Usage: mt_host_resolves <hostname>
+mt_host_resolves() {
+    local host="$1"
+    [ -z "$host" ] && return 1
+    if command -v getent >/dev/null 2>&1; then
+        getent hosts "$host" >/dev/null 2>&1
+    elif command -v nslookup >/dev/null 2>&1; then
+        nslookup "$host" >/dev/null 2>&1
+    elif command -v host >/dev/null 2>&1; then
+        host "$host" >/dev/null 2>&1
+    else
+        return 0
+    fi
+}
+
 # Wait for Nextcloud's occ status to report installed=true.
 # This is the "Gate 4" readiness check after the install Job + helmfile sync:
 # pod-Ready is necessary but not sufficient (the seed-identity init container


### PR DESCRIPTION
## Summary

For `dns_external` tenants (whose DNS zone we don't control), `create_env`'s final post-deploy gate — `mt_wait_for_admin_portal`, which curls `https://${ADMIN_HOST}/version` and expects 200 — **fails until the tenant adds their service CNAMEs** (the admin host doesn't resolve, and the all-or-nothing HTTP-01 cert hasn't issued). That left the prod-eu deploy **red for the entire pre-cutover window** (potentially weeks), even though the deploy itself applied fine.

**Fix:** gate the check on DNS resolution.
- For `dns_external` tenants, **skip-with-warning only while the admin host is unresolved** (pre-cutover, gated on DNS we don't control).
- The moment it resolves (post-cutover), the **normal FATAL gate re-arms** — so a real admin-portal regression is still caught.
- Adds an `mt_host_resolves` helper (`getent`/`nslookup`/`host`; assumes resolvable when no resolver tool is present, so the fatal check is never skipped spuriously — fail-closed).
- Non-`dns_external` tenants: **unchanged** (fatal as before).

This is a deploy-time readiness probe, not a security control — it's not a silent skip (it emits a loud warning naming exactly what's pending), and it's doubly gated (`DNS_EXTERNAL=true` AND host unresolved).

## OSS Compliance Review

`oss-compliance`: **0 findings** (CRITICAL/HIGH/MEDIUM/LOW all 0). Uses `${ADMIN_HOST}`/`$host` variables, no literal domains; no credentials, PII, or private-registry references.

## Security Review

`security-reviewer`: **No CRITICAL/HIGH/MEDIUM. 1 LOW (non-blocking):** a *transient* resolver hiccup on the CI box post-cutover could make a single deploy take the skip-with-warning branch and mask a regression for that one run — self-healing on the next deploy (re-arm is per-run). This is a substantial improvement over keying the relaxation on `DNS_EXTERNAL` permanently. Verified clean: re-arm restores the fatal check under `set -euo pipefail`; no command injection (`"$host"` quoted, config-sourced); no-tool→assume-resolvable is the fail-closed direction; "fail fast — never silently skip" satisfied (loud warning, doubly gated, can't reach a mail-enabled tenant).

`version-bump`: no portal code changed — no bump needed.
