### PR TITLE
feat(monitoring): federate prod-eu metrics into grafana.prod over Headscale

### DIFF
--- a/ansible/templates/headscale-acl-policy.json.j2
+++ b/ansible/templates/headscale-acl-policy.json.j2
@@ -16,6 +16,7 @@
   "acls": [
     {"action": "accept", "src": ["tag:pgbouncer"], "dst": ["tag:postgres:5432"]},
     {"action": "accept", "src": ["tag:monitoring"], "dst": ["tag:postgres:9187"]},
+    {"action": "accept", "src": ["tag:monitoring"], "dst": ["tag:monitoring:9090"]},
     {"action": "accept", "src": ["tag:ci"], "dst": ["tag:k8s-node:6443", "tag:postgres:5432"]},
     {"action": "accept", "src": ["tag:router"], "dst": ["*:*"]},
     {"action": "accept", "src": ["tag:headscale"], "dst": ["*:*"]},

--- a/apps/deploy-metrics-federation.sh
+++ b/apps/deploy-metrics-federation.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+# Deploy Cross-Cluster Metrics Federation bridge
+# Purpose: Let grafana.prod query the prod-eu Prometheus over the Headscale mesh,
+#          consolidating all metrics into a single Grafana viewer (grafana.prod).
+#
+# Two roles, selected by `metrics_federation.role` in the infra config:
+#
+#   role: exposer  (prod-eu)
+#       Deploys `prometheus-mesh-expose`: a socat + Tailscale (tag:monitoring)
+#       sidecar pod that exposes the in-cluster Prometheus (ClusterIP :9090) on
+#       the mesh via the pod's own 100.64.x.x address.
+#
+#   role: consumer (prod)
+#       Deploys `prometheus-eu-bridge`: a socat + Tailscale sidecar pod that
+#       forwards an in-cluster ClusterIP (:9090) to the prod-eu exposer's mesh IP
+#       (metrics_federation.source_mesh_ip), PLUS a Grafana datasource ConfigMap
+#       registering "Prometheus (prod-eu)" (uid: prometheus-eu).
+#
+#   (role unset)   -> feature disabled for this env; the script is a no-op.
+#
+# Bootstrap order (operator):
+#   1. Set metrics_federation.role: exposer in the prod-eu infra config; ensure a
+#      reusable tag:monitoring pre-auth key exists (tailscale.metrics_authkey).
+#   2. deploy_infra -e prod-eu  (deploys the exposer); read its assigned mesh IP:
+#        tailscale --socket=... status   (or: headscale nodes list | grep prom-mesh)
+#   3. Add an ACL rule allowing tag:monitoring -> tag:monitoring:9090 and redeploy
+#      the Headscale ACL (ansible/templates/headscale-acl-policy.json.j2).
+#   4. Set metrics_federation.role: consumer AND metrics_federation.source_mesh_ip:
+#      <exposer mesh IP> in the prod infra config.
+#   5. deploy_infra -e prod  (deploys the consumer + datasource).
+#
+# Required infra config (config/platform/infra/<env>.config.yaml):
+#   metrics_federation:
+#     role: exposer | consumer
+#     source_mesh_ip: "100.64.x.x"   # consumer only
+# Required infra secret (config/platform/infra/<env>.secrets.yaml):
+#   tailscale:
+#     metrics_authkey: "<reusable tag:monitoring pre-auth key>"
+#
+# Called by: deploy_infra (after pg-metrics-bridge). Can also be run standalone.
+#
+# Usage:
+#   ./apps/deploy-metrics-federation.sh -e <env>
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "${REPO_ROOT}/scripts/lib/common.sh"
+source "${REPO_ROOT}/scripts/lib/args.sh"
+
+mt_usage() {
+  echo "Usage: $0 -e <env>"
+  echo ""
+  echo "Deploy the cross-cluster metrics federation bridge (socat + Tailscale) so"
+  echo "grafana.prod can query the prod-eu Prometheus over the Headscale mesh."
+  echo ""
+  echo "Role is selected by metrics_federation.role in the infra config"
+  echo "(exposer on prod-eu, consumer on prod). Unset = no-op."
+  echo ""
+  echo "Options:"
+  echo "  -e <env>       Environment (e.g., prod, prod-eu)"
+  echo "  -h, --help     Show this help"
+}
+
+mt_parse_args "$@"
+mt_require_env
+
+# Load infrastructure configuration
+source "${REPO_ROOT}/scripts/lib/infra-config.sh"
+mt_load_infra_config
+
+mt_require_commands kubectl envsubst
+
+MANIFESTS_DIR="$REPO_ROOT/apps/manifests/metrics-federation"
+
+# =============================================================================
+# Feature gate — disabled unless a role is configured
+# =============================================================================
+
+ROLE="${MT_METRICS_FED_ROLE:-}"
+if [ -z "$ROLE" ] || [ "$ROLE" = "null" ]; then
+  print_status "Metrics federation not enabled for $MT_ENV (set metrics_federation.role in infra config). Skipping."
+  exit 0
+fi
+
+: "${HEADSCALE_URL:?HEADSCALE_URL not set. Add headscale.url to infra config.}"
+export HEADSCALE_URL
+export NS_MONITORING
+
+# Tailscale pre-auth key — only needed for first-time bootstrap.
+# After initial creation, the key-rotator CronJob manages this secret.
+TAILSCALE_AUTHKEY="${TAILSCALE_AUTHKEY_METRICS:-${TAILSCALE_AUTHKEY:-}}"
+
+# =============================================================================
+# Role selection
+# =============================================================================
+
+DEPLOY_DATASOURCE=false
+case "$ROLE" in
+  exposer)
+    # prod-eu: expose the in-cluster Prometheus on the mesh.
+    export FED_NAME="prometheus-mesh-expose"
+    export SOCAT_TARGET="kube-prometheus-stack-prometheus.${NS_MONITORING}.svc.cluster.local:9090"
+    export TS_HOSTNAME="prom-mesh-${MT_ENV}"
+    ;;
+  consumer)
+    # prod: forward an in-cluster ClusterIP to the prod-eu exposer's mesh IP.
+    : "${MT_METRICS_FED_SOURCE_IP:?metrics_federation.source_mesh_ip is required when role=consumer (the prod-eu exposer's 100.64.x.x mesh IP — see bootstrap steps in this script's header).}"
+    # Defence-in-depth: this value flows straight into socat args, so reject anything
+    # that is not a Tailscale CGNAT mesh IP (100.64.0.0/10 → second octet 64-127).
+    if ! [[ "$MT_METRICS_FED_SOURCE_IP" =~ ^100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+      print_error "metrics_federation.source_mesh_ip ('$MT_METRICS_FED_SOURCE_IP') is not a Tailscale mesh IP (expected 100.64.0.0/10, e.g. 100.64.0.x)"
+      exit 1
+    fi
+    export FED_NAME="prometheus-eu-bridge"
+    export SOCAT_TARGET="${MT_METRICS_FED_SOURCE_IP}:9090"
+    export TS_HOSTNAME="prom-eu-bridge-${MT_ENV}"
+    DEPLOY_DATASOURCE=true
+    ;;
+  *)
+    print_error "Unknown metrics_federation.role '$ROLE' (expected: exposer | consumer)"
+    exit 1
+    ;;
+esac
+
+print_status "Deploying metrics federation ($ROLE) to $NS_MONITORING (env: $MT_ENV)"
+print_status "  Pod/Service:  $FED_NAME"
+print_status "  socat target: $SOCAT_TARGET"
+print_status "  Headscale URL: $HEADSCALE_URL"
+
+mt_reset_change_tracker
+
+# =============================================================================
+# Apply RBAC
+# =============================================================================
+
+print_status "Applying metrics federation RBAC..."
+envsubst '${NS_MONITORING} ${FED_NAME}' < "$MANIFESTS_DIR/rbac.yaml.tpl" | mt_apply kubectl apply -f -
+
+# =============================================================================
+# Apply Secret (create only if missing — managed by key-rotator CronJob)
+# =============================================================================
+
+if ! kubectl get secret "${FED_NAME}-tailscale-auth" -n "$NS_MONITORING" >/dev/null 2>&1; then
+  if [ -z "${TAILSCALE_AUTHKEY:-}" ]; then
+    print_error "${FED_NAME}-tailscale-auth secret does not exist and no Tailscale auth key is set"
+    print_error "Bootstrap: create a reusable tag:monitoring pre-auth key and set tailscale.metrics_authkey in infra secrets"
+    exit 1
+  fi
+  print_status "Creating metrics federation Tailscale auth secret (first-time bootstrap)..."
+  envsubst '${NS_MONITORING} ${FED_NAME} ${TAILSCALE_AUTHKEY}' \
+    < "$MANIFESTS_DIR/secret.yaml.tpl" | mt_apply kubectl apply -f -
+else
+  print_status "Tailscale auth secret exists (managed by key-rotator CronJob)"
+fi
+
+# =============================================================================
+# Apply Deployment + Service
+# =============================================================================
+
+print_status "Applying metrics federation Deployment..."
+envsubst '${NS_MONITORING} ${FED_NAME} ${SOCAT_TARGET} ${HEADSCALE_URL} ${TS_HOSTNAME}' \
+  < "$MANIFESTS_DIR/deployment.yaml.tpl" | mt_apply kubectl apply -f -
+
+print_status "Applying metrics federation Service..."
+envsubst '${NS_MONITORING} ${FED_NAME}' < "$MANIFESTS_DIR/service.yaml.tpl" | mt_apply kubectl apply -f -
+
+# =============================================================================
+# Apply Grafana datasource (consumer only)
+# =============================================================================
+
+if [ "$DEPLOY_DATASOURCE" = true ]; then
+  print_status "Registering 'Prometheus (prod-eu)' Grafana datasource..."
+  envsubst '${NS_MONITORING}' < "$MANIFESTS_DIR/grafana-datasource.configmap.yaml.tpl" | mt_apply kubectl apply -f -
+fi
+
+# =============================================================================
+# Conditional restart + rollout wait
+# =============================================================================
+
+mt_restart_if_changed "deployment/${FED_NAME}" -n "$NS_MONITORING"
+
+if mt_has_changes; then
+  print_status "Waiting for metrics federation rollout..."
+  kubectl rollout status "deployment/${FED_NAME}" -n "$NS_MONITORING" --timeout=120s
+fi
+
+print_success "Metrics federation ($ROLE) deployed to $NS_MONITORING"

--- a/apps/manifests/metrics-federation/README.md
+++ b/apps/manifests/metrics-federation/README.md
@@ -1,0 +1,134 @@
+# Cross-Cluster Metrics Federation
+
+Lets **grafana.prod** query the **prod-eu** Prometheus over the existing Headscale
+mesh, so every cluster's metrics show up in a single Grafana viewer (grafana.prod)
+without moving any time-series data between clusters.
+
+## Why a bridge (and not just a datasource URL)
+
+`grafana.prod` runs in the prod LKE cluster; prod-eu's Prometheus is a plain
+ClusterIP in a *different* cluster. You can't route cluster IPs across the two
+clusters — prod and prod-eu both use Service CIDR `10.128.0.0/16`, so they
+collide (this is also why the Tailscale subnet router only advertises the
+internal-ingress `/32`). The only stable cross-cluster address is a **mesh IP**.
+
+So we mirror the proven `pg-metrics-bridge` pattern (socat + native Tailscale
+sidecar) on **both** sides:
+
+```
+grafana.prod ──ClusterIP──▶ prometheus-eu-bridge        (PROD, role: consumer)
+                              │ socat :9090
+                              │ Tailscale sidecar (tag:monitoring)
+                              ▼ mesh 100.64.x.x:9090
+                   ┌──── Headscale mesh ────┐
+                              ▼
+            prometheus-mesh-expose          (PROD-EU, role: exposer)
+                              │ Tailscale sidecar (tag:monitoring, mesh IP X)
+                              │ socat :9090
+                              ▼ ClusterIP
+            kube-prometheus-stack-prometheus:9090   (prod-eu)
+```
+
+Grafana itself never joins the mesh; only the two tiny bridge pods do.
+
+## Resources
+
+| File | Role | Notes |
+|---|---|---|
+| `deployment.yaml.tpl` | both | socat + native Tailscale sidecar, `Recreate`, 1 replica |
+| `service.yaml.tpl` | both | ClusterIP `:9090` (consumer side is what Grafana hits) |
+| `secret.yaml.tpl` | both | `${FED_NAME}-tailscale-auth` (bootstrap only; then key-rotator owns it) |
+| `rbac.yaml.tpl` | both | SA + Role for the sidecar's state Secret |
+| `grafana-datasource.configmap.yaml.tpl` | consumer | registers `Prometheus (prod-eu)` (uid `prometheus-eu`) |
+
+Deployed by `apps/deploy-metrics-federation.sh`, wired into `scripts/deploy_infra`.
+Feature-gated by `metrics_federation.role` in the infra config — **no-op when unset**
+(so dev and any not-yet-enabled env are unaffected).
+
+## Required config (private `config/platform` submodule)
+
+`config/platform/infra/<env>.config.yaml`:
+
+```yaml
+# prod-eu
+metrics_federation:
+  role: exposer
+
+# prod
+metrics_federation:
+  role: consumer
+  source_mesh_ip: "100.64.x.x"   # the prod-eu exposer's assigned mesh IP (step 2 below)
+```
+
+`config/platform/infra/<env>.secrets.yaml` (both prod and prod-eu):
+
+```yaml
+tailscale:
+  metrics_authkey: "<reusable tag:monitoring pre-auth key>"
+```
+
+prod already has `metrics_authkey` (pg-metrics-bridge). **prod-eu likely does not** —
+mint one (see step 1).
+
+## Operator bootstrap (run in order)
+
+1. **prod-eu key**: mint a reusable `tag:monitoring` pre-auth key and set
+   `tailscale.metrics_authkey` in the prod-eu infra secrets:
+   ```bash
+   ./scripts/rotate-tailscale-keys.sh -e prod-eu   # or mint manually on the Headscale VM:
+   #   headscale preauthkeys create --user <infra-id> --reusable --expiration 8760h --tags tag:monitoring
+   ```
+   Set `metrics_federation.role: exposer` in the prod-eu infra config.
+
+2. **Deploy the exposer + capture its mesh IP**:
+   ```bash
+   ./scripts/deploy_infra -e prod-eu
+   # then read the assigned 100.64.x.x of node "prom-mesh-prod-eu":
+   ssh root@<headscale-vm> 'headscale nodes list' | grep prom-mesh-prod-eu
+   ```
+
+3. **ACL**: this PR adds `{"src":["tag:monitoring"],"dst":["tag:monitoring:9090"]}`
+   to `ansible/templates/headscale-acl-policy.json.j2`. Redeploy it:
+   ```bash
+   ./ci/scripts/provision-ci.sh --ansible-only   # or the headscale playbook tag that runs "Deploy ACL policy"
+   ```
+
+4. **prod config**: set `metrics_federation.role: consumer` **and**
+   `metrics_federation.source_mesh_ip: <ip from step 2>` in the prod infra config.
+
+5. **Deploy the consumer + datasource**:
+   ```bash
+   ./scripts/deploy_infra -e prod
+   ```
+
+## Verify
+
+```bash
+# prod-eu exposer healthy & on the mesh
+kubectl --kubeconfig=kubeconfig.prod-eu.yaml -n infra-monitoring get pod -l app=prometheus-mesh-expose
+
+# prod consumer healthy
+kubectl --kubeconfig=kubeconfig.prod.yaml -n infra-monitoring get pod -l app=prometheus-eu-bridge
+
+# from grafana.prod: Connections → Data sources → "Prometheus (prod-eu)" → Save & test  (should be green)
+# or, in-cluster:
+kubectl --kubeconfig=kubeconfig.prod.yaml -n infra-monitoring run q --rm -it --image=curlimages/curl --restart=Never -- \
+  curl -s 'http://prometheus-eu-bridge.infra-monitoring:9090/api/v1/query?query=up' | head -c 200
+```
+
+## Using it in dashboards
+
+The datasource uid is **`prometheus-eu`**. To make an existing dashboard
+switchable between clusters, add a `datasource` template variable (type
+*Data source*, query `prometheus`) and replace each panel's hardcoded
+`"uid": "prometheus"` with `"uid": "${datasource}"`. That retrofit is the
+dashboard-revamp follow-up, tracked separately.
+
+## Known follow-up
+
+`scripts/rotate-tailscale-keys.sh` / `scripts/lib/tailscale-keys.sh` only rotate
+the `pgbouncer` and `metrics` (pg-metrics-bridge) components today. The two bridge
+pods here reuse the shared `tag:monitoring` key and — because tagged Headscale
+nodes don't key-expire by default — run fine without per-component rotation. If you
+later want their bootstrap auth-key Secrets refreshed on rotation, add
+`prometheus-mesh-expose` / `prometheus-eu-bridge` entries to those scripts.

--- a/apps/manifests/metrics-federation/deployment.yaml.tpl
+++ b/apps/manifests/metrics-federation/deployment.yaml.tpl
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${FED_NAME}
+  namespace: ${NS_MONITORING}
+  labels:
+    app: ${FED_NAME}
+    component: metrics-federation
+spec:
+  replicas: 1
+  # Recreate: single-replica pod with a Tailscale sidecar — two pods cannot share
+  # the same mesh identity during a rolling update, causing readiness failures.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ${FED_NAME}
+  template:
+    metadata:
+      labels:
+        app: ${FED_NAME}
+        component: metrics-federation
+    spec:
+      serviceAccountName: ${FED_NAME}
+      containers:
+        # socat — TCP proxy. Two roles, selected by ${SOCAT_TARGET}:
+        #   exposer  (prod-eu): forwards mesh -> in-cluster Prometheus ClusterIP:9090
+        #   consumer (prod):    forwards in-cluster ClusterIP -> prod-eu bridge mesh IP:9090
+        - name: socat
+          image: alpine/socat:1.8.0.3
+          args:
+            - TCP-LISTEN:9090,fork,reuseaddr
+            - TCP:${SOCAT_TARGET}
+          ports:
+            - containerPort: 9090
+              name: http
+          livenessProbe:
+            tcpSocket:
+              port: 9090
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+
+      # Native sidecar (K8s 1.28+): starts before main containers, terminated AFTER
+      # them. This guarantees the WireGuard tunnel stays alive while socat drains
+      # any in-flight requests on shutdown.
+      initContainers:
+        - name: tailscale
+          # tailscale/tailscale:v1.94.2 — stable release, multi-arch
+          # https://hub.docker.com/r/tailscale/tailscale
+          image: tailscale/tailscale:v1.94.2
+          restartPolicy: Always
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: ${FED_NAME}-tailscale-auth
+                  key: TS_AUTHKEY
+            - name: TS_HOSTNAME
+              value: "${TS_HOSTNAME}"
+            - name: TS_EXTRA_ARGS
+              value: "--login-server=${HEADSCALE_URL}"
+            - name: TS_KUBE_SECRET
+              value: "${FED_NAME}-tailscale-state-$(POD_NAME)"
+            - name: TS_ACCEPT_DNS
+              value: "false"
+            - name: TS_USERSPACE
+              value: "false"
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+
+      terminationGracePeriodSeconds: 15

--- a/apps/manifests/metrics-federation/grafana-datasource.configmap.yaml.tpl
+++ b/apps/manifests/metrics-federation/grafana-datasource.configmap.yaml.tpl
@@ -1,0 +1,32 @@
+---
+# Registers the prod-eu Prometheus as a Grafana datasource in the PROD cluster,
+# reached over the Headscale mesh via the prometheus-eu-bridge consumer pod.
+# Picked up by the kube-prometheus-stack Grafana datasource sidecar
+# (watches ConfigMaps labelled grafana_datasource: "1").
+#
+# Deployed ONLY in the consumer cluster (prod). The uid `prometheus-eu` is the
+# stable handle dashboards use in a $datasource template variable to switch
+# between the local cluster and prod-eu.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-eu-datasource
+  namespace: ${NS_MONITORING}
+  labels:
+    grafana_datasource: "1"
+    component: metrics-federation
+data:
+  prometheus-eu.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus (prod-eu)
+        type: prometheus
+        uid: prometheus-eu
+        access: proxy
+        url: http://prometheus-eu-bridge.${NS_MONITORING}.svc.cluster.local:9090
+        isDefault: false
+        editable: false
+        jsonData:
+          httpMethod: POST
+          # Cross-cluster hop over the mesh — allow a little extra headroom.
+          timeout: 60

--- a/apps/manifests/metrics-federation/rbac.yaml.tpl
+++ b/apps/manifests/metrics-federation/rbac.yaml.tpl
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${FED_NAME}
+  namespace: ${NS_MONITORING}
+  labels:
+    app: ${FED_NAME}
+    component: metrics-federation
+---
+# Role granting the Tailscale sidecar permission to manage its state Secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ${FED_NAME}-tailscale
+  namespace: ${NS_MONITORING}
+  labels:
+    app: ${FED_NAME}
+    component: metrics-federation
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${FED_NAME}-tailscale
+  namespace: ${NS_MONITORING}
+  labels:
+    app: ${FED_NAME}
+    component: metrics-federation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ${FED_NAME}-tailscale
+subjects:
+  - kind: ServiceAccount
+    name: ${FED_NAME}
+    namespace: ${NS_MONITORING}

--- a/apps/manifests/metrics-federation/secret.yaml.tpl
+++ b/apps/manifests/metrics-federation/secret.yaml.tpl
@@ -1,0 +1,14 @@
+---
+# Tailscale pre-authenticated key for mesh connectivity (tag:monitoring).
+# Created only on first-time bootstrap; thereafter owned by the key-rotator CronJob.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${FED_NAME}-tailscale-auth
+  namespace: ${NS_MONITORING}
+  labels:
+    app: ${FED_NAME}
+    component: metrics-federation
+type: Opaque
+stringData:
+  TS_AUTHKEY: "${TAILSCALE_AUTHKEY}"

--- a/apps/manifests/metrics-federation/service.yaml.tpl
+++ b/apps/manifests/metrics-federation/service.yaml.tpl
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${FED_NAME}
+  namespace: ${NS_MONITORING}
+  labels:
+    app: ${FED_NAME}
+    component: metrics-federation
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+      protocol: TCP
+  selector:
+    app: ${FED_NAME}

--- a/scripts/deploy_infra
+++ b/scripts/deploy_infra
@@ -478,6 +478,19 @@ else
 fi
 
 # =============================================================================
+# Deploy Cross-Cluster Metrics Federation bridge
+# (grafana.prod <- prod-eu Prometheus over the Headscale mesh).
+# Feature-gated by metrics_federation.role in the infra config; no-op when unset.
+# =============================================================================
+print_status "Deploying cross-cluster metrics federation (if enabled)..."
+if [ -x "$REPO_ROOT/apps/deploy-metrics-federation.sh" ]; then
+  "$REPO_ROOT/apps/deploy-metrics-federation.sh" -e "$MT_ENV" --nesting-level=$((MT_NESTING_LEVEL+1)) 2>&1 | sed 's/^/  /'
+else
+  print_error "deploy-metrics-federation.sh not found or not executable"
+  exit 1
+fi
+
+# =============================================================================
 # Deploy Tailscale Key Rotator CronJob
 # =============================================================================
 print_status "Deploying Tailscale key rotator CronJob..."

--- a/scripts/lib/infra-config.sh
+++ b/scripts/lib/infra-config.sh
@@ -142,6 +142,15 @@ _mt_infra_load_env_config() {
     # TURN server Tailscale IP (for Ansible inventory mesh fallback)
     TURN_TAILSCALE_IP=$(yq '.turn.tailscale_ip // ""' "$infra_config")
     export TURN_TAILSCALE_IP
+
+    # Cross-cluster metrics federation (grafana.prod queries prod-eu Prometheus
+    # over the Headscale mesh). role: exposer (prod-eu) | consumer (prod) | unset.
+    # source_mesh_ip is the prod-eu exposer's 100.64.x.x mesh IP (consumer only).
+    MT_METRICS_FED_ROLE=$(yq '.metrics_federation.role // ""' "$infra_config")
+    MT_METRICS_FED_SOURCE_IP=$(yq '.metrics_federation.source_mesh_ip // ""' "$infra_config")
+    [ "$MT_METRICS_FED_ROLE" = "null" ] && MT_METRICS_FED_ROLE=""
+    [ "$MT_METRICS_FED_SOURCE_IP" = "null" ] && MT_METRICS_FED_SOURCE_IP=""
+    export MT_METRICS_FED_ROLE MT_METRICS_FED_SOURCE_IP
   else
     echo "[WARNING] Infrastructure config not found: $infra_config"
     echo "[WARNING] Using defaults: PG_READ_REPLICAS=1, KEYCLOAK_REPLICAS=2"


### PR DESCRIPTION
## What & why

Consolidates every cluster's metrics into **one viewer — grafana.prod** — by letting it query the **prod-eu** Prometheus over the existing Headscale mesh. No time-series data leaves either cluster; grafana.prod just gains a second datasource.

This is the second of two PRs revamping the Grafana setup (PR #474 fixed the broken prod dashboards). Topology was chosen with you: **two bridges, grafana stays off the mesh.**

## Why a bridge on each side

grafana.prod runs in the prod cluster; prod-eu's Prometheus is a ClusterIP in a *different* cluster. The two clusters **both use Service CIDR `10.128.0.0/16`**, so cluster IPs can't be routed across them (this is also why the Tailscale subnet router only advertises the internal-ingress `/32`). The only stable cross-cluster address is a **mesh IP** — so we mirror the proven `pg-metrics-bridge` pattern (socat + native Tailscale sidecar, `tag:monitoring`) on both sides:

```
grafana.prod ──ClusterIP──▶ prometheus-eu-bridge      (PROD, role: consumer)
                              │ socat :9090 + Tailscale sidecar
                              ▼ mesh 100.64.x.x:9090
                   ┌──── Headscale mesh (prod ⇄ prod-eu) ────┐
                              ▼
            prometheus-mesh-expose                (PROD-EU, role: exposer)
                              │ socat :9090 + Tailscale sidecar (mesh IP)
                              ▼ ClusterIP
            kube-prometheus-stack-prometheus:9090  (prod-eu)
```

## What's in this PR

- `apps/manifests/metrics-federation/` — one templated manifest set (deployment/service/secret/rbac) used for **both** roles, a prod-only Grafana datasource ConfigMap (`uid: prometheus-eu`), and a README runbook.
- `apps/deploy-metrics-federation.sh` — env-branched (exposer on prod-eu, consumer + datasource on prod), **feature-gated by `metrics_federation.role`** in the infra config (no-op when unset → dev/other envs untouched). Wired into `scripts/deploy_infra`.
- `scripts/lib/infra-config.sh` — loads `metrics_federation.role` / `.source_mesh_ip`.
- `ansible/templates/headscale-acl-policy.json.j2` — adds `{"src":["tag:monitoring"],"dst":["tag:monitoring:9090"]}`.

Reuses the existing `tag:monitoring` reusable pre-auth key — no new key type or rotation wiring.

## Operator bootstrap (required before it works — see README)
1. Mint a reusable `tag:monitoring` key for **prod-eu**; set `metrics_federation.role: exposer` (prod-eu infra config).
2. `deploy_infra -e prod-eu` → read the exposer's assigned `100.64.x.x` (`headscale nodes list | grep prom-mesh-prod-eu`).
3. Redeploy the Headscale ACL (this PR's rule).
4. Set `metrics_federation.role: consumer` + `source_mesh_ip: <that IP>` (prod infra config).
5. `deploy_infra -e prod` → `Prometheus (prod-eu)` datasource appears in grafana.prod.

> Private values (role, mesh IP, the prod-eu auth key) live in the `config/platform` submodule — your operator step, documented in the README.

## Verification (this PR)
- Shell `bash -n` clean (deploy script, `deploy_infra`, `infra-config.sh`).
- ACL still valid JSON; new rule present.
- Both roles rendered via `envsubst` → valid YAML, `$(POD_NAME)` preserved, correct socat targets, no leftover `${...}`.
- Full consumer set passes `kubectl apply --dry-run=client` against the live prod API (all 7 objects).
- `source_mesh_ip` regex unit-tested: accepts `100.64–127.x.x`, rejects out-of-range / non-mesh / injection (`100.64.0.40; rm -rf /`).

## Follow-ups (not in this PR)
- Retrofit existing dashboards with a `$datasource` variable (`uid prometheus-eu`) so each can switch prod ⇄ prod-eu — part of the broader dashboard revamp.
- Optional hardening from the security review (below).

## OSS Compliance Review
✅ Clean — **CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0**. No real domains/IPs/credentials/PII/private-registry refs. `secret.yaml.tpl` uses the `${TAILSCALE_AUTHKEY}` envsubst placeholder; all hostnames are `${VAR}` / `*.svc.cluster.local` / `<placeholder>`. Private config (role, source_mesh_ip, auth key) correctly documented as living in the submodule.

## Security Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 1 | LOW: 4** — non-blocking. Contained by three layers: encrypted WireGuard, the `tag:monitoring` ACL, and the fact that **dev is on a separate Headscale tailnet** (cannot reach prod-eu). Secret handling, fail-fast, and RBAC match the vetted `pg-metrics-bridge` pattern.

- **MEDIUM — ACL grants the whole `tag:monitoring` fleet, not just the 2 federation pods.** `pg-metrics-bridge` also carries `tag:monitoring` (though it only dials `:9187`). Blast radius = 3 admin-owned monitoring nodes on the prod+prod-eu tailnet, read-only metrics. *Disposition:* kept `tag:monitoring` for pattern-consistency and to avoid a new key + rotation wiring (and the documented "mistagged-key → outage" risk). Tighter option, as a **follow-up**: a dedicated `tag:metrics-fed` scoped `tag:metrics-fed → tag:metrics-fed:9090`.
- **LOW — full Prometheus HTTP API reachable (socat can't path-filter to `/federate`).** Read-only, ACL+mesh-contained. Acceptable.
- **LOW — consumer ClusterIP has no NetworkPolicy** (any prod pod could reach it). Mirrors `pg-metrics-bridge`; pre-existing posture. Follow-up: restrict ingress to the Grafana pod.
- **LOW — sidecar RBAC is namespace-wide Secret `create/get/update/patch`.** Exact copy of `pg-metrics-bridge`; `get/update/patch` could be `resourceNames`-scoped to the state secret.
- **LOW — `source_mesh_ip` injected into socat args without validation.** ✅ **Fixed in this PR** (100.64.0.0/10 regex + fail-fast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)