### PR TITLE
fix(monitoring): repair namespace-drifted dashboards + add $datasource for cross-cluster view

### DIFF
--- a/apps/manifests/docs/docs-dashboard-configmap.yaml
+++ b/apps/manifests/docs/docs-dashboard-configmap.yaml
@@ -47,7 +47,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -113,9 +113,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_ready{namespace=\"docs\", pod=~\"backend-.*\", container=\"backend\"}",
+              "expr": "kube_pod_container_status_ready{namespace=~\"tn-.*-docs\", pod=~\"backend-.*\", container=\"backend\"}",
               "legendFormat": "Backend",
               "refId": "A"
             }
@@ -126,7 +126,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -192,9 +192,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_ready{namespace=\"docs\", pod=~\"frontend-.*\", container=\"frontend\"}",
+              "expr": "kube_pod_container_status_ready{namespace=~\"tn-.*-docs\", pod=~\"frontend-.*\", container=\"frontend\"}",
               "legendFormat": "Frontend",
               "refId": "A"
             }
@@ -205,7 +205,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -271,9 +271,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_ready{namespace=\"docs\", pod=~\"docs-y-provider-.*\", container=\"docs\"}",
+              "expr": "kube_pod_container_status_ready{namespace=~\"tn-.*-docs\", pod=~\"docs-y-provider-.*\", container=\"docs\"}",
               "legendFormat": "Y-Provider",
               "refId": "A"
             }
@@ -284,86 +284,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "0": {
-                      "color": "red",
-                      "index": 1,
-                      "text": "Down"
-                    },
-                    "1": {
-                      "color": "green",
-                      "index": 0,
-                      "text": "Ready"
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 12,
-            "y": 1
-          },
-          "id": 4,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "pluginVersion": "10.0.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "kube_pod_container_status_ready{namespace=\"docs\", pod=~\"docs-postgresql-.*\", container=\"postgresql\"}",
-              "legendFormat": "PostgreSQL",
-              "refId": "A"
-            }
-          ],
-          "title": "PostgreSQL",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -429,9 +350,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_ready{namespace=\"docs\", pod=~\"redis-.*\", container=\"redis\"}",
+              "expr": "kube_pod_container_status_ready{namespace=~\"tn-.*-docs\", pod=~\"redis-.*\", container=\"redis\"}",
               "legendFormat": "Redis",
               "refId": "A"
             }
@@ -442,7 +363,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -508,9 +429,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_ready{namespace=\"docs\", pod=~\"keycloak-.*\"}",
+              "expr": "kube_pod_container_status_ready{namespace=\"infra-auth\", pod=~\"keycloak-.*\"}",
               "legendFormat": "Keycloak",
               "refId": "A"
             }
@@ -534,7 +455,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -611,140 +532,32 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"docs\", pod=~\"backend-.*\", container=\"backend\"}[5m]) * 100",
+              "expr": "rate(container_cpu_usage_seconds_total{namespace=~\"tn-.*-docs\", pod=~\"backend-.*\", container=\"backend\"}[5m]) * 100",
               "legendFormat": "Backend",
               "refId": "A"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"docs\", pod=~\"frontend-.*\", container=\"frontend\"}[5m]) * 100",
+              "expr": "rate(container_cpu_usage_seconds_total{namespace=~\"tn-.*-docs\", pod=~\"frontend-.*\", container=\"frontend\"}[5m]) * 100",
               "legendFormat": "Frontend",
               "refId": "B"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"docs\", pod=~\"docs-y-provider-.*\", container=\"docs\"}[5m]) * 100",
+              "expr": "rate(container_cpu_usage_seconds_total{namespace=~\"tn-.*-docs\", pod=~\"docs-y-provider-.*\", container=\"docs\"}[5m]) * 100",
               "legendFormat": "Y-Provider",
               "refId": "C"
             }
           ],
           "title": "Application CPU Usage",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 6
-          },
-          "id": 11,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "max"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"docs\", pod=~\"docs-postgresql-.*\", container=\"postgresql\"}[5m]) * 100",
-              "legendFormat": "PostgreSQL",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"docs\", pod=~\"redis-.*\", container=\"redis\"}[5m]) * 100",
-              "legendFormat": "Redis",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"docs\", pod=~\"keycloak-.*\"}[5m]) * 100",
-              "legendFormat": "Keycloak",
-              "refId": "C"
-            }
-          ],
-          "title": "Infrastructure CPU Usage",
           "type": "timeseries"
         },
         {
@@ -763,7 +576,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -840,140 +653,32 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "container_memory_usage_bytes{namespace=\"docs\", pod=~\"backend-.*\", container=\"backend\"}",
+              "expr": "container_memory_usage_bytes{namespace=~\"tn-.*-docs\", pod=~\"backend-.*\", container=\"backend\"}",
               "legendFormat": "Backend",
               "refId": "A"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "container_memory_usage_bytes{namespace=\"docs\", pod=~\"frontend-.*\", container=\"frontend\"}",
+              "expr": "container_memory_usage_bytes{namespace=~\"tn-.*-docs\", pod=~\"frontend-.*\", container=\"frontend\"}",
               "legendFormat": "Frontend",
               "refId": "B"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "container_memory_usage_bytes{namespace=\"docs\", pod=~\"docs-y-provider-.*\", container=\"docs\"}",
+              "expr": "container_memory_usage_bytes{namespace=~\"tn-.*-docs\", pod=~\"docs-y-provider-.*\", container=\"docs\"}",
               "legendFormat": "Y-Provider",
               "refId": "C"
             }
           ],
           "title": "Application Memory Usage",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "bytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 15
-          },
-          "id": 21,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "max"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "container_memory_usage_bytes{namespace=\"docs\", pod=~\"docs-postgresql-.*\", container=\"postgresql\"}",
-              "legendFormat": "PostgreSQL",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "container_memory_usage_bytes{namespace=\"docs\", pod=~\"redis-.*\", container=\"redis\"}",
-              "legendFormat": "Redis",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "container_memory_usage_bytes{namespace=\"docs\", pod=~\"keycloak-.*\"}",
-              "legendFormat": "Keycloak",
-              "refId": "C"
-            }
-          ],
-          "title": "Infrastructure Memory Usage",
           "type": "timeseries"
         },
         {
@@ -992,7 +697,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1069,36 +774,36 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_receive_bytes_total{namespace=\"docs\", pod=~\"backend-.*\"}[5m])",
+              "expr": "rate(container_network_receive_bytes_total{namespace=~\"tn-.*-docs\", pod=~\"backend-.*\"}[5m])",
               "legendFormat": "Backend RX",
               "refId": "A"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_transmit_bytes_total{namespace=\"docs\", pod=~\"backend-.*\"}[5m])",
+              "expr": "rate(container_network_transmit_bytes_total{namespace=~\"tn-.*-docs\", pod=~\"backend-.*\"}[5m])",
               "legendFormat": "Backend TX",
               "refId": "B"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_receive_bytes_total{namespace=\"docs\", pod=~\"frontend-.*\"}[5m])",
+              "expr": "rate(container_network_receive_bytes_total{namespace=~\"tn-.*-docs\", pod=~\"frontend-.*\"}[5m])",
               "legendFormat": "Frontend RX",
               "refId": "C"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_transmit_bytes_total{namespace=\"docs\", pod=~\"frontend-.*\"}[5m])",
+              "expr": "rate(container_network_transmit_bytes_total{namespace=~\"tn-.*-docs\", pod=~\"frontend-.*\"}[5m])",
               "legendFormat": "Frontend TX",
               "refId": "D"
             }
@@ -1109,7 +814,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1186,36 +891,36 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_receive_bytes_total{namespace=\"docs\", pod=~\"docs-y-provider-.*\"}[5m])",
+              "expr": "rate(container_network_receive_bytes_total{namespace=~\"tn-.*-docs\", pod=~\"docs-y-provider-.*\"}[5m])",
               "legendFormat": "Y-Provider RX",
               "refId": "A"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_transmit_bytes_total{namespace=\"docs\", pod=~\"docs-y-provider-.*\"}[5m])",
+              "expr": "rate(container_network_transmit_bytes_total{namespace=~\"tn-.*-docs\", pod=~\"docs-y-provider-.*\"}[5m])",
               "legendFormat": "Y-Provider TX",
               "refId": "B"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_receive_bytes_total{namespace=\"docs\", pod=~\"docs-postgresql-.*\"}[5m])",
+              "expr": "rate(container_network_receive_bytes_total{namespace=~\"tn-.*-docs\", pod=~\"docs-postgresql-.*\"}[5m])",
               "legendFormat": "PostgreSQL RX",
               "refId": "C"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_transmit_bytes_total{namespace=\"docs\", pod=~\"docs-postgresql-.*\"}[5m])",
+              "expr": "rate(container_network_transmit_bytes_total{namespace=~\"tn-.*-docs\", pod=~\"docs-postgresql-.*\"}[5m])",
               "legendFormat": "PostgreSQL TX",
               "refId": "D"
             }
@@ -1239,7 +944,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1324,36 +1029,36 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_restarts_total{namespace=\"docs\", pod=~\"backend-.*\", container=\"backend\"}",
+              "expr": "kube_pod_container_status_restarts_total{namespace=~\"tn-.*-docs\", pod=~\"backend-.*\", container=\"backend\"}",
               "legendFormat": "Backend",
               "refId": "A"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_restarts_total{namespace=\"docs\", pod=~\"frontend-.*\", container=\"frontend\"}",
+              "expr": "kube_pod_container_status_restarts_total{namespace=~\"tn-.*-docs\", pod=~\"frontend-.*\", container=\"frontend\"}",
               "legendFormat": "Frontend",
               "refId": "B"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_restarts_total{namespace=\"docs\", pod=~\"docs-y-provider-.*\", container=\"docs\"}",
+              "expr": "kube_pod_container_status_restarts_total{namespace=~\"tn-.*-docs\", pod=~\"docs-y-provider-.*\", container=\"docs\"}",
               "legendFormat": "Y-Provider",
               "refId": "C"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_restarts_total{namespace=\"docs\", pod=~\"docs-postgresql-.*\", container=\"postgresql\"}",
+              "expr": "kube_pod_container_status_restarts_total{namespace=~\"tn-.*-docs\", pod=~\"docs-postgresql-.*\", container=\"postgresql\"}",
               "legendFormat": "PostgreSQL",
               "refId": "D"
             }
@@ -1364,7 +1069,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1440,27 +1145,27 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_deployment_status_replicas_available{namespace=\"docs\", deployment=\"backend\"}",
+              "expr": "kube_deployment_status_replicas_available{namespace=~\"tn-.*-docs\", deployment=\"backend\"}",
               "legendFormat": "Backend",
               "refId": "A"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_deployment_status_replicas_available{namespace=\"docs\", deployment=\"frontend\"}",
+              "expr": "kube_deployment_status_replicas_available{namespace=~\"tn-.*-docs\", deployment=\"frontend\"}",
               "legendFormat": "Frontend",
               "refId": "B"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_deployment_status_replicas_available{namespace=\"docs\", deployment=\"docs-y-provider\"}",
+              "expr": "kube_deployment_status_replicas_available{namespace=~\"tn-.*-docs\", deployment=\"docs-y-provider\"}",
               "legendFormat": "Y-Provider",
               "refId": "C"
             }
@@ -1484,7 +1189,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1569,7 +1274,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(nginx_ingress_controller_requests{ingress=\"docs\", status=~\"5..\"}[5m])) by (status)",
               "legendFormat": "Docs {{status}}",
@@ -1578,7 +1283,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(nginx_ingress_controller_requests{ingress=\"keycloak-keycloakx\", status=~\"5..\"}[5m])) by (status)",
               "legendFormat": "Keycloak {{status}}",
@@ -1591,7 +1296,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1668,7 +1373,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(nginx_ingress_controller_requests{ingress=\"docs\", status=~\"4..\"}[5m])) by (status)",
               "legendFormat": "Docs {{status}}",
@@ -1677,7 +1382,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(nginx_ingress_controller_requests{ingress=\"keycloak-keycloakx\", status=~\"4..\"}[5m])) by (status)",
               "legendFormat": "Keycloak {{status}}",
@@ -1690,7 +1395,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1767,7 +1472,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(nginx_ingress_controller_requests{ingress=\"docs\"}[5m])) by (status)",
               "legendFormat": "{{status}}",
@@ -1780,7 +1485,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1835,7 +1540,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "100 * sum(rate(nginx_ingress_controller_requests{ingress=\"docs\", status=~\"5..\"}[5m])) / sum(rate(nginx_ingress_controller_requests{ingress=\"docs\"}[5m]))",
               "legendFormat": "Docs 5xx %",
@@ -1844,7 +1549,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "100 * sum(rate(nginx_ingress_controller_requests{ingress=\"docs\", status=~\"4..\"}[5m])) / sum(rate(nginx_ingress_controller_requests{ingress=\"docs\"}[5m]))",
               "legendFormat": "Docs 4xx %",
@@ -1864,7 +1569,26 @@ data:
         "collaboration"
       ],
       "templating": {
-        "list": []
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Data source",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
       },
       "time": {
         "from": "now-1h",
@@ -1877,5 +1601,3 @@ data:
       "version": 1,
       "weekStart": ""
     }
-
-

--- a/apps/manifests/email-probe/email-probe-dashboard-configmap.yaml
+++ b/apps/manifests/email-probe/email-probe-dashboard-configmap.yaml
@@ -40,7 +40,7 @@ data:
           "type": "row"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -75,7 +75,7 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "email_probe_up{tenant=~\"$tenant\"}",
               "legendFormat": "{{tenant}}",
               "refId": "A"
@@ -85,7 +85,7 @@ data:
           "type": "stat"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -113,7 +113,7 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "email_probe_roundtrip_seconds{tenant=~\"$tenant\"}",
               "legendFormat": "{{tenant}}",
               "refId": "A"
@@ -123,7 +123,7 @@ data:
           "type": "stat"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -151,7 +151,7 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "time() - email_probe_last_success_timestamp{tenant=~\"$tenant\"}",
               "legendFormat": "{{tenant}}",
               "refId": "A"
@@ -161,7 +161,7 @@ data:
           "type": "stat"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -189,7 +189,7 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "email_probe_send_seconds{tenant=~\"$tenant\"}",
               "legendFormat": "{{tenant}}",
               "refId": "A"
@@ -207,7 +207,7 @@ data:
           "type": "row"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -247,7 +247,7 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "email_probe_roundtrip_seconds{tenant=~\"$tenant\"}",
               "legendFormat": "{{tenant}} roundtrip",
               "refId": "A"
@@ -257,7 +257,7 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -303,7 +303,7 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "email_probe_consecutive_failures{tenant=~\"$tenant\"}",
               "legendFormat": "{{tenant}} failures",
               "refId": "A"
@@ -321,7 +321,7 @@ data:
           "type": "row"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -361,13 +361,13 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "email_probe_inbound_total_seconds{tenant=~\"$tenant\"}",
               "legendFormat": "{{tenant}} total",
               "refId": "A"
             },
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "email_probe_inbound_infra_seconds{tenant=~\"$tenant\"}",
               "legendFormat": "{{tenant}} MT infra",
               "refId": "B"
@@ -377,7 +377,7 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -405,7 +405,7 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "email_probe_inbound_total_seconds{tenant=~\"$tenant\"}",
               "legendFormat": "{{tenant}}",
               "refId": "A"
@@ -415,7 +415,7 @@ data:
           "type": "stat"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -443,7 +443,7 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "email_probe_inbound_infra_seconds{tenant=~\"$tenant\"}",
               "legendFormat": "{{tenant}}",
               "refId": "A"
@@ -461,7 +461,7 @@ data:
           "type": "row"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -506,13 +506,13 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "increase(email_probe_send_total{tenant=~\"$tenant\"}[1h])",
               "legendFormat": "{{tenant}} sends",
               "refId": "A"
             },
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "increase(email_probe_send_errors_total{tenant=~\"$tenant\"}[1h])",
               "legendFormat": "{{tenant}} send errors",
               "refId": "B"
@@ -522,7 +522,7 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -567,13 +567,13 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "increase(email_probe_roundtrip_total{tenant=~\"$tenant\"}[1h])",
               "legendFormat": "{{tenant}} roundtrips",
               "refId": "A"
             },
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "increase(email_probe_roundtrip_errors_total{tenant=~\"$tenant\"}[1h])",
               "legendFormat": "{{tenant}} roundtrip errors",
               "refId": "B"
@@ -595,8 +595,22 @@ data:
       "templating": {
         "list": [
           {
+            "current": { "selected": false, "text": "Prometheus", "value": "prometheus" },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Data source",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
             "current": { "selected": false, "text": "All", "value": "$__all" },
-            "datasource": { "type": "prometheus", "uid": "prometheus" },
+            "datasource": { "type": "prometheus", "uid": "${datasource}" },
             "definition": "label_values(email_probe_up, tenant)",
             "includeAll": true,
             "multi": true,

--- a/apps/manifests/jitsi/jitsi-dashboard-configmap.yaml
+++ b/apps/manifests/jitsi/jitsi-dashboard-configmap.yaml
@@ -37,7 +37,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -111,7 +111,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_conferences",
               "refId": "A"
@@ -119,7 +119,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jicofo_conferences",
               "refId": "B"
@@ -131,7 +131,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -205,7 +205,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_participants",
               "refId": "A"
@@ -213,7 +213,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jicofo_participants",
               "refId": "B"
@@ -225,7 +225,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -278,7 +278,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"jvb\", namespace=\"$namespace\"}[5m]))",
               "refId": "A"
@@ -290,7 +290,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -368,7 +368,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"jvb\", namespace=\"$namespace\"}[5m])) / sum(kube_pod_container_resource_requests{container=\"jvb\", namespace=\"$namespace\", resource=\"cpu\"}) * 100",
               "legendFormat": "% of Request",
@@ -381,7 +381,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -455,7 +455,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_bit_rate_download_bps",
               "legendFormat": "Download (Colibri)",
@@ -464,7 +464,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_bit_rate_upload_bps",
               "legendFormat": "Upload (Colibri)",
@@ -473,7 +473,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_bit_rate_download_bps + jitsi_jvb_bit_rate_upload_bps",
               "legendFormat": "Total Bitrate (Colibri)",
@@ -486,7 +486,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -560,7 +560,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_bit_rate_download_bps / clamp_min(jitsi_jvb_conferences, 1)",
               "legendFormat": "Download per Conference",
@@ -569,7 +569,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_bit_rate_upload_bps / clamp_min(jitsi_jvb_conferences, 1)",
               "legendFormat": "Upload per Conference",
@@ -582,7 +582,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -656,7 +656,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"jvb\", namespace=\"$namespace\"}[5m])) / sum(kube_pod_container_resource_requests{container=\"jvb\", namespace=\"$namespace\", resource=\"cpu\"}) * 100",
               "legendFormat": "CPU (% of Request)",
@@ -665,7 +665,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_participants * 10",
               "legendFormat": "Participants (×10 for scale)",
@@ -678,7 +678,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -752,7 +752,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"jvb\", namespace=\"$namespace\"}[5m])) / sum(kube_pod_container_resource_requests{container=\"jvb\", namespace=\"$namespace\", resource=\"cpu\"}) * 100",
               "legendFormat": "CPU (% of Request)",
@@ -761,7 +761,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_conferences * 10",
               "legendFormat": "Conferences (×10 for scale)",
@@ -774,7 +774,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -848,7 +848,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_bit_rate_download_bps + jitsi_jvb_bit_rate_upload_bps",
               "legendFormat": "Total Bandwidth",
@@ -857,7 +857,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_participants * 100000",
               "legendFormat": "Participants (×100k for scale)",
@@ -870,7 +870,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -935,7 +935,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "up{job=\"jitsi-metrics-exporter\"}",
               "legendFormat": "Metrics Exporter",
@@ -944,7 +944,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "kube_pod_container_status_ready{namespace=\"$namespace\", pod=~\"jitsi-jvb-.*\"}",
               "legendFormat": "JVB Pod",
@@ -953,7 +953,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "kube_pod_container_status_ready{namespace=\"$namespace\", pod=~\"jitsi-jicofo-.*\"}",
               "legendFormat": "Jicofo Pod",
@@ -962,7 +962,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "kube_pod_container_status_ready{namespace=\"$namespace\", pod=~\"jitsi-prosody-.*\"}",
               "legendFormat": "Prosody Pod",
@@ -971,7 +971,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "kube_pod_container_status_ready{namespace=\"$namespace\", pod=~\"jitsi-web-.*\"}",
               "legendFormat": "Web Pod",
@@ -984,7 +984,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1058,7 +1058,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "container_memory_usage_bytes{container=\"jvb\", namespace=\"$namespace\"}",
               "legendFormat": "JVB Memory",
@@ -1067,7 +1067,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "container_memory_usage_bytes{container=\"jicofo\", namespace=\"$namespace\"}",
               "legendFormat": "Jicofo Memory",
@@ -1080,7 +1080,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1154,7 +1154,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_bit_rate_download_bps / clamp_min(jitsi_jvb_participants, 1)",
               "legendFormat": "Download per Participant",
@@ -1163,7 +1163,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_bit_rate_upload_bps / clamp_min(jitsi_jvb_participants, 1)",
               "legendFormat": "Upload per Participant",
@@ -1176,7 +1176,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1241,7 +1241,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_bosh_reachable",
               "legendFormat": "BOSH Endpoint",
@@ -1250,7 +1250,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_healthy",
               "legendFormat": "JVB Health",
@@ -1259,7 +1259,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_turn_stun_reachable",
               "legendFormat": "TURN STUN",
@@ -1268,7 +1268,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_turn_allocate_ok",
               "legendFormat": "TURN Allocate",
@@ -1277,7 +1277,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_keycloak_adapter_healthy",
               "legendFormat": "Keycloak Adapter",
@@ -1286,7 +1286,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_prosody_xmpp_c2s_up",
               "legendFormat": "Prosody XMPP",
@@ -1299,7 +1299,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1373,7 +1373,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jicofo_operational_bridge_count",
               "legendFormat": "Operational Bridges",
@@ -1382,7 +1382,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jicofo_bridge_count",
               "legendFormat": "Total Bridges",
@@ -1391,7 +1391,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_muc_clients_connected",
               "legendFormat": "MUC Connected",
@@ -1400,7 +1400,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "jitsi_jvb_muc_clients_configured",
               "legendFormat": "MUC Configured",
@@ -1413,7 +1413,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1533,7 +1533,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "rate(jitsi_jvb_ice_succeeded_total[5m])",
               "legendFormat": "ICE Succeeded",
@@ -1542,7 +1542,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "rate(jitsi_jvb_ice_failed_total[5m])",
               "legendFormat": "ICE Failed",
@@ -1551,7 +1551,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "rate(jitsi_jvb_ice_succeeded_relayed_total[5m])",
               "legendFormat": "ICE Relayed",
@@ -1560,7 +1560,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "rate(jitsi_jvb_dtls_failed_endpoints[5m])",
               "legendFormat": "DTLS Failures",
@@ -1569,7 +1569,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "rate(jitsi_jicofo_participant_ice_restart_requests[5m])",
               "legendFormat": "ICE Restarts",
@@ -1587,6 +1587,20 @@ data:
       "templating": {
         "list": [
           {
+            "current": { "selected": false, "text": "Prometheus", "value": "prometheus" },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Data source",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
             "allValue": null,
             "current": {
               "selected": false,
@@ -1595,7 +1609,7 @@ data:
             },
             "datasource": {
               "type": "prometheus",
-              "uid": "prometheus"
+              "uid": "${datasource}"
             },
             "definition": "label_values(up{job=\"jitsi-metrics-exporter\"}, namespace)",
             "hide": 0,

--- a/apps/manifests/loki/loki-dashboard-configmap.yaml
+++ b/apps/manifests/loki/loki-dashboard-configmap.yaml
@@ -284,7 +284,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -318,7 +318,7 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "sum(rate(loki_distributor_bytes_received_total{namespace=\"infra-monitoring\"}[5m]))",
               "legendFormat": "Bytes Ingested/sec",
               "refId": "A"
@@ -330,7 +330,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -364,13 +364,13 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket{namespace=\"infra-monitoring\", route=~\"loki_api_v1_push|/loki/api/v1/push\"}[5m])) by (le))",
               "legendFormat": "p99 Push",
               "refId": "A"
             },
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket{namespace=\"infra-monitoring\", route=~\"loki_api_v1_query_range|/loki/api/v1/query_range\"}[5m])) by (le))",
               "legendFormat": "p99 Query",
               "refId": "B"
@@ -389,7 +389,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -423,13 +423,13 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "sum(rate(vector_component_received_events_total{component_type=\"kubernetes_logs\"}[5m]))",
               "legendFormat": "Events Received",
               "refId": "A"
             },
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "sum(rate(vector_component_sent_events_total{component_type=\"loki\"}[5m]))",
               "legendFormat": "Events Sent to Loki",
               "refId": "B"
@@ -441,7 +441,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -475,7 +475,7 @@ data:
           },
           "targets": [
             {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "expr": "sum by (component_type) (increase(vector_component_errors_total[5m]))",
               "legendFormat": "{{component_type}}",
               "refId": "A"
@@ -489,7 +489,7 @@ data:
       "schemaVersion": 38,
       "style": "dark",
       "tags": ["logging", "loki", "vector", "monitoring"],
-      "templating": { "list": [] },
+      "templating": { "list": [ { "current": { "selected": false, "text": "Prometheus", "value": "prometheus" }, "hide": 0, "includeAll": false, "label": "Data source", "multi": false, "name": "datasource", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" } ] },
       "time": {
         "from": "now-1h",
         "to": "now"

--- a/apps/manifests/mail/postfix-dashboard-configmap.yaml
+++ b/apps/manifests/mail/postfix-dashboard-configmap.yaml
@@ -47,7 +47,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -113,9 +113,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_ready{namespace=\"mail\", pod=~\"postfix-.*\", container=\"postfix\"}",
+              "expr": "kube_pod_container_status_ready{namespace=\"infra-mail\", pod=~\"postfix-.*\", container=\"postfix\"}",
               "legendFormat": "Postfix",
               "refId": "A"
             }
@@ -126,7 +126,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -181,9 +181,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_restarts_total{namespace=\"mail\", pod=~\"postfix-.*\", container=\"postfix\"}",
+              "expr": "kube_pod_container_status_restarts_total{namespace=\"infra-mail\", pod=~\"postfix-.*\", container=\"postfix\"}",
               "legendFormat": "Restarts",
               "refId": "A"
             }
@@ -207,7 +207,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -284,9 +284,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"mail\", pod=~\"postfix-.*\", container=\"postfix\"}[5m]) * 100",
+              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"infra-mail\", pod=~\"postfix-.*\", container=\"postfix\"}[5m]) * 100",
               "legendFormat": "Postfix",
               "refId": "A"
             }
@@ -297,7 +297,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -374,9 +374,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "container_memory_usage_bytes{namespace=\"mail\", pod=~\"postfix-.*\", container=\"postfix\"}",
+              "expr": "container_memory_usage_bytes{namespace=\"infra-mail\", pod=~\"postfix-.*\", container=\"postfix\"}",
               "legendFormat": "Postfix",
               "refId": "A"
             }
@@ -400,7 +400,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -477,18 +477,18 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_receive_bytes_total{namespace=\"mail\", pod=~\"postfix-.*\"}[5m])",
+              "expr": "rate(container_network_receive_bytes_total{namespace=\"infra-mail\", pod=~\"postfix-.*\"}[5m])",
               "legendFormat": "Receive (RX)",
               "refId": "A"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_transmit_bytes_total{namespace=\"mail\", pod=~\"postfix-.*\"}[5m])",
+              "expr": "rate(container_network_transmit_bytes_total{namespace=\"infra-mail\", pod=~\"postfix-.*\"}[5m])",
               "legendFormat": "Transmit (TX)",
               "refId": "B"
             }
@@ -499,7 +499,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Network traffic can indicate email activity - higher TX typically means emails being sent",
           "fieldConfig": {
@@ -547,9 +547,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "increase(container_network_transmit_bytes_total{namespace=\"mail\", pod=~\"postfix-.*\"}[1h])",
+              "expr": "increase(container_network_transmit_bytes_total{namespace=\"infra-mail\", pod=~\"postfix-.*\"}[1h])",
               "legendFormat": "Bytes Transmitted (1h)",
               "refId": "A"
             }
@@ -568,7 +568,26 @@ data:
         "email"
       ],
       "templating": {
-        "list": []
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Data source",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
       },
       "time": {
         "from": "now-1h",
@@ -581,4 +600,3 @@ data:
       "version": 1,
       "weekStart": ""
     }
-

--- a/apps/manifests/nextcloud/nextcloud-dashboard-configmap.yaml
+++ b/apps/manifests/nextcloud/nextcloud-dashboard-configmap.yaml
@@ -47,7 +47,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -113,9 +113,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_ready{namespace=\"files\", pod=~\"nextcloud-.*\", container=~\"nextcloud|php-fpm\"}",
+              "expr": "kube_pod_container_status_ready{namespace=~\"tn-.*-files\", pod=~\"nextcloud-.*\", container=~\"nextcloud|php-fpm\"}",
               "legendFormat": "Nextcloud",
               "refId": "A"
             }
@@ -126,86 +126,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "0": {
-                      "color": "red",
-                      "index": 1,
-                      "text": "Down"
-                    },
-                    "1": {
-                      "color": "green",
-                      "index": 0,
-                      "text": "Ready"
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 6,
-            "x": 6,
-            "y": 1
-          },
-          "id": 2,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "pluginVersion": "10.0.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "kube_pod_container_status_ready{namespace=\"docs\", pod=~\"docs-postgresql-.*\", container=\"postgresql\"}",
-              "legendFormat": "PostgreSQL",
-              "refId": "A"
-            }
-          ],
-          "title": "PostgreSQL (Shared)",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -271,9 +192,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_deployment_status_replicas_available{namespace=\"files\", deployment=\"nextcloud\"}",
+              "expr": "kube_deployment_status_replicas_available{namespace=~\"tn-.*-files\", deployment=\"nextcloud\"}",
               "legendFormat": "Available",
               "refId": "A"
             }
@@ -284,7 +205,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -339,9 +260,9 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "kube_pod_container_status_restarts_total{namespace=\"files\", pod=~\"nextcloud-.*\"}",
+              "expr": "kube_pod_container_status_restarts_total{namespace=~\"tn-.*-files\", pod=~\"nextcloud-.*\"}",
               "legendFormat": "Restarts",
               "refId": "A"
             }
@@ -365,7 +286,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -442,104 +363,14 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"files\", pod=~\"nextcloud-.*\", container=~\"nextcloud|php-fpm\"}[5m]) * 100",
+              "expr": "rate(container_cpu_usage_seconds_total{namespace=~\"tn-.*-files\", pod=~\"nextcloud-.*\", container=~\"nextcloud|php-fpm\"}[5m]) * 100",
               "legendFormat": "Nextcloud CPU",
               "refId": "A"
             }
           ],
           "title": "Nextcloud CPU Usage",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 6
-          },
-          "id": 11,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "max"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"docs\", pod=~\"docs-postgresql-.*\", container=\"postgresql\"}[5m]) * 100",
-              "legendFormat": "PostgreSQL CPU",
-              "refId": "A"
-            }
-          ],
-          "title": "PostgreSQL CPU Usage (Shared)",
           "type": "timeseries"
         },
         {
@@ -558,7 +389,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -635,104 +466,14 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "container_memory_usage_bytes{namespace=\"files\", pod=~\"nextcloud-.*\", container=~\"nextcloud|php-fpm\"}",
+              "expr": "container_memory_usage_bytes{namespace=~\"tn-.*-files\", pod=~\"nextcloud-.*\", container=~\"nextcloud|php-fpm\"}",
               "legendFormat": "Nextcloud Memory",
               "refId": "A"
             }
           ],
           "title": "Nextcloud Memory Usage",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "bytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 15
-          },
-          "id": 21,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "max"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "container_memory_usage_bytes{namespace=\"docs\", pod=~\"docs-postgresql-.*\", container=\"postgresql\"}",
-              "legendFormat": "PostgreSQL Memory",
-              "refId": "A"
-            }
-          ],
-          "title": "PostgreSQL Memory Usage (Shared)",
           "type": "timeseries"
         },
         {
@@ -751,7 +492,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -828,18 +569,18 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_receive_bytes_total{namespace=\"files\", pod=~\"nextcloud-.*\"}[5m])",
+              "expr": "rate(container_network_receive_bytes_total{namespace=~\"tn-.*-files\", pod=~\"nextcloud-.*\"}[5m])",
               "legendFormat": "Nextcloud RX",
               "refId": "A"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
-              "expr": "rate(container_network_transmit_bytes_total{namespace=\"files\", pod=~\"nextcloud-.*\"}[5m])",
+              "expr": "rate(container_network_transmit_bytes_total{namespace=~\"tn-.*-files\", pod=~\"nextcloud-.*\"}[5m])",
               "legendFormat": "Nextcloud TX",
               "refId": "B"
             }
@@ -863,7 +604,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -948,7 +689,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(nginx_ingress_controller_requests{ingress=\"nextcloud\", status=~\"5..\"}[5m])) by (status)",
               "legendFormat": "Nextcloud {{status}}",
@@ -961,7 +702,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1038,7 +779,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "sum(rate(nginx_ingress_controller_requests{ingress=\"nextcloud\", status=~\"4..\"}[5m])) by (status)",
               "legendFormat": "Nextcloud {{status}}",
@@ -1058,7 +799,26 @@ data:
         "file-management"
       ],
       "templating": {
-        "list": []
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Data source",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
       },
       "time": {
         "from": "now-1h",
@@ -1071,4 +831,3 @@ data:
       "version": 1,
       "weekStart": ""
     }
-

--- a/apps/manifests/postgresql/postgresql-dashboard-configmap.yaml
+++ b/apps/manifests/postgresql/postgresql-dashboard-configmap.yaml
@@ -37,7 +37,7 @@ data:
           "type": "row"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "thresholds": {
@@ -66,7 +66,7 @@ data:
           ]
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "unit": "short",
@@ -86,7 +86,7 @@ data:
           ]
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "unit": "short",
@@ -106,7 +106,7 @@ data:
           ]
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "unit": "percentunit",
@@ -127,7 +127,7 @@ data:
           ]
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": {
             "defaults": {
               "unit": "bytes",
@@ -154,7 +154,7 @@ data:
           "type": "row"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 1, "fillOpacity": 20, "stacking": { "mode": "normal" } } } },
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
           "id": 10,
@@ -169,7 +169,7 @@ data:
           ]
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": { "defaults": { "unit": "ops", "custom": { "lineWidth": 1, "fillOpacity": 10 } } },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
           "id": 11,
@@ -195,7 +195,7 @@ data:
           "type": "row"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "lineWidth": 1, "fillOpacity": 10 } } },
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
           "id": 20,
@@ -210,7 +210,7 @@ data:
           ]
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 1, "fillOpacity": 10 } } },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
           "id": 21,
@@ -236,7 +236,7 @@ data:
           "type": "row"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": { "defaults": { "unit": "ops", "custom": { "lineWidth": 1, "fillOpacity": 10, "stacking": { "mode": "normal" } } } },
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
           "id": 30,
@@ -259,7 +259,7 @@ data:
           ]
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 1, "fillOpacity": 10 } } },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
           "id": 31,
@@ -285,7 +285,7 @@ data:
           "type": "row"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "lineWidth": 1, "fillOpacity": 20 } } },
           "gridPos": { "h": 8, "w": 24, "x": 0, "y": 33 },
           "id": 42,
@@ -302,7 +302,7 @@ data:
       ],
       "schemaVersion": 39,
       "tags": ["postgresql", "database", "infra"],
-      "templating": { "list": [] },
+      "templating": { "list": [ { "current": { "selected": false, "text": "Prometheus", "value": "prometheus" }, "hide": 0, "includeAll": false, "label": "Data source", "multi": false, "name": "datasource", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" } ] },
       "time": { "from": "now-6h", "to": "now" },
       "timepicker": {},
       "timezone": "browser",

--- a/apps/manifests/prometheus/prometheus-storage-dashboard-configmap.yaml
+++ b/apps/manifests/prometheus/prometheus-storage-dashboard-configmap.yaml
@@ -47,7 +47,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -102,7 +102,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "prometheus_tsdb_storage_blocks_bytes",
               "legendFormat": "TSDB Blocks",
@@ -115,7 +115,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -170,7 +170,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "kubelet_volume_stats_used_bytes{persistentvolumeclaim=\"prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0\"}",
               "legendFormat": "PVC Used",
@@ -183,7 +183,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -238,7 +238,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=\"prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0\"}",
               "legendFormat": "PVC Capacity",
@@ -251,7 +251,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -306,7 +306,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "(kubelet_volume_stats_used_bytes{persistentvolumeclaim=\"prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0\"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=\"prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0\"}) * 100",
               "legendFormat": "Usage %",
@@ -332,7 +332,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -409,7 +409,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "prometheus_tsdb_storage_blocks_bytes",
               "legendFormat": "TSDB Blocks",
@@ -418,7 +418,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "kubelet_volume_stats_used_bytes{persistentvolumeclaim=\"prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0\"}",
               "legendFormat": "PVC Used",
@@ -431,7 +431,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -508,7 +508,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "rate(prometheus_tsdb_storage_blocks_bytes[1h])",
               "legendFormat": "TSDB Growth Rate",
@@ -534,7 +534,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -611,7 +611,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "prometheus_tsdb_head_series",
               "legendFormat": "Head Series",
@@ -624,7 +624,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -701,7 +701,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "prometheus_tsdb_head_chunks",
               "legendFormat": "Head Chunks",
@@ -714,7 +714,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -791,7 +791,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "expr": "rate(prometheus_tsdb_head_samples_appended_total[5m])",
               "legendFormat": "Samples/sec",
@@ -811,7 +811,26 @@ data:
         "storage"
       ],
       "templating": {
-        "list": []
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Data source",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
       },
       "time": {
         "from": "now-6h",
@@ -824,5 +843,3 @@ data:
       "version": 1,
       "weekStart": ""
     }
-
-


### PR DESCRIPTION
## What & why

Final piece of the Grafana revamp. Audited **all 8** dashboards against **live prod Prometheus** and fixed two classes of problem. Every repointed query was verified to return data before committing.

### 1. Namespace drift — silently dead dashboards
Three dashboards still queried **pre-multitenant namespaces** that no longer exist (same root cause as the jitsi bug in #474), so every panel returned **0 series**:

| Dashboard | Was | Now |
|---|---|---|
| docs | `namespace="docs"` | `namespace=~"tn-.*-docs"` |
| nextcloud | `namespace="files"` | `namespace=~"tn-.*-files"` |
| postfix | `namespace="mail"` | `namespace="infra-mail"` |
| docs → Keycloak panel | `namespace="docs"` | `namespace="infra-auth"` (shared infra) |

Regex form keeps them multi-tenant-safe. **Dropped dead in-cluster-postgres panels** (docs: `PostgreSQL`, `Infrastructure CPU/Memory Usage`; nextcloud: the three `PostgreSQL (Shared)` panels) — the PG VM has been external since #293, and shared-DB health is already owned by the dedicated **postgresql** dashboard.

### 2. Cross-cluster consolidation (`$datasource`)
Added a `datasource` template variable (**default = local Prometheus**) to every dashboard and switched panel datasource uids `"prometheus"` → `"${datasource}"`. Now any dashboard in grafana.prod flips between the local cluster and **`Prometheus (prod-eu)`** (uid `prometheus-eu`, the federation datasource from #475) via one dropdown — no behavior change by default. Loki-typed panels keep their `loki` datasource.

## Per-dashboard summary
| Dashboard | Change |
|---|---|
| docs | ns repoint + Keycloak→infra-auth + drop 3 dead PG panels + `$datasource` |
| nextcloud | ns repoint + drop 3 dead "(Shared)" PG panels + `$datasource` |
| postfix | ns repoint (`infra-mail`) + `$datasource` |
| jitsi, postgresql | already fixed in #474 → only `$datasource` added |
| email-probe, prometheus-storage | already healthy → only `$datasource` added |
| loki | `$datasource` added (metric panels); "Vector Sink Errors" empty by nature (zero errors), not a drift bug |

## Verification
- Every repointed query run against **live prod Prometheus** — all return data (docs backend/y-provider/redis/keycloak, nextcloud pod/replicas/cpu, postfix ready/cpu).
- All 8 dashboards: valid JSON, `$datasource` var present, datasource uids swapped (loki uids untouched), pass `kubectl apply --dry-run=client`.
- `json.dumps` round-trip confirmed byte-faithful (no reformatting noise) — the large `-808` line count is genuinely the dropped dead panels, not churn.

## Follow-ups (not in this PR)
- Bridge the PG VM's `node_exporter` to restore real VM CPU/mem/IO (the deferred replacement for the dropped postgres container panels).
- #475 security hardening (dedicated `tag:metrics-fed`, NetworkPolicy on consumer, scoped sidecar RBAC).

## OSS Compliance Review
✅ Clean — **0/0/0/0**. No real domains, PII, credentials, registry refs, or tenant leaks. Namespace selectors use the generic `tn-.*-*` / `infra-*` conventions already public in CLAUDE.md.

## Security Review
✅ Clean — **0/0/0/0**. Display-only dashboard JSON; no secrets, executable code, or network/RBAC change. Dropped panels contained no DSNs/connection strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)