### PR TITLE
fix(ci): instrument shard-5/10 Roundcube-login failures instead of guessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ e2e/test-results/
 e2e/playwright-report/
 e2e/blob-report/
 e2e/.env
+# Ephemeral tenant handoff written by e2e-playwright.sh for the on-failure
+# diagnostics step (ci-e2e-diagnostics.sh); never committed.
+.e2e-tenant

--- a/.woodpecker/e2e-shard-10.yaml
+++ b/.woodpecker/e2e-shard-10.yaml
@@ -50,3 +50,28 @@ steps:
     commands:
       - ci/scripts/e2e-playwright.sh
       - ci/scripts/ci-renew-lease.sh
+
+  # On-failure ONLY: dump roundcube + stalwart + keycloak pod logs/state while
+  # the failing pods are still live, so a Roundcube-login failure (the chronic
+  # shard-5/10 flake) names the broken layer instead of leaving an opaque
+  # "inbox never appeared" timeout. Adds zero latency to green runs and no new
+  # DAG edges. LINODE_CLI_TOKEN lives here (not the test step) so the powerful
+  # token stays out of the Playwright-execution env. See ci-e2e-diagnostics.sh
+  # and memory project_shard5_10_roundcube_login_root_cause.
+  - name: roundcube-diagnostics
+    image: bash
+    when:
+      - status: [ failure ]
+    environment:
+      CI: "true"
+      CI_VALKEY_PASSWORD:
+        from_secret: ci_valkey_password
+      LINODE_CLI_TOKEN:
+        from_secret: linode_token
+      E2E_POOL1_TENANT:
+        from_secret: e2e_pool1_tenant
+      E2E_POOL2_TENANT:
+        from_secret: e2e_pool2_tenant
+      E2E_SHARD: "10/10"
+    commands:
+      - ci/scripts/ci-e2e-diagnostics.sh

--- a/.woodpecker/e2e-shard-5.yaml
+++ b/.woodpecker/e2e-shard-5.yaml
@@ -50,3 +50,28 @@ steps:
     commands:
       - ci/scripts/e2e-playwright.sh
       - ci/scripts/ci-renew-lease.sh
+
+  # On-failure ONLY: dump roundcube + stalwart + keycloak pod logs/state while
+  # the failing pods are still live, so a Roundcube-login failure (the chronic
+  # shard-5/10 flake) names the broken layer instead of leaving an opaque
+  # "inbox never appeared" timeout. Adds zero latency to green runs and no new
+  # DAG edges. LINODE_CLI_TOKEN lives here (not the test step) so the powerful
+  # token stays out of the Playwright-execution env. See ci-e2e-diagnostics.sh
+  # and memory project_shard5_10_roundcube_login_root_cause.
+  - name: roundcube-diagnostics
+    image: bash
+    when:
+      - status: [ failure ]
+    environment:
+      CI: "true"
+      CI_VALKEY_PASSWORD:
+        from_secret: ci_valkey_password
+      LINODE_CLI_TOKEN:
+        from_secret: linode_token
+      E2E_POOL1_TENANT:
+        from_secret: e2e_pool1_tenant
+      E2E_POOL2_TENANT:
+        from_secret: e2e_pool2_tenant
+      E2E_SHARD: "5/10"
+    commands:
+      - ci/scripts/ci-e2e-diagnostics.sh

--- a/ci/scripts/ci-e2e-diagnostics.sh
+++ b/ci/scripts/ci-e2e-diagnostics.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# On-failure diagnostic dump for the Roundcube-login e2e shards (5 & 10).
+#
+# WHY THIS EXISTS
+# --------------
+# Shards 5 (tests/email/roundcube-basic.spec.ts) and 10
+# (tests/sso/cross-app-sso.spec.ts "SSO to Roundcube") fail together whenever
+# Roundcube's OIDC login never reaches the inbox (the ROUNDCUBE_INBOX selector
+# never appears -> 60s timeout). The Playwright output only ever says "inbox
+# never appeared" — it cannot say WHICH layer broke (Stalwart OAUTHBEARER token
+# validation / Roundcube app+session / Keycloak / DB schema). Because nobody
+# ever saw the real error, every past debugging cycle GUESSED a layer, patched
+# static state for it, got a lucky green, and the failure came back. See memory
+# project_shard5_10_roundcube_login_root_cause.
+#
+# This step captures the server-side evidence (roundcube + stalwart + keycloak
+# pod logs/state) AT THE MOMENT OF FAILURE, while the failing pods are still
+# live, so the NEXT failure NAMES the layer instead of needing CI archaeology.
+#
+# CONTRACT
+# --------
+# - Runs ONLY as a `when: status: [failure]` step inside e2e-shard-5/10, so it
+#   adds zero latency to green runs and zero new DAG edges.
+# - Best-effort: it must NEVER mask the real test failure. It always exits 0
+#   (the shard's failure status already stands), and every external call is
+#   guarded so a missing cluster / expired lease just degrades to a warning.
+# - Keeps LINODE_CLI_TOKEN out of the Playwright-execution step: this is a
+#   separate step with its own minimal env.
+
+# Best-effort throughout: no -e, no pipefail (every call is individually
+# guarded). We control failure explicitly via warn+exit 0.
+set +e +o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=ci-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/ci-lib.sh"   # provides vcli()
+# shellcheck source=../../scripts/lib/common.sh
+source "$REPO_ROOT/scripts/lib/common.sh"           # provides dump_pod_diagnostics, print_status
+
+LOG_TAIL="${MT_DIAG_LOG_TAIL:-300}"
+
+echo "=================================================================="
+echo "  E2E ROUNDCUBE-LOGIN FAILURE DIAGNOSTICS"
+echo "  shard=${E2E_SHARD:-?}  pipeline=#${CI_PIPELINE_NUMBER:-?}"
+echo "=================================================================="
+
+# ── Resolve the leased tenant (namespaces = tn-<tenant>-{webmail,mail}) ───────
+# 1) Prefer the file the e2e step wrote THIS run — lease-independent, so it
+#    survives a PR lease (1000s) expiring during a long (<=15m) shard.
+# 2) Fall back to the Valkey reverse-lookup if the file is missing.
+E2E_TENANT=""
+if [[ -f "$REPO_ROOT/.e2e-tenant" ]]; then
+  E2E_TENANT="$(tr -d '[:space:]' < "$REPO_ROOT/.e2e-tenant" 2>/dev/null)"
+fi
+if [[ -z "$E2E_TENANT" && -n "${CI_VALKEY_PASSWORD:-}" && -n "${CI_PIPELINE_NUMBER:-}" ]]; then
+  LEASED_POOL="$(vcli GET "ci-build-${CI_PIPELINE_NUMBER}" 2>/dev/null)"
+  if [[ -n "$LEASED_POOL" ]]; then
+    POOL_KEY="$(echo "$LEASED_POOL" | tr '[:lower:]-' '[:upper:]_')"
+    _tvar="E2E_${POOL_KEY}_TENANT"
+    E2E_TENANT="${!_tvar:-}"
+  fi
+fi
+if [[ -z "$E2E_TENANT" ]]; then
+  echo "WARNING: could not resolve the leased tenant (no .e2e-tenant file and no"
+  echo "         live Valkey lease). Cannot locate tenant namespaces — skipping dump."
+  exit 0
+fi
+echo "Leased tenant: ${E2E_TENANT}"
+
+# ── Fetch a live dev kubeconfig (cluster is still up right after e2e) ─────────
+if [[ -z "${LINODE_CLI_TOKEN:-}" ]]; then
+  echo "WARNING: LINODE_CLI_TOKEN not set in this step's env — cannot fetch a"
+  echo "         kubeconfig; no pod logs available. Wire linode_token into the step."
+  exit 0
+fi
+KCFG="$(mktemp -t ci-e2e-diag-kcfg-XXXXXX)"
+trap 'rm -f "$KCFG"' EXIT
+if ! ci_fetch_dev_kubeconfig "$KCFG"; then
+  echo "WARNING: could not fetch dev kubeconfig (cluster reaped, or Linode API"
+  echo "         issue) — no pod logs available."
+  exit 0
+fi
+export KUBECONFIG="$KCFG"
+
+NS_WEBMAIL="tn-${E2E_TENANT}-webmail"
+NS_MAIL="tn-${E2E_TENANT}-mail"
+NS_AUTH="infra-auth"
+
+dump_component() {  # namespace selector friendly-name
+  local ns="$1" sel="$2" name="$3"
+  echo ""
+  echo "------------------------------------------------------------------"
+  echo "  ${name}   (ns=${ns}, selector=${sel})"
+  echo "------------------------------------------------------------------"
+  dump_pod_diagnostics "$ns" "$sel"
+  echo ""
+  echo ">>> ${name} current logs (last ${LOG_TAIL} lines, all containers):"
+  kubectl logs -n "$ns" -l "$sel" --tail="$LOG_TAIL" --all-containers=true --timestamps 2>&1 \
+    | sed 's/^/    /'
+  echo ""
+  echo ">>> ${name} PREVIOUS logs (only if a container restarted):"
+  kubectl logs -n "$ns" -l "$sel" --previous --tail="$LOG_TAIL" --all-containers=true 2>/dev/null \
+    | sed 's/^/    /' || echo "    (no previous container)"
+}
+
+# Roundcube — the OIDC client. DB-schema / session / oauth-state errors land here.
+dump_component "$NS_WEBMAIL" "app=roundcube" "ROUNDCUBE"
+
+# Stalwart — the OAUTHBEARER token validator + IMAP backend. Token-decode /
+# unauthorized errors here mean the OIDC->IMAP auth leg failed.
+dump_component "$NS_MAIL" "app=stalwart" "STALWART"
+echo ""
+echo ">>> STALWART auth/oauth/token highlights (grep over last 1000 lines):"
+kubectl logs -n "$NS_MAIL" -l app=stalwart --tail=1000 --all-containers=true 2>/dev/null \
+  | grep -iE 'oauth|bearer|token|jwt|jwks|unauthor|decode|introspect|oidc|authenticat' \
+  | tail -n 60 | sed 's/^/    /' || echo "    (no auth-related lines found)"
+
+# Keycloak — token issuance / redirect_uri / invalid_client errors. Helm-managed,
+# so match pods by name rather than a fixed label.
+echo ""
+echo "------------------------------------------------------------------"
+echo "  KEYCLOAK   (ns=${NS_AUTH})"
+echo "------------------------------------------------------------------"
+_kc_pods="$(kubectl get pods -n "$NS_AUTH" -o name 2>/dev/null | grep -i keycloak)"
+if [[ -z "$_kc_pods" ]]; then
+  echo "    (no keycloak pods found in ${NS_AUTH})"
+else
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    echo ">>> ${p} error/warn/token highlights (last 1000 lines):"
+    kubectl logs -n "$NS_AUTH" "$p" --tail=1000 2>/dev/null \
+      | grep -iE 'error|warn|invalid|token|client|roundcube|reject|redirect_uri' \
+      | tail -n 40 | sed 's/^/    /' || echo "    (none)"
+  done <<< "$_kc_pods"
+fi
+
+echo ""
+echo "=================================================================="
+echo "  HOW TO READ THIS (see memory project_shard5_10_roundcube_login_root_cause):"
+echo "   • roundcube 'DB Error: column ... does not exist'      -> DB schema"
+echo "   • stalwart  OAUTHBEARER / 'Failed to decode token' /"
+echo "               'unauthorized'                              -> Stalwart token validation"
+echo "   • roundcube session / oauth-state / redirect errors    -> Roundcube 1.7 / session store"
+echo "   • keycloak  invalid_client / redirect_uri              -> Keycloak client config"
+echo "   • browser-side [roundcube-stuck:*] lines in the e2e log show WHERE"
+echo "     the browser stopped (Keycloak vs webmail-no-inbox)."
+echo "=================================================================="
+exit 0

--- a/ci/scripts/e2e-playwright.sh
+++ b/ci/scripts/e2e-playwright.sh
@@ -6,6 +6,14 @@ echo "--- :playwright: E2E Browser Tests"
 # Resolve tenant from Valkey lease (sets E2E_BASE_DOMAIN, E2E_TENANT, etc.)
 if [[ "${CI:-}" == "true" ]]; then
   source ci/scripts/ci-resolve-tenant.sh
+  # Persist the resolved tenant so the on-failure diagnostics step
+  # (ci/scripts/ci-e2e-diagnostics.sh, a `when: status: [failure]` sibling step
+  # in e2e-shard-5/10) can locate the tenant namespaces even if the Valkey lease
+  # has since expired during a long shard. Workspace is shared across a
+  # workflow's steps, so the file is readable there. Best-effort.
+  if [[ -n "${E2E_TENANT:-}" ]]; then
+    printf '%s\n' "$E2E_TENANT" > .e2e-tenant 2>/dev/null || true
+  fi
   # Acquire e2e protection lock — blocks deploy_infra on other pipelines
   # from running while our tests are active.
   ci/scripts/ci-e2e-lock.sh acquire

--- a/e2e/helpers/roundcube-failure.ts
+++ b/e2e/helpers/roundcube-failure.ts
@@ -1,0 +1,58 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Capture, at the moment a Roundcube OIDC login fails to reach the inbox,
+ * WHERE the browser got stuck.
+ *
+ * The Playwright timeout alone ("ROUNDCUBE_INBOX never appeared") cannot tell
+ * the failure layers apart. This logs the final URL/host + visible page text so
+ * the CI log shows whether the browser was:
+ *   - stuck on Keycloak  -> redirect/login never completed (KC client/redirect/session)
+ *   - on the webmail host with no inbox -> OIDC returned but the app never
+ *     rendered the inbox (Roundcube app/session, or Stalwart OAUTHBEARER)
+ *   - on an error page   -> the visible text usually names the error
+ *
+ * Pairs with the server-side pod-log dump in ci/scripts/ci-e2e-diagnostics.sh.
+ * Best-effort: NEVER throws, so it cannot mask the real assertion failure.
+ */
+export async function captureRoundcubeStuckState(page: Page, label: string): Promise<void> {
+  try {
+    const url = page.url();
+    let host = '(unparseable)';
+    // Log only origin+pathname — a STUCK OIDC URL can carry an auth `code`/`state`
+    // (or tokens in hybrid flows) in its query/fragment. The path (e.g.
+    // /realms/<realm>/protocol/openid-connect/auth) is the diagnostic signal we
+    // want; the query/fragment is not, and must not land in the CI log.
+    let safeUrl = url.split('?')[0].split('#')[0];
+    try {
+      const u = new URL(url);
+      host = u.host;
+      safeUrl = `${u.origin}${u.pathname}`;
+    } catch {
+      /* keep defaults */
+    }
+    const onKeycloak =
+      /(^|\.)auth\./.test(host) ||
+      url.includes('/realms/') ||
+      url.includes('/protocol/openid-connect');
+    const title = await page.title().catch(() => '(no title)');
+    const bodyText = (
+      await page.locator('body').innerText({ timeout: 2_000 }).catch(() => '')
+    )
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 600);
+
+    const verdict = onKeycloak
+      ? 'STUCK ON KEYCLOAK — OIDC redirect/login did not complete (suspect KC client/redirect or session)'
+      : 'ON WEBMAIL HOST, NO INBOX — OIDC returned but inbox never rendered (suspect Roundcube app/session or Stalwart OAUTHBEARER)';
+
+    console.log(`\n  [roundcube-stuck:${label}] ${verdict}`);
+    console.log(`  [roundcube-stuck:${label}] final URL : ${safeUrl}`);
+    console.log(`  [roundcube-stuck:${label}] host      : ${host}`);
+    console.log(`  [roundcube-stuck:${label}] title     : ${title}`);
+    console.log(`  [roundcube-stuck:${label}] body text : ${bodyText || '(empty)'}`);
+  } catch (e) {
+    console.log(`  [roundcube-stuck:${label}] capture failed: ${(e as Error)?.message ?? e}`);
+  }
+}

--- a/e2e/tests/email/roundcube-basic.spec.ts
+++ b/e2e/tests/email/roundcube-basic.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../../fixtures/authenticated';
 import { urls } from '../../helpers/urls';
 import { TEST_USERS } from '../../helpers/test-users';
 import { keycloakLogin } from '../../helpers/auth';
+import { captureRoundcubeStuckState } from '../../helpers/roundcube-failure';
 
 const ROUNDCUBE_INBOX = '#messagelist, #mailboxlist, .mailbox-list, button:has-text("Compose")';
 
@@ -14,6 +15,21 @@ const ROUNDCUBE_INBOX = '#messagelist, #mailboxlist, .mailbox-list, button:has-t
  * - If page ends up mid-redirect on Keycloak, retries the OAuth URL
  */
 async function navigateToRoundcube(
+  page: import('@playwright/test').Page,
+  username: string,
+  password: string,
+) {
+  try {
+    await navigateToRoundcubeInner(page, username, password);
+  } catch (err) {
+    // On failure, record WHERE the OIDC login got stuck (browser-side); the
+    // server-side pod logs are dumped by ci/scripts/ci-e2e-diagnostics.sh.
+    await captureRoundcubeStuckState(page, 'roundcube-basic');
+    throw err;
+  }
+}
+
+async function navigateToRoundcubeInner(
   page: import('@playwright/test').Page,
   username: string,
   password: string,

--- a/e2e/tests/sso/cross-app-sso.spec.ts
+++ b/e2e/tests/sso/cross-app-sso.spec.ts
@@ -3,6 +3,7 @@ import { urls } from '../../helpers/urls';
 import { selectors } from '../../helpers/selectors';
 import { TEST_USERS } from '../../helpers/test-users';
 import { keycloakLogin } from '../../helpers/auth';
+import { captureRoundcubeStuckState } from '../../helpers/roundcube-failure';
 
 test.describe('SSO — Cross-App Single Sign-On', () => {
   test('login to account portal enables SSO to admin portal', async ({ context }) => {
@@ -61,9 +62,16 @@ test.describe('SSO — Cross-App Single Sign-On', () => {
     }
 
     // Final assertion — will fail with a clear error message
-    await expect(
-      page.locator(ROUNDCUBE_INBOX).first(),
-    ).toBeVisible({ timeout: 15_000 });
+    try {
+      await expect(
+        page.locator(ROUNDCUBE_INBOX).first(),
+      ).toBeVisible({ timeout: 15_000 });
+    } catch (err) {
+      // On failure, record WHERE the OIDC login got stuck (browser-side); the
+      // server-side pod logs are dumped by ci/scripts/ci-e2e-diagnostics.sh.
+      await captureRoundcubeStuckState(page, 'cross-app-sso');
+      throw err;
+    }
   });
 
   test('login to account portal enables SSO to Files', async ({ memberPage: page }) => {


### PR DESCRIPTION
## Why

Shards **5** (`roundcube-basic`) and **10** (`cross-app-sso` → "SSO to Roundcube") fail **together**, every time, with one signature: Roundcube's OIDC login never reaches the inbox (`ROUNDCUBE_INBOX` never appears → 60s timeout). Every other SSO target (admin, Files/Nextcloud, account portal, sign-out) passes — so the failure is specific to **Roundcube's OIDC login path**.

The reason the fix-loop never ends: the Playwright output only ever says *"inbox never appeared."* It can't say **which layer** broke (Stalwart OAUTHBEARER token validation / Roundcube app+session / Keycloak / DB schema). So each cycle guessed a layer, patched static state, got a lucky green, and the failure returned.

### What the last 20 pipelines actually show (every prior theory disproven)

| Prior theory | Verdict | Evidence |
|---|---|---|
| Static per-tenant DB poison (#465) | **Disproven** | Same pool flips pass↔fail over time (pool2: 1527 FAIL → 1538 PASS → 1546 FAIL). A static poison can't un- then re-poison itself. |
| Dynamic roundcube-DB schema drift | **Disproven** | Bringup logs: 1538 (PASS) dropped+recreated DB→fresh; 1527 (FAIL) dropped+recreated→fresh; 1546 (FAIL) none found→db-init creates fresh. All three end with a fresh schema, different outcomes. |
| Missing Stalwart principal (#456) | **Disproven** | In failing run 1546, `create-test-users` logged `e2e-mailrt: ok`. |
| Spam / RBL | **N/A** | That's the delivery layer; the failing tests are pure login tests that never send mail. |

It behaves like a **runtime/timing** failure in the OIDC login path. The exact sub-mechanism is still unconfirmed because nothing ever captured it.

## What this does — make the failure visible (it can't "work then stop working")

This PR **does not try to fix the bug.** It instruments it so the *next* red 5/10 run names the broken layer.

- **`ci/scripts/ci-e2e-diagnostics.sh`** (new) — on a Roundcube-login failure, dumps **roundcube + stalwart + keycloak** pod logs / describe / events (with an auth·oauth·token grep highlight and a how-to-read legend) **while the failing pods are still live**. Best-effort, always `exit 0` — never masks the real failure.
- **`.woodpecker/e2e-shard-5.yaml` / `e2e-shard-10.yaml`** — add a `roundcube-diagnostics` step with `when: status: [failure]`. It's a **step inside the existing shard workflow** → **zero new DAG edges** (no gate/prod risk) and **zero latency on green runs**. `LINODE_CLI_TOKEN` lives only on this step, **not** the Playwright-execution step (keeps the powerful token out of the npm/browser env).
- **`ci/scripts/e2e-playwright.sh`** — persists the resolved tenant to `.e2e-tenant` so diagnostics can locate the namespaces even if the PR lease (1000s) expires during a ≤15-min shard.
- **`e2e/helpers/roundcube-failure.ts`** (new) + both specs — on failure, log **where** the browser stuck (*stuck-on-Keycloak* vs *on-webmail-host-no-inbox*). Logs only origin+pathname, never the OIDC query/fragment (which can carry `code`/`state`).
- **`.gitignore`** — ignore the ephemeral `.e2e-tenant`.

### How to read a future failure
- roundcube `DB Error: column … does not exist` → DB schema
- stalwart `OAUTHBEARER` / "Failed to decode token" / unauthorized → Stalwart token validation
- roundcube session / oauth-state / redirect errors → Roundcube 1.7 / session store
- keycloak `invalid_client` / `redirect_uri` → Keycloak client config
- browser-side `[roundcube-stuck:*]` line → which side of the redirect it died on

## OSS Compliance Review
✅ **CLEAN — 0 findings** (CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0). No real domains, personal info, hardcoded credentials, private registry refs, or tenant leaks. All Woodpecker secret usages are `from_secret:` name references. `.e2e-tenant` is gitignored and untracked.

## Security Review
✅ **0 CRITICAL / 0 HIGH.** Two LOW (optional hardening):
1. **OIDC URL query/fragment in CI log** (`roundcube-failure.ts`) — **addressed in this PR**: now logs only `origin+pathname`.
2. **Stalwart/Keycloak log grep** — safe while both services stay at `INFO` in dev (verified: Stalwart `[tracing] level = info`, Keycloak `KC_LOG_LEVEL: INFO`); would only surface raw tokens if either is raised to DEBUG/trace. Awareness note, no change needed.

Cleared on review: `LINODE_CLI_TOKEN` isolation is adequate (already on sibling deploy steps on the same host; deliberately off the test step; only sent as a Bearer header to `api.linode.com`, kubeconfig written `umask 077` + trap-cleaned); `kubectl describe` renders secrets as `<set to the key …>` not values; browser capture reads `body.innerText` only (no input/hidden values); no command injection (`E2E_TENANT` quoted throughout, from trusted secret/lease).

## version-bump
✅ Not required — CI/e2e-test-only changes; no `apps/{admin,account}-portal` runtime code touched. Portal VERSIONs already in sync with main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)