### PR TITLE
fix(dev): scope bringup Roundcube DB reset to the leased tenant only

### DIFF
--- a/scripts/dev-bringup.sh
+++ b/scripts/dev-bringup.sh
@@ -202,32 +202,65 @@ if [ -z "$NEW_LB_IP" ]; then
     exit 1
 fi
 
-# Reset persistent Roundcube tenant DBs so their schema always matches the
+# Reset the LEASED tenant's Roundcube DB so its schema always matches the
 # deployed image. postgres-dev is an always-up VM, so roundcube_<tenant> DBs
 # survive every cluster rebuild; Roundcube's forward-only, version-stamp-gated
 # updatedb.sh means a schema migrated forward by one image version (or
 # hand-patched during an incident) can neither re-migrate nor roll back — the
 # mismatch (e.g. the 1.6<->1.7 session.changed/expires_at rename) breaks OIDC
-# login ("OIDC redirect timed out") on whichever pool tenant carries the stale
-# DB. Dropping here on every bringup makes the next deploy recreate an empty DB
-# (via the idempotent roundcube-db-init Job) whose schema the entrypoint rebuilds
-# fresh from the deployed image — clearing any existing poison AND closing the
-# warm-cluster cross-version drift case. Session/contact/cache data on dev is
-# disposable login state. This is the bringup-side companion to the destroy-time
-# drop in scripts/destroy-dev-cluster.sh (Step 2c) — keep the two in sync.
+# login on whichever tenant carries the stale DB. Dropping it makes the next
+# deploy recreate an empty DB (via the idempotent roundcube-db-init Job) whose
+# schema the entrypoint rebuilds fresh from the deployed image. Session/contact/
+# cache data on dev is disposable login state.
+#
+# SCOPED PER LEASED TENANT — do NOT drop all roundcube_*. The dev LKE cluster and
+# postgres-dev VM are shared across concurrently-running pipelines, each holding a
+# DIFFERENT pool/tenant lease. Dropping every roundcube_* on each bringup wiped a
+# *sibling* pipeline's DB out from under its running e2e: pipeline #1547 logged in
+# fine on shard 10 at 15:15, a sibling bringup (#1548/#1549/#1550, all created
+# 15:12-15:16) dropped the leased tenant's roundcube DB mid-run, PgBouncer then
+# cached `FATAL: ... database "roundcube_<tenant>" does not exist
+# (server_login_retry)`, and shard 5 failed at 15:19:57. The lease guarantees the
+# leased tenant is exclusively ours, so only ITS DB is ever safe to reset here.
+# This mirrors the per-tenant scoping the nextcloud_<tenant> block below already
+# has (which is why nextcloud was never hit). See memory
+# project_shard5_10_roundcube_login_root_cause.
 #
 # Bounded to dev: $KUBECONFIG points at the dev cluster (kubeconfig.dev.yaml),
-# whose in-cluster PgBouncer fronts the dev postgres VM only. Unlike the
-# best-effort destroy-side drop, this fails fast if the DB query errors — a
-# silent skip would leave webmail login broken for the whole pipeline. But it
-# only fails after (a) waiting for PgBouncer to be ready and (b) retrying the
-# throwaway psql pod: pipeline #1519 hit `error: timed out waiting for the
-# condition` because the diagnostic pod couldn't reach Running within kubectl's
-# default 60s `--pod-running-timeout` (cold/autoscaling node). Mitigations:
-# reuse the small postgres:15-alpine image db-init already pulls (warm cache),
-# raise the pod-running-timeout, and retry with backoff.
+# whose in-cluster PgBouncer fronts the dev postgres VM only. Fails fast if the
+# drop errors — a silent skip would leave webmail login broken for the whole
+# pipeline. But it only fails after (a) waiting for PgBouncer to be ready and
+# (b) retrying the throwaway psql pod: pipeline #1519 hit `error: timed out
+# waiting for the condition` because the diagnostic pod couldn't reach Running
+# within kubectl's default 60s `--pod-running-timeout` (cold/autoscaling node).
+# Mitigations: reuse the small postgres:15-alpine image db-init already pulls
+# (warm cache), raise the pod-running-timeout, and retry with backoff.
+#
+# NOTE: the destroy-side companion in scripts/destroy-dev-cluster.sh (Step 2c)
+# still drops all roundcube_* — safe there because teardown runs when the cluster
+# is idle (no concurrent e2e) and the reaper holds no lease to scope to.
+RC_TENANT=""
 if [ "${MT_ENV:-dev}" = "dev" ]; then
-    print_status "dev-bringup: resetting persistent Roundcube tenant DBs (schema-vs-image drift guard)"
+    # Resolve the leased tenant from the Valkey lease. Run the canonical resolver
+    # in a subshell so its no-lease `exit 1` (and its `${VAR:?}` guards on a
+    # non-CI/operator run) can't abort this script — we only want E2E_TENANT.
+    RC_TENANT=$( (source "$REPO_ROOT/ci/scripts/ci-resolve-tenant.sh" >/dev/null 2>&1; printf '%s' "${E2E_TENANT:-}") 2>/dev/null || true )
+fi
+if [ "${MT_ENV:-dev}" = "dev" ] && [ -z "$RC_TENANT" ]; then
+    # No lease (operator run, or lease lookup failed) → nothing to scope to.
+    # Skip rather than fall back to a global drop, which is the exact action that
+    # wiped a sibling pipeline's DB (#1547). There is no concurrent e2e in the
+    # no-lease case, and the schema-drift this guards was disproven as the live
+    # failure cause, so skipping is strictly safer.
+    print_warning "dev-bringup: no leased tenant resolved — skipping Roundcube DB reset (avoids wiping a concurrent pipeline's DB)"
+fi
+if [ "${MT_ENV:-dev}" = "dev" ] && [ -n "$RC_TENANT" ]; then
+    # Allowlist-validate before using the name in a SQL string / identifier.
+    if [[ ! "$RC_TENANT" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+        print_error "dev-bringup: refusing to reset Roundcube DB — suspicious leased tenant name: $RC_TENANT"
+        exit 1
+    fi
+    print_status "dev-bringup: resetting leased tenant's Roundcube DB (roundcube_${RC_TENANT}) only — scoped per-tenant (schema-vs-image drift guard, #1547)"
     RC_PG_PASSWORD=$(kubectl --kubeconfig="$KUBECONFIG" get secret postgres-credentials -n infra-db \
         -o jsonpath='{.data.postgres-password}' 2>/dev/null | base64 -d || true)
     if [ -z "$RC_PG_PASSWORD" ]; then
@@ -262,7 +295,7 @@ if [ "${MT_ENV:-dev}" = "dev" ]; then
             --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
             --env "PGUSER=postgres" \
             --env "PGPASSWORD=$RC_PG_PASSWORD" \
-            -- psql -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'roundcube\\_%' ESCAPE '\\';" 2>&1); then
+            -- psql -tAc "SELECT datname FROM pg_database WHERE datname = 'roundcube_${RC_TENANT}';" 2>&1); then
             RC_QUERY_OK=true
             break
         fi
@@ -276,7 +309,7 @@ if [ "${MT_ENV:-dev}" = "dev" ]; then
     fi
     RC_DBS=$(grep -E '^[a-z0-9_-]+$' <<< "$RC_LIST_OUT" || true)
     if [ -z "$RC_DBS" ]; then
-        echo "  No roundcube_* databases found, nothing to reset"
+        echo "  roundcube_${RC_TENANT} does not exist yet — nothing to reset (roundcube-db-init will create it on deploy)"
     else
         _rc_i=0
         while IFS= read -r db; do


### PR DESCRIPTION
## Root cause (confirmed, not theorized)

The #469 diagnostics captured the real failure on pipeline #1547 — every Roundcube request logged:

```
DB Error: SQLSTATE[08006] FATAL: server login has been failing,
cached error: database "roundcube_<tenant>" does not exist (server_login_retry)
```

`dev-bringup.sh` dropped **all** `roundcube_*` databases on every cluster bringup. The dev LKE cluster and the always-up `postgres-dev` VM are **shared across concurrently running pipelines** (each holding a different pool/tenant lease), so a *sibling* pipeline's bringup wiped the leased tenant's roundcube DB out from under a **running** e2e.

Timeline on #1547 (proven):
- shard 10 logged in fine at **15:15** (DB existed)
- sibling bringups **#1548 / #1549 / #1550** (created 15:12–15:16) dropped all `roundcube_*`
- PgBouncer cached the "does not exist" login failure
- shard 5 hit it at **15:19:57** → Roundcube can't reach its Postgres **session store** → PHP session can't persist → OIDC `state` lost across the Keycloak redirect → inbox never loads

Same dump ruled out every prior theory: Stalwart oauth logs empty (not OAUTHBEARER), Keycloak clean, roundcube pod healthy with 0 restarts (not schema poison / crashloop / missing principal / spam). This also explains the long-standing **pool-independent intermittency** — it depends on whether a sibling pipeline happens to bring up the cluster during your e2e.

## Fix

Scope the reset to the **leased tenant's DB only**:
- Resolve the leased tenant via the existing `ci-resolve-tenant.sh`, run in a subshell so its no-lease `exit 1` / `${VAR:?}` guards can't abort bringup. The `ensure-dev-cluster` step already carries `CI_VALKEY_PASSWORD` + `E2E_POOL{1,2}_TENANT` — **no new secrets**.
- Query/drop **only** `roundcube_<E2E_TENANT>` — exact-equality (was `LIKE 'roundcube\_%'`), allowlist-validated (`^[a-z0-9][a-z0-9_-]*$`) before first use. Worst case is dropping our own leased DB or nothing — **never a sibling's**.
- **No lease resolved** (operator run / no active lease): skip the reset with a warning instead of the global drop. There's no concurrent e2e then, and the schema-drift this guarded was disproven as the live failure cause — so skipping is strictly safer.

This gives Roundcube the same per-tenant safety the `nextcloud_<tenant>` block (#468) already has via its identity-secret gate (which is exactly why Nextcloud was never hit). The destroy-side drop in `destroy-dev-cluster.sh` (Step 2c) intentionally still drops all `roundcube_*` — safe at teardown (idle cluster, no concurrent e2e, no lease to scope to).

## Relationship to #469
Independent change (#469 is the instrumentation that *found* this; this is the fix). Touches only `scripts/dev-bringup.sh` — no overlap, can merge in either order. The #469 diagnostics will confirm this fix on the next concurrent-pipeline run (no more `database … does not exist`).

## Possible follow-up (not in this PR)
If a residual within-pipeline window ever shows the cached-failure again, add a PgBouncer cache clear (`RECONNECT`/`RELOAD`) after `roundcube-db-init` recreates the DB. Not needed for the proven cross-pipeline cause.

## OSS Compliance Review
✅ **CLEAN — 0 findings** (CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0). Only `${RC_TENANT}`/`${E2E_TENANT}` runtime vars and `roundcube_<tenant>` placeholders; all secrets are env-var references; only public `postgres:15-alpine` image.

## Security Review
✅ **0 CRITICAL / 0 HIGH** — net security improvement (blast radius cut from "all `roundcube_*`" to exactly one tenant's DB via an exact-equality query). Verified: `RC_TENANT` allowlist-validated before any SQL/shell use; subshell resolver isolation sound under `set -euo pipefail`; fail-open-on-no-lease is the correct posture for a *destructive* op and is not silent (warns). 2 LOW items (`PGPASSWORD` via `kubectl run --env`; psql stderr in failure dump) are **pre-existing patterns untouched by this diff**.

## version-bump
✅ Not required — infra/bringup script; no `apps/{admin,account}-portal` runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)