### PR TITLE
fix(ansible): register Headscale box on the mesh with a real hostname (not localhost)

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -965,12 +965,18 @@
       changed_when: false
       failed_when: false
 
+    # --hostname pins the node name on the mesh; without it the box registers
+    # under its OS hostname ("localhost"), which is opaque in `headscale nodes
+    # list` and yields no usable MagicDNS name. Derive it from the Headscale
+    # FQDN (e.g. hs-prod-eu.example.com -> "hs-prod-eu"), matching the
+    # --hostname the PostgreSQL VM already sets in its cloud-init join.
     - name: Join own tailnet if not connected
       command: >
         tailscale up
         --reset
         --login-server=https://{{ headscale_domain }}:8080
         --authkey={{ tailscale_auth_key }}
+        --hostname={{ headscale_domain.split('.')[0] }}
         --accept-routes=true
       when: >
         tailscale_auth_key is defined and tailscale_auth_key | length > 0 and


### PR DESCRIPTION
## Summary

The Headscale control-plane VM joins its own tailnet (for operator SSH access) via `tailscale up` **without `--hostname`**, and its OS hostname is never set — so it registers on the mesh as **`localhost`**. This makes `headscale nodes list` opaque and gives the box no usable MagicDNS name, so finding the control plane means probing nodes by IP.

This adds `--hostname={{ headscale_domain.split('.')[0] }}` to that join (e.g. `hs-prod-eu`), matching the `--hostname` the PostgreSQL VM already sets in its cloud-init join. The name derives from `headscale_domain`, which is identical across the prod and prod-eu configs that share this box, so it's stable regardless of which env runs the play.

### Scope / limitation
The play's `when:` guard skips `tailscale up` for an already-connected node, so this governs **fresh joins** only. Existing `localhost` nodes need a one-time `headscale nodes rename -i <id> <name>` on the control plane (Headscale's `given_name` is sticky once registered). Done operationally for the current prod-eu box alongside this change.

> Follow-up: the TURN VM has the same latent `localhost` registration (its `tailscale up` also lacks `--hostname`); left out of scope here.

## OSS Compliance Review
⚠️→✅ Initial scan flagged **1 HIGH**: an illustrative `hs-prod-eu.mother-tree.org` FQDN in the new comment (a real operator domain mustn't appear in the public repo outside `config/`). **Fixed** — comment now uses `hs-prod-eu.example.com`. Re-verified: no real domain in the diff. The code change itself is a Jinja expression deriving from a variable — no hardcoded domains/IPs/credentials.

## Security Review
✅ **0 findings.** Headscale ACLs are keyed on **tags** (assigned via the preauthkey's `--tags`), not hostnames, so `--hostname` has no auth/ACL impact. The `command:` module execs argv directly (no shell) and the value is a DNS label from operator-controlled infra config — no injection vector. No secrets touched.

## Version Bump
N/A — ansible/VM provisioning only, no portal code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
