### PR TITLE
chore(ci): finish #463 host-copy removal + correct DEV_VAULT_ACCESS.md

### DIFF
--- a/DEV_VAULT_ACCESS.md
+++ b/DEV_VAULT_ACCESS.md
@@ -62,13 +62,19 @@ Run once, from an operator machine with LastPass + the repo checked out.
      && echo "OK: dev pw opens dev" || echo "FAIL: dev pw cannot open dev"
    ```
 
-4. **Let CI decrypt the re-keyed dev vault.** Add the dev password to the
-   **private, gitignored** `config/platform/ci/ansible-vars.yml`:
+4. **Let CI decrypt the re-keyed dev vault.** Add the dev password to
+   `config/platform/ci/ansible-vars.yml` in the **private config/platform
+   submodule**:
    ```yaml
    deploy_vault_password_dev: "<the dev password>"
    ```
-   > Never commit the real value. It belongs only in the gitignored
-   > `ansible-vars.yml`. Ansible writes it to
+   > **Heads-up on where this lives:** `ansible-vars.yml` is **tracked in the
+   > private, operator-only config/platform submodule** — it is *not* gitignored.
+   > It holds operator-level CI secrets, and the dev password is committed there
+   > alongside them, so anyone with config/platform access can read it. This is
+   > acceptable because config/platform is operator-restricted **and the shared
+   > prod/prod-eu vault password is _not_ in this file** (it is a Woodpecker
+   > secret) — so committing here never exposes prod. Ansible writes the value to
    > `/home/woodpecker/deploy-vaults/dev-vault-pass` (0600) with `no_log`.
 
 5. **Re-provision the CI host** to push the **dev password file**
@@ -97,6 +103,11 @@ Update the LastPass note, repeat steps 2–5. Re-share with the contributor.
 You need: the **dev vault password** (from the operator) and **write access to
 the `config/tenants` and `config/platform` submodules**. You do **not** need
 LastPass, the dev kubeconfig, terraform outputs, or tf-state credentials.
+
+> **Note:** config/platform access is not narrow — that submodule holds
+> operator-level CI secrets. Granting a contributor config/platform access
+> therefore exposes those too — it does **not** expose prod/prod-eu vault
+> secrets, but treat config/platform access as operator-level, not dev-only.
 
 You deploy via CI only — never directly.
 

--- a/ci/ansible/playbook.yml
+++ b/ci/ansible/playbook.yml
@@ -8,7 +8,6 @@
 #   ghcr_username, ghcr_pat
 #
 # Optional vars for CI deploy vaults:
-#   ci_deploy_vaults — list of local paths to encrypted vault files to provision
 #   deploy_vault_password_dev — dev-only ansible-vault password. When set, it is
 #       written to /home/woodpecker/deploy-vaults/dev-vault-pass (0600) so CI can
 #       decrypt the re-keyed dev vault. Keep this ONLY in the private (gitignored)
@@ -564,11 +563,11 @@
       args:
         creates: /home/woodpecker/.docker/buildx
 
-    # ── Deploy Vaults (encrypted secrets for CI deploy steps) ─────
-    # Vault files are Ansible Vault-encrypted tarballs containing
-    # kubeconfigs, tenant secrets, and terraform outputs per environment.
-    # They remain encrypted at rest on disk; CI scripts decrypt them
-    # into temp dirs at build time using DEPLOY_VAULT_PASSWORD.
+    # ── Deploy Vaults directory ──────────────────────────────────
+    # The encrypted deploy-vault blobs are NO LONGER pushed to the host: CI
+    # decrypts them from the committed copy inside the cloned config/platform
+    # submodule (ci_decrypt_committed_vault, GitHub issue #463). This directory
+    # now only holds the dev-only vault password (dev-vault-pass) written below.
     - name: Create deploy-vaults directory
       ansible.builtin.file:
         path: /home/woodpecker/deploy-vaults
@@ -577,15 +576,18 @@
         group: woodpecker
         mode: "0700"
 
-    - name: Deploy encrypted vault files
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: /home/woodpecker/deploy-vaults/
-        owner: woodpecker
-        group: woodpecker
-        mode: "0600"
-        decrypt: false
-      loop: "{{ ci_deploy_vaults | default([]) }}"
+    # Remove the vestigial host-copied vault blobs from the pre-#463 model.
+    # Nothing reads them anymore (CI uses the committed copy); this converges
+    # any host provisioned before the host-copy task was dropped. Targets only
+    # the .vault blobs — dev-vault-pass in the same dir must survive.
+    - name: Remove vestigial host-copied deploy-vault blobs
+      ansible.builtin.file:
+        path: "/home/woodpecker/deploy-vaults/deploy-vault-{{ item }}.vault"
+        state: absent
+      loop:
+        - dev
+        - prod
+        - prod-eu
 
     # ── Dev vault password (dev-only re-key) ──────────────────────
     # The dev vault is encrypted with its OWN password, separate from the


### PR DESCRIPTION
## Summary

Finishes the GitHub #463 committed-vault migration and corrects two inaccuracies in the public `DEV_VAULT_ACCESS.md`.

CI no longer reads deploy-vault blobs from the CI host — it decrypts them from the committed copy in the cloned `config/platform` submodule (`ci_decrypt_committed_vault`). The host-copy mechanism was left in place as dead weight; this removes it.

### Changes
- **`ci/ansible/playbook.yml`** — drop the `Deploy encrypted vault files` task and its `ci_deploy_vaults` var (no live consumer; verified no script reads `/home/woodpecker/deploy-vaults/*.vault`). Replace with a `state: absent` task that removes the stale `deploy-vault-{dev,prod,prod-eu}.vault` blobs from the host on next reprovision. The `deploy-vaults` dir and the `dev-vault-pass` write are preserved.
- **`config/platform`** (private submodule pointer) — matching removal of the orphaned `ci_deploy_vaults` var from `ci/ansible-vars.yml`.
- **`DEV_VAULT_ACCESS.md`** — correct two false claims:
  - `ansible-vars.yml` is **tracked in the private, operator-only config/platform submodule** — not "gitignored / never commit" as previously stated.
  - Add a Part B caveat: config/platform access is operator-level, not dev-only.

### Operational note
The host is not actually cleaned until `./ci/scripts/provision-ci.sh --ansible-only` runs (the `state: absent` task removes the stale blobs). Reprovision performed alongside this PR.

## OSS Compliance Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 1**

No compliance issues. The public doc uses only placeholders (`<the dev password>`); no real secrets, tenant domains, personal info, or private-registry refs in the changed public lines. The corrected doc does **not** enumerate which secrets live in the tracked file (says only "operator-level CI secrets" in the abstract) and contains no unremediated-weakness admission — the earlier itemized inventory was removed before commit. LOW: pre-existing generic `/home/woodpecker/...` service-account path (no action).

## Security Review
**CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 1**

Net-positive for security. Verified:
- **No fail-open** — `ci_decrypt_committed_vault` reads the vault solely from the cloned committed copy and treats a missing file as a hard error; both deploy entrypoints use it; no live consumer of host-side blobs remains.
- **`state: absent` correctly scoped** — `deploy-vault-{{ item }}.vault` over `{dev,prod,prod-eu}` can only match the three blob filenames; `dev-vault-pass` does not match and is re-written by an independent later task, so it survives.
- **No dangling `ci_deploy_vaults` refs** anywhere in the live tree.
- **Public doc** restates already-public architecture and discloses no secret value; corrects a previously wrong OPSEC instruction. LOW: informational only.
