### PR TITLE
fix(roundcube): gate readiness on DB schema, not bare HTTP

### DIFF
--- a/apps/manifests/roundcube/roundcube.yaml.tpl
+++ b/apps/manifests/roundcube/roundcube.yaml.tpl
@@ -227,6 +227,15 @@ spec:
           value: "elastic"
         - name: ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE
           value: "25M"
+        # DB coordinates for the readiness probe's schema check (non-secret — the
+        # password stays in the Secret above). These mirror the db_dsnw the
+        # ConfigMap builds, so the probe connects exactly like the app does.
+        - name: ROUNDCUBE_DB_HOST
+          value: "${PG_HOST}"
+        - name: ROUNDCUBE_DB_NAME
+          value: "${ROUNDCUBE_DB_NAME}"
+        - name: ROUNDCUBE_DB_USER
+          value: "${ROUNDCUBE_DB_USER}"
         volumeMounts:
         - name: config
           mountPath: /var/roundcube/config/custom.config.php
@@ -251,12 +260,35 @@ spec:
             port: 80
           initialDelaySeconds: 30
           periodSeconds: 30
+        # Readiness gates on the DB SCHEMA, not just HTTP. A bare GET / returns 200
+        # even when roundcube_<tenant> has no `session` table (empty/never-built
+        # schema), so a schema-less pod used to pass as healthy and only surfaced as
+        # a webmail-login hang in e2e (#1571/#1586). This PDO check connects as the
+        # roundcube DB user (the same path the app uses) and probes the `session`
+        # table. It reports NotReady ONLY on undefined_table (SQLSTATE 42P01 = schema
+        # missing): a connection/auth error (PgBouncer down, bad creds — different
+        # SQLSTATE classes, never 42P01) exits 0 (Ready), so a brief DB/PgBouncer
+        # blip can't depool webmail. A SUSTAINED session-store hang (e.g. PgBouncer
+        # pool saturation) does depool after failureThreshold×period (~60s) — by
+        # design: webmail login is non-functional then anyway, and the pod re-pools
+        # within one period on recovery. Liveness stays HTTP, so a DB issue never
+        # crashloops the pod. $-prefixed names are PHP vars — the explicit-list
+        # envsubst in deploy-roundcube.sh leaves them untouched (only ${...} of
+        # listed vars is substituted).
         readinessProbe:
-          httpGet:
-            path: /
-            port: 80
-          initialDelaySeconds: 10
-          periodSeconds: 10
+          exec:
+            command:
+            - php
+            - -r
+            - |
+              $h=getenv('ROUNDCUBE_DB_HOST');$d=getenv('ROUNDCUBE_DB_NAME');
+              $u=getenv('ROUNDCUBE_DB_USER');$p=getenv('ROUNDCUBE_DB_PASSWORD');
+              try{$dbh=new PDO("pgsql:host=$h;dbname=$d;connect_timeout=3",$u,$p,[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]);$dbh->query('SELECT 1 FROM session LIMIT 1');exit(0);}
+              catch(PDOException $e){fwrite(STDERR,'rc-readiness: SQLSTATE '.$e->getCode());exit($e->getCode()==='42P01'?1:0);}
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
## Why

A bare `GET /` readiness probe returns **200 even when `roundcube_<tenant>` has no `session` table** (empty/never-built schema). That's the hole that let a schema-less pod pass as healthy on #1571/#1586 and only surface as a webmail-login hang in e2e. This is the **defense-in-depth half** of the fix — the root cause (the bringup roundcube-DB drop) is removed in companion PR #480; this makes a schema-less pod **impossible to ship undetected**, so both the deploy rollout and e2e catch it instead of users.

## What

Replace the Roundcube **readiness** probe with an inline `php -r` PDO check that connects as the roundcube DB user (the exact path the app uses) and probes the `session` table:

- **exits 1 (NotReady) ONLY on SQLSTATE `42P01`** (undefined_table = schema missing);
- **exits 0 (Ready) on any other error** — a connection/auth blip (PgBouncer down, bad creds) is a *different* SQLSTATE class (`08xxx`/`28xxx`), never `42P01`, so **a transient DB hiccup cannot depool webmail** (fail-open). `connect_timeout=3` bounds the connect phase. A *sustained* session-store hang (e.g. PgBouncer pool saturation) does depool after `failureThreshold×period` (~60s) — by design (webmail login is non-functional then anyway; the pod re-pools within one period on recovery).
- **Liveness stays HTTP** (`GET /`) so a DB issue never crashloops the pod.

Adds 3 **non-secret** env vars (`ROUNDCUBE_DB_HOST/NAME/USER`) for the probe; the password is read at runtime from the existing Secret via `getenv` (never templated into YAML).

Validated locally: rendered with the exact `deploy-roundcube.sh` envsubst var list, confirmed valid k8s YAML, the PHP `$`-vars survive envsubst untouched, and the probe extracts cleanly. The PR's own **dev CI exercises the probe** (deploy-dev + e2e) before it can ever reach prod.

## OSS Compliance Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0** — clean. DB coordinates are `${...}` placeholders; no real values; password not added (stays in the existing Secret).

## Security Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 3 — prod-safe to ship** (all LOWs by-design/defense-in-depth; two applied as hardenings before push):
- **Fail-open confirmed**: `42P01` is reachable only after a successful connect+auth, so connection/auth errors never false-NotReady. Backed empirically by this repo's own history (the PgBouncer "database does not exist" case logs `SQLSTATE[08006]`, not `42P01`). The strict `=== '42P01'` (string SQLSTATE) is the correct comparison.
- **No password leak**: password is a separate PDO arg (not in the DSN), read via `getenv` from the Secret (never in rendered YAML); kubelet surfaces probe output only on non-zero exit, and the only non-zero path is `42P01` (`relation "session" does not exist` — no secret). **Hardened**: stderr now logs only `$e->getCode()` (the SQLSTATE), not `$e->getMessage()`.
- **No injection**: exec list (no shell); static SQL literal; DB coords used only as PDO connection params; PHP `$`-vars excluded from the envsubst allowlist.
- **Comment hardened** to accurately state that a sustained hang depools after ~60s (by design).
- Sustained-hang depool (~60s) and per-probe PgBouncer connection (20s-spaced, transient) noted as acceptable.

Companion to #480 (removes the bringup drop). Recommend merging #480 first (root cause), then this (defense-in-depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)