### PR TITLE
fix(dev): drop orphaned nextcloud_* DBs on bringup to fix cold-start install

### DIFF
--- a/scripts/dev-bringup.sh
+++ b/scripts/dev-bringup.sh
@@ -304,6 +304,115 @@ if [ "${MT_ENV:-dev}" = "dev" ]; then
     fi
 fi
 
+# Reset ORPHANED persistent Nextcloud tenant DBs. Like roundcube_<tenant>, the
+# nextcloud_<tenant> DBs live on the always-up postgres-dev VM and survive every
+# on-demand cluster rebuild. But unlike Roundcube, Nextcloud is NOT forced-fresh
+# on every bringup: it migrates its own schema across image upgrades via
+# `occ upgrade`, so a LIVE install must be left intact. The failure we do have to
+# fix is the cold-start orphan: deploy-nextcloud.sh runs the `occ
+# maintenance:install` Job only when the in-cluster `nextcloud-identity` Secret
+# is absent (cold start). On a freshly rebuilt cluster that Secret is gone but
+# the DB persists, so maintenance:install runs against a populated DB and aborts
+# with "The Login is already being used" → the install Job hits
+# BackoffLimitExceeded and the whole deploy stalls (pipeline #1537). The
+# destroy-time drop in destroy-dev-cluster.sh (Step 2c) clears this on a clean
+# teardown, but a teardown that skips/fails that drop (reaper orphan leak,
+# crashed destroy) leaves the DB orphaned; this is the bringup-side backstop.
+#
+# Gate: a nextcloud_<tenant> DB is orphaned poison iff its paired
+# tn-<tenant>-files/nextcloud-identity Secret is ABSENT. We check PER TENANT, not
+# cluster-wide: a cluster-wide "any identity Secret exists" gate would (a) skip
+# the leased tenant's orphaned DB whenever some OTHER tenant is installed, and
+# (b) risk wiping every live tenant at once on a single misread. Per-tenant
+# bounds a wrong drop to one tenant and lets a re-run self-heal the leased one.
+# The nextcloud_<tenant> <-> tn-<tenant>-files mapping is the same convention the
+# allowlist regex and destroy-dev-cluster.sh (Step 2c) already assume.
+#
+# Destructive op → fail fast (project rule): a transient kube-API error must
+# NEVER be read as "Secret absent → drop". We drop only on a definitive NotFound
+# (missing namespace or Secret); any other non-zero exit aborts the run.
+if [ "${MT_ENV:-dev}" = "dev" ]; then
+    print_status "dev-bringup: checking for orphaned persistent Nextcloud tenant DBs (cold-start poison guard)"
+    NC_PG_PASSWORD=$(kubectl --kubeconfig="$KUBECONFIG" get secret postgres-credentials -n infra-db \
+        -o jsonpath='{.data.postgres-password}' 2>/dev/null | base64 -d || true)
+    if [ -z "$NC_PG_PASSWORD" ]; then
+        print_error "dev-bringup: could not load postgres-credentials secret in infra-db"
+        print_error "Cannot check the Nextcloud DBs; a persistent orphaned DB would stall the deploy. Aborting."
+        exit 1
+    fi
+
+    # List nextcloud_<tenant> DBs via the in-cluster PgBouncer. Same throwaway-pod
+    # pattern, image, and retry/backoff as the Roundcube block above (PgBouncer is
+    # already confirmed ready there; postgres:15-alpine stays warm-cached from it).
+    NC_LIST_OUT=""
+    NC_QUERY_OK=false
+    for _nc_attempt in 1 2 3; do
+        if NC_LIST_OUT=$(kubectl --kubeconfig="$KUBECONFIG" run "nextcloud-db-list-${_nc_attempt}" --rm -i --restart=Never \
+            --image=postgres:15-alpine --quiet -n default --pod-running-timeout=240s \
+            --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+            --env "PGUSER=postgres" \
+            --env "PGPASSWORD=$NC_PG_PASSWORD" \
+            -- psql -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'nextcloud\\_%' ESCAPE '\\';" 2>&1); then
+            NC_QUERY_OK=true
+            break
+        fi
+        print_warning "dev-bringup: nextcloud DB query attempt ${_nc_attempt}/3 failed; retrying in $((_nc_attempt * 15))s"
+        sleep "$((_nc_attempt * 15))"
+    done
+    if [ "$NC_QUERY_OK" != "true" ]; then
+        print_error "dev-bringup: failed to query nextcloud_* DBs via PgBouncer after 3 attempts — cannot guarantee a clean cold start"
+        printf '%s\n' "$NC_LIST_OUT" >&2
+        exit 1
+    fi
+    NC_DBS=$(grep -E '^[a-z0-9_-]+$' <<< "$NC_LIST_OUT" || true)
+    if [ -z "$NC_DBS" ]; then
+        echo "  No nextcloud_* databases found, nothing to reset"
+    else
+        _nc_i=0
+        while IFS= read -r db; do
+            _nc_i=$((_nc_i + 1))
+            # Allowlist regex defends against SQL identifier injection AND pins the
+            # tenant slug we derive the namespace from. Tenant DB names are
+            # operator-controlled and always match nextcloud_<tenant> (lowercase +
+            # digits + underscore/hyphen). Anything else is suspicious.
+            if [[ ! "$db" =~ ^nextcloud_[a-z0-9][a-z0-9_-]*$ ]]; then
+                print_error "dev-bringup: refusing to act on suspicious DB name: $db"
+                exit 1
+            fi
+            _nc_tenant="${db#nextcloud_}"
+            _nc_ns="tn-${_nc_tenant}-files"
+
+            # Per-tenant orphan gate with fail-fast classification:
+            #   exit 0              -> Secret present -> live install, KEEP
+            #   NotFound (ns/sec)   -> Secret absent  -> orphaned poison, DROP
+            #   any other non-zero  -> transient/RBAC -> ABORT (never drop on a misread)
+            if _nc_idcheck=$(kubectl --kubeconfig="$KUBECONFIG" get secret nextcloud-identity \
+                                -n "$_nc_ns" -o name 2>&1); then
+                echo "  $db: nextcloud-identity present in $_nc_ns — live install, keeping"
+                continue
+            fi
+            if ! grep -qiE '\(notfound\)|not found' <<< "$_nc_idcheck"; then
+                print_error "dev-bringup: error checking nextcloud-identity in $_nc_ns (not a NotFound) — refusing to drop $db"
+                printf '%s\n' "$_nc_idcheck" >&2
+                exit 1
+            fi
+
+            print_status "  Dropping orphaned $db (no nextcloud-identity in $_nc_ns; nextcloud-db-init + install Job recreate it on next deploy)"
+            # DROP DATABASE cannot run in a transaction block, so one psql -c each.
+            # Node + image are warm now (the list query just ran here), so a single
+            # attempt with a generous timeout suffices; fail fast if it errors.
+            kubectl --kubeconfig="$KUBECONFIG" run "nextcloud-db-drop-${_nc_i}" --rm -i --restart=Never \
+                --image=postgres:15-alpine --quiet -n default --pod-running-timeout=240s \
+                --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+                --env "PGUSER=postgres" \
+                --env "PGPASSWORD=$NC_PG_PASSWORD" \
+                -- psql -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS \"$db\" WITH (FORCE);" 2>&1 \
+                | sed 's/^/    /' \
+                || { print_error "dev-bringup: failed to drop $db — aborting"; exit 1; }
+        done <<< "$NC_DBS"
+    fi
+fi
+
 # secrets.tfvars.env is required by manage_infra; write it if absent
 # (reuse path doesn't run the cold-start block above).
 if [ ! -f "$REPO_ROOT/secrets.tfvars.env" ]; then


### PR DESCRIPTION
## Problem

CI pipeline [#1537](https://ci.mother-tree.org/repos/1/pipeline/1537) (the Dependabot PR #460 run, unrelated to Nextcloud) **stalled then failed** on the `deploy-dev-nextcloud` step. Everything downstream (finalize, all 10 e2e shards, ci-release, the gate) was blocked behind it.

Root cause — the install pod's actual error:

```
Running occ maintenance:install (DB=nextcloud_<tenant> user=<tenant>_<tenant>)...
The Login is already being used
```

→ `BackoffLimitExceeded` → deploy fails.

This is the **Nextcloud sibling of the Roundcube shared-DB poison**. The always-up `postgres-dev` VM persists `nextcloud_<tenant>` databases across on-demand cluster rebuilds. On a cold-start cluster, the in-cluster `nextcloud-identity` Secret is gone (it dies with the cluster) but the DB survives. `deploy-nextcloud.sh:319` runs the `occ maintenance:install` Job **only** when that Secret is absent — so it runs `maintenance:install` against a populated DB, which aborts because the admin login already exists.

## Why the backstop was missing

- `destroy-dev-cluster.sh` (Step 2c) already drops **both** `nextcloud_*` and `roundcube_*` on a clean teardown.
- `dev-bringup.sh` already resets `roundcube_*` on **every** bringup.
- But nothing reset `nextcloud_*` at bringup. So when a teardown skips/fails the destroy-side drop (reaper orphan leak, crashed destroy), the `nextcloud_<tenant>` DB is left orphaned and the next cold-start cluster fails here. The Roundcube block's own comment says "keep the two in sync" — they were out of sync for Nextcloud.

## Fix

Add a bringup-side backstop to `dev-bringup.sh`: for each persistent `nextcloud_<tenant>` DB, **drop it iff its paired `tn-<tenant>-files/nextcloud-identity` Secret is ABSENT** (orphaned). After the drop, `nextcloud-db-init` recreates an empty DB and the cold-start install Job runs cleanly.

Design choices (vetted with the advisor):

- **Per-tenant gate, not cluster-wide.** A cluster-wide "any identity Secret exists" check would (a) skip the leased tenant's orphaned DB whenever some *other* tenant is installed, and (b) risk wiping every live tenant on a single misread. Per-tenant bounds a wrong drop to one tenant and lets a re-run self-heal the leased tenant.
- **Live installs are left intact.** Unlike Roundcube (forced-fresh every bringup because its forward-only `updatedb.sh` can't roll back), Nextcloud migrates its own schema via `occ upgrade`, so a healthy warm install is kept.
- **Fail-fast on a destructive op.** A `DROP` happens only on a definitive `NotFound` (missing namespace or Secret); any other non-zero `kubectl` exit (transient API / RBAC) aborts the run instead of being misread as "absent → drop". The upstream `postgres-credentials` read already proves the API server is live/authenticated before any per-tenant NotFound is trusted.
- **Dev-only**, mirroring the existing Roundcube block; no path to prod data.

The Roundcube block is left untouched.

## Impact on the failing pipeline

A plain re-run of #460 would have hit the same failure (install never created the identity Secret; DB still poisoned). Once this merges, re-running #460 self-heals: the leased tenant's `tn-<tenant>-files` namespace exists but `nextcloud-identity` is absent → the orphaned DB is dropped → install runs on an empty DB.

## Verification

- `shellcheck -S error -x scripts/dev-bringup.sh` (exact CI `validate` command) → **PASS**, no new findings.
- Confirmed `nextcloud-db-init` recreates an *absent* DB (`SELECT 1 FROM pg_database` → `CREATE DATABASE`), so the drop→recreate→install chain is sound.

## OSS Compliance Review

**Clean** — 0 findings (CRITICAL/HIGH/MEDIUM/LOW). No real tenant domains/names, no hardcoded credentials (PG password read at runtime from the `postgres-credentials` Secret), no private registry refs (only public `postgres:15-alpine`), no real IPs/hosts (only the in-cluster `pgbouncer.infra-db.svc.cluster.local` service DNS).

## Security Review

**0 CRITICAL / 0 HIGH / 0 MEDIUM / 1 LOW.**

- **SQL/command injection — clean.** DB names are double-guarded (`grep -E '^[a-z0-9_-]+$'` then allowlist `^nextcloud_[a-z0-9][a-z0-9_-]*$`), passed as a `psql` argv element and embedded in a double-quoted SQL identifier whose permitted charset can't contain a `"`.
- **Destructive-op safety — fail-fast, correct.** Drops only when the Secret check exits non-zero AND output matches `(notfound)|not found`. Transient strings (`Forbidden`, `Unauthorized`, `connection refused`, `i/o timeout`, …) lack that substring → abort. The one generic-404 false-match is foreclosed by the upstream `postgres-credentials` read proving the API server is genuine.
- **Scope — bounded to dev** (`MT_ENV=dev` guard + dev-only KUBECONFIG/PgBouncer). No path to prod PostgreSQL.
- **Blast radius — single tenant** per drop; recreated by `nextcloud-db-init` + install Job on next deploy.
- **LOW (pre-existing, no action):** `PGPASSWORD` passed via `--env` into the throwaway pod is briefly visible in the pod env — **byte-identical to the already-shipped Roundcube block**, not introduced here. The new stderr-surfacing line prints auth-failure text without the secret value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)