### PR TITLE
fix(ci): capture roundcube DB/startup/PgBouncer state in e2e-shard diagnostics

### DIFF
--- a/ci/scripts/ci-e2e-diagnostics.sh
+++ b/ci/scripts/ci-e2e-diagnostics.sh
@@ -106,6 +106,32 @@ dump_component() {  # namespace selector friendly-name
 # Roundcube — the OIDC client. DB-schema / session / oauth-state errors land here.
 dump_component "$NS_WEBMAIL" "app=roundcube" "ROUNDCUBE"
 
+# The 300-line tail above MISSES the container entrypoint/startup, which is where
+# any schema-init attempt (or its absence) shows up. Capture the FIRST lines of
+# the CURRENT roundcube log so the NEXT failure tells us WHETHER the entrypoint
+# tried to build the schema at all (pipeline #1571: DB exists but is empty).
+echo ""
+echo ">>> ROUNDCUBE STARTUP (first 150 log lines — entrypoint / schema-init attempt):"
+_rc_startup="$(kubectl logs -n "$NS_WEBMAIL" -l app=roundcube -c roundcube --tail=-1 --timestamps 2>/dev/null | head -150)"
+if [[ -z "$_rc_startup" ]]; then
+  echo "    (no startup logs captured)"
+else
+  printf '%s\n' "$_rc_startup" | sed 's/^/    /'
+fi
+echo ""
+echo ">>> ROUNDCUBE schema/init markers (grep over full current log):"
+_rc_markers="$(kubectl logs -n "$NS_WEBMAIL" -l app=roundcube -c roundcube --tail=-1 2>/dev/null \
+  | grep -iE 'initdb|updatedb|installto|create table|creating|initializ|schema|waiting for|wait for db|database .*(does not exist|not exist)|relation .*does not exist|system' \
+  | head -80)"
+if [[ -z "$_rc_markers" ]]; then
+  # ABSENCE is itself the key signal: in this config the DB is wired via a mounted
+  # custom.config.php db_dsnw (NOT ROUNDCUBEMAIL_DB_* env), so the stock image's
+  # auto-init (gated on ROUNDCUBEMAIL_DB_TYPE) never fires -> trigger (b).
+  echo "    (no schema/init markers found)"
+else
+  printf '%s\n' "$_rc_markers" | sed 's/^/    /'
+fi
+
 # Stalwart — the OAUTHBEARER token validator + IMAP backend. Token-decode /
 # unauthorized errors here mean the OIDC->IMAP auth leg failed.
 dump_component "$NS_MAIL" "app=stalwart" "STALWART"
@@ -134,6 +160,75 @@ else
   done <<< "$_kc_pods"
 fi
 
+# ── Live DB + PgBouncer introspection ─────────────────────────────────────────
+# Both sections need the PG admin password and reach the DB through PgBouncer the
+# same way real pods do. We fetch the password ONCE and guard both sections on it.
+# Read-only throughout (no DROP) — so unlike dev-bringup's reset block, a bad
+# tenant name or missing secret just SKIPS (best-effort: never exit non-zero).
+# Sanitize the slash in E2E_SHARD ("5/10") so pod names stay valid DNS-1123 labels.
+_diag_suffix="${CI_PIPELINE_NUMBER:-x}-${E2E_SHARD//\//-}"
+_pg_pwd="$(kubectl get secret postgres-credentials -n infra-db -o jsonpath='{.data.postgres-password}' 2>/dev/null | base64 -d)"
+
+echo ""
+echo "------------------------------------------------------------------"
+echo "  ROUNDCUBE DATABASE (live introspection)   (db=roundcube_${E2E_TENANT})"
+echo "------------------------------------------------------------------"
+if [[ -z "$_pg_pwd" ]]; then
+  echo "    (postgres-credentials secret in infra-db unavailable — skipping DB introspection)"
+elif [[ ! "$E2E_TENANT" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+  # Allowlist-validate BEFORE interpolating the tenant into the DB name / SQL
+  # (defends against SQL/identifier injection — mirrors dev-bringup's guard).
+  echo "    (suspicious tenant name '$E2E_TENANT' — skipping DB introspection)"
+else
+  echo ">>> Introspecting roundcube_${E2E_TENANT} via PgBouncer (postgres:15-alpine throwaway pod):"
+  _rc_db_out="$(kubectl run "rc-diag-db-${_diag_suffix}" --rm -i --restart=Never \
+    --image=postgres:15-alpine --quiet -n default --pod-running-timeout=120s \
+    --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+    --env "PGUSER=postgres" \
+    --env "PGPASSWORD=$_pg_pwd" \
+    --env "PGDATABASE=roundcube_${E2E_TENANT}" \
+    -- psql -v ON_ERROR_STOP=0 \
+       -c "\echo '--- public tables ---'" \
+       -c "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY 1;" \
+       -c "\echo '--- table count ---'" \
+       -c "SELECT count(*) AS public_table_count FROM information_schema.tables WHERE table_schema='public';" \
+       -c "\echo '--- roundcube schema version (errors if system table missing) ---'" \
+       -c "SELECT value FROM system WHERE name='roundcube-version';" 2>&1)"
+  printf '%s\n' "$_rc_db_out" | sed 's/^/    /'
+  echo ""
+  echo "    INTERPRETATION:"
+  echo "      • 'database \"roundcube_...\" does not exist' (maybe PgBouncer-cached as"
+  echo "        server_login_retry) -> DB MISSING (trigger-a / #1547 family)."
+  echo "      • connects but ZERO public tables           -> DB exists, schema NEVER"
+  echo "        built (#1571 cause); read ROUNDCUBE STARTUP above for whether the"
+  echo "        entrypoint even tried (no init markers -> trigger b)."
+fi
+
+echo ""
+echo "------------------------------------------------------------------"
+echo "  PGBOUNCER (admin console)   (host=pgbouncer.infra-db.svc.cluster.local)"
+echo "------------------------------------------------------------------"
+if [[ -z "$_pg_pwd" ]]; then
+  echo "    (postgres-credentials secret in infra-db unavailable — skipping pgbouncer dump)"
+else
+  echo ">>> SHOW DATABASES / POOLS / SERVERS (surfaces a stale/negative cached roundcube entry):"
+  _pgb_out="$(kubectl run "rc-diag-pgb-${_diag_suffix}" --rm -i --restart=Never \
+    --image=postgres:15-alpine --quiet -n default --pod-running-timeout=120s \
+    --env "PGHOST=pgbouncer.infra-db.svc.cluster.local" \
+    --env "PGUSER=postgres" \
+    --env "PGPASSWORD=$_pg_pwd" \
+    --env "PGDATABASE=pgbouncer" \
+    -- psql -v ON_ERROR_STOP=0 \
+       -c "SHOW DATABASES;" \
+       -c "SHOW POOLS;" \
+       -c "SHOW SERVERS;" 2>&1)"
+  if [[ -z "$_pgb_out" ]]; then
+    echo "    (pgbouncer admin not accessible — no output)"
+  else
+    printf '%s\n' "$_pgb_out" | sed 's/^/    /'
+  fi
+fi
+
 echo ""
 echo "=================================================================="
 echo "  HOW TO READ THIS (see memory project_shard5_10_roundcube_login_root_cause):"
@@ -142,6 +237,15 @@ echo "   • stalwart  OAUTHBEARER / 'Failed to decode token' /"
 echo "               'unauthorized'                              -> Stalwart token validation"
 echo "   • roundcube session / oauth-state / redirect errors    -> Roundcube 1.7 / session store"
 echo "   • keycloak  invalid_client / redirect_uri              -> Keycloak client config"
+echo "   • roundcube 'relation \"session\" does not exist' + DB introspection shows"
+echo "     0 public tables -> DB created EMPTY, schema NEVER built (#1571 cause)."
+echo "     Then read ROUNDCUBE STARTUP / schema-init markers: NO init lines ->"
+echo "     entrypoint never auto-inits (trigger b); init attempted but errored /"
+echo "     'database does not exist' -> trigger a/c."
+echo "   • DB introspection shows 'database \"...\" does not exist' -> DB MISSING /"
+echo "     PgBouncer-cached (#1547 cause)."
+echo '   • pgbouncer SHOW DATABASES / SHOW SERVERS with a stale/absent roundcube'
+echo '     entry corroborates a drop/recreate cache window.'
 echo "   • browser-side [roundcube-stuck:*] lines in the e2e log show WHERE"
 echo "     the browser stopped (Keycloak vs webmail-no-inbox)."
 echo "=================================================================="


### PR DESCRIPTION
## Why

The shard-5/10 Roundcube-login failure diagnostics added in #469 truncated the roundcube pod log to the **last 300 lines**, which misses the container **entrypoint startup** — exactly where any schema-init attempt (or its absence) appears. It also never introspected the **database** or **PgBouncer**.

Pipeline **#1571** (main, post-#473) failed again: shard-5 **and** shard-10, both on the same `pool1` tenant, with `relation "session" does not exist` (66 hits). The `roundcube_<tenant>` DB **exists and is reachable but is completely empty** — the schema was never built. Stalwart healthy, Keycloak only old unrelated noise. Timing disproves the "bringup wiped the schema after the pod booted" race (bringup done 19:38:20, pod started 19:46:39). But the existing diagnostics **could not tell us the trigger**: did the entrypoint try to build the schema and fail (PgBouncer negative-cache window), or never auto-init at all (the DB is wired via a mounted `custom.config.php` `db_dsnw`, not `ROUNDCUBEMAIL_DB_*` env, so the stock image's `ROUNDCUBEMAIL_DB_TYPE`-gated auto-init never fires)?

This PR is **evidence-first**: it makes the *next* failure name the trigger. No behavior fix yet — that lands in a follow-up once the trigger is confirmed.

## What

Three best-effort, **read-only** captures added to `ci/scripts/ci-e2e-diagnostics.sh` (the `when: status:[failure]` step on e2e-shard-5/10):

1. **ROUNDCUBE STARTUP** — first 150 lines of the current container log (`--tail=-1 | head -150`) + a grep over the full log for schema/init markers (`initdb|updatedb|installto|create table|...`). Absence of init markers is itself the signal for "entrypoint never auto-inits".
2. **ROUNDCUBE DATABASE (live introspection)** — throwaway `postgres:15-alpine` pod through PgBouncer: lists public tables, counts them, reads the `system` `roundcube-version` row. Distinguishes **DB missing** (#1547) from **DB empty / schema never built** (#1571).
3. **PGBOUNCER (admin console)** — `SHOW DATABASES / POOLS / SERVERS`, surfacing a stale/negative cached roundcube entry from a drop/recreate window.

Plus an expanded "HOW TO READ THIS" legend mapping each signal to trigger (a)/(b)/(c).

### Safety
- **Read-only** — only `SELECT`/`SHOW`, no `DROP`/`CREATE` (unlike `dev-bringup.sh`, no drop block at all).
- **Allowlist-validated** tenant name (`^[a-z0-9][a-z0-9_-]*$`) before any DB-name/SQL interpolation; tenant never enters a SQL `-c` string (only the `PGDATABASE` connection target).
- **DNS-1123-safe** pod names (tenant deliberately excluded; `E2E_SHARD` slash sanitized).
- **No new Woodpecker secret** — PG password fetched at runtime from the in-cluster `postgres-credentials` secret, passed only via `kubectl run --env` (mirrors the accepted `scripts/dev-bringup.sh` pattern); never echoed/logged.
- **Best-effort** — `set +e +o pipefail` preserved, every call guarded, terminal `exit 0`; cannot add latency to green runs or mask a real shard failure.
- `shellcheck -S error -x` clean (CI's exact invocation).

## OSS Compliance Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0** — clean. No real domains/tenant names/IPs, no hardcoded credentials, no private-registry refs. The PG password is a runtime reference to an in-cluster secret, never a hardcoded value and never echoed to logs.

## Security Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 2** — clean; both LOW are informational, no fix required:
- PgBouncer `SHOW DATABASES` lists cross-tenant DB *names* (no row data, no creds) into operator-only CI logs — acceptable for dev e2e pool tenants.
- The section header echoes `db=roundcube_${E2E_TENANT}` before the allowlist guard — echo-only, reaches no shell/SQL sink, operator-controlled value.

Verified safe: SQL/identifier injection (tenant never in a SQL string; guard runs before `kubectl run`), pod-name DNS-1123 safety, secret handling (matches accepted baseline, `--quiet` + no `set -x`, `2>&1` captures only psql output), no state mutation, and the step always `exit 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)