### PR TITLE
fix(e2e): robust roundcube login (drop networkidle) + mail-delivery diagnostics

### DIFF
--- a/.woodpecker/e2e-shard-10.yaml
+++ b/.woodpecker/e2e-shard-10.yaml
@@ -72,6 +72,13 @@ steps:
         from_secret: e2e_pool1_tenant
       E2E_POOL2_TENANT:
         from_secret: e2e_pool2_tenant
+      # Declared so Woodpecker MASKS the echo-group address if it surfaces in the
+      # Stalwart mail round-trip grep (outbound to=<echo group>). The diagnostics
+      # script does not otherwise read these — they are here for log redaction.
+      E2E_POOL1_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_pool1_echo_group_address
+      E2E_POOL2_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_pool2_echo_group_address
       E2E_SHARD: "10/10"
     commands:
       - ci/scripts/ci-e2e-diagnostics.sh

--- a/.woodpecker/e2e-shard-5.yaml
+++ b/.woodpecker/e2e-shard-5.yaml
@@ -72,6 +72,13 @@ steps:
         from_secret: e2e_pool1_tenant
       E2E_POOL2_TENANT:
         from_secret: e2e_pool2_tenant
+      # Declared so Woodpecker MASKS the echo-group address if it surfaces in the
+      # Stalwart mail round-trip grep (outbound to=<echo group>). The diagnostics
+      # script does not otherwise read these — they are here for log redaction.
+      E2E_POOL1_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_pool1_echo_group_address
+      E2E_POOL2_ECHO_GROUP_ADDRESS:
+        from_secret: e2e_pool2_echo_group_address
       E2E_SHARD: "5/10"
     commands:
       - ci/scripts/ci-e2e-diagnostics.sh

--- a/ci/scripts/ci-e2e-diagnostics.sh
+++ b/ci/scripts/ci-e2e-diagnostics.sh
@@ -17,6 +17,18 @@
 # pod logs/state) AT THE MOMENT OF FAILURE, while the failing pods are still
 # live, so the NEXT failure NAMES the layer instead of needing CI archaeology.
 #
+# Shard 5 ALSO runs tests/email/email-roundtrip.spec.ts, whose failure is a
+# mail DELIVERY problem, not a login one (sender -> external echo group ->
+# receiver inbox). The login-shaped capture above is blind to it: a fixed
+# `--tail` of the Stalwart log can cover only a few seconds under IMAP-auth
+# churn (pipeline #1597: 300 lines = a 28s window that MISSED the echo-group
+# send and any inbound echo), the auth/oauth grep filters delivery lines out,
+# and Postfix (the inbound MX the echo returns through) was never captured at
+# all. So we ALSO capture, time-windowed (not line-capped): the Stalwart mail
+# round-trip/delivery lines and the infra-mail Postfix inbound-MX log — naming
+# WHICH leg of the round-trip broke (outbound reject vs. reflector latency vs.
+# inbound loss).
+#
 # CONTRACT
 # --------
 # - Runs ONLY as a `when: status: [failure]` step inside e2e-shard-5/10, so it
@@ -38,6 +50,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/ci-lib.sh"   # provides vcli()
 source "$REPO_ROOT/scripts/lib/common.sh"           # provides dump_pod_diagnostics, print_status
 
 LOG_TAIL="${MT_DIAG_LOG_TAIL:-300}"
+# Time window for components where line-capping loses the signal (Stalwart's
+# mail-delivery trace, Postfix). The whole e2e shard runs in well under this, so
+# a time window captures the round-trip's outbound send + inbound echo that a
+# fixed --tail (28s under IMAP-auth churn, #1597) drops on the floor.
+LOG_SINCE="${MT_DIAG_LOG_SINCE:-15m}"
 
 echo "=================================================================="
 echo "  E2E ROUNDCUBE-LOGIN FAILURE DIAGNOSTICS"
@@ -86,17 +103,26 @@ NS_WEBMAIL="tn-${E2E_TENANT}-webmail"
 NS_MAIL="tn-${E2E_TENANT}-mail"
 NS_AUTH="infra-auth"
 
-dump_component() {  # namespace selector friendly-name
-  local ns="$1" sel="$2" name="$3"
+dump_component() {  # namespace selector friendly-name [since]
+  # Pass a 4th arg (e.g. "$LOG_SINCE") to capture by time window instead of a
+  # fixed line tail — use it for components whose log churns past LOG_TAIL lines
+  # in seconds (Stalwart, Postfix), so the failure window isn't truncated away.
+  local ns="$1" sel="$2" name="$3" since="${4:-}"
   echo ""
   echo "------------------------------------------------------------------"
   echo "  ${name}   (ns=${ns}, selector=${sel})"
   echo "------------------------------------------------------------------"
   dump_pod_diagnostics "$ns" "$sel"
   echo ""
-  echo ">>> ${name} current logs (last ${LOG_TAIL} lines, all containers):"
-  kubectl logs -n "$ns" -l "$sel" --tail="$LOG_TAIL" --all-containers=true --timestamps 2>&1 \
-    | sed 's/^/    /'
+  if [[ -n "$since" ]]; then
+    echo ">>> ${name} current logs (since ${since}, all containers):"
+    kubectl logs -n "$ns" -l "$sel" --since="$since" --all-containers=true --timestamps 2>&1 \
+      | sed 's/^/    /'
+  else
+    echo ">>> ${name} current logs (last ${LOG_TAIL} lines, all containers):"
+    kubectl logs -n "$ns" -l "$sel" --tail="$LOG_TAIL" --all-containers=true --timestamps 2>&1 \
+      | sed 's/^/    /'
+  fi
   echo ""
   echo ">>> ${name} PREVIOUS logs (only if a container restarted):"
   kubectl logs -n "$ns" -l "$sel" --previous --tail="$LOG_TAIL" --all-containers=true 2>/dev/null \
@@ -167,13 +193,49 @@ else
 fi
 
 # Stalwart — the OAUTHBEARER token validator + IMAP backend. Token-decode /
-# unauthorized errors here mean the OIDC->IMAP auth leg failed.
-dump_component "$NS_MAIL" "app=stalwart" "STALWART"
+# unauthorized errors here mean the OIDC->IMAP auth leg failed. Capture the log
+# by TIME WINDOW (not a 300-line tail): under e2e IMAP-auth churn a fixed tail
+# covers only ~28s and drops the round-trip's send/echo lines (#1597).
+dump_component "$NS_MAIL" "app=stalwart" "STALWART" "$LOG_SINCE"
 echo ""
 echo ">>> STALWART auth/oauth/token highlights (grep over last 1000 lines):"
 kubectl logs -n "$NS_MAIL" -l app=stalwart --tail=1000 --all-containers=true 2>/dev/null \
   | grep -iE 'oauth|bearer|token|jwt|jwks|unauthor|decode|introspect|oidc|authenticat' \
   | tail -n 60 | sed 's/^/    /' || echo "    (no auth-related lines found)"
+
+# ── Mail round-trip / delivery (the email-roundtrip shard-5 failure) ──────────
+# email-roundtrip.spec.ts sends e2e-mailrt -> external echo group -> e2e-mailrcv
+# and fails if the echo never lands in the receiver's inbox within 120s. Surface
+# the whole round-trip from Stalwart's side over the same time window: the
+# OUTBOUND submission (from=e2e-mailrt, to=<echo group>) and its remote-delivery
+# RESULT (completed / dsn-perm-fail / bounce / null-mx), plus any INBOUND echo
+# back (rcpt-to / message-ingest to e2e-mailrcv). The to=<...> field names the
+# echo-group domain without needing its secret here. Delivery-result lines key
+# off queueId (not user), so they're matched broadly and bounded by tail.
+echo ""
+echo ">>> STALWART mail round-trip / delivery (grep over --since=${LOG_SINCE} window):"
+kubectl logs -n "$NS_MAIL" -l app=stalwart --since="$LOG_SINCE" --all-containers=true --timestamps 2>/dev/null \
+  | grep -iE 'e2e-mailr(t|cv)|queue-message|mail-from|rcpt-to|delivery\.(attempt|domain|completed|null-mx)|dsn-(perm-fail|temp-fail|success)|queue-dsn|bounce|reject|message-ingest' \
+  | tail -n 120 | sed 's/^/    /' || echo "    (no mail-delivery lines found in window)"
+
+# Postfix — the inbound MX the echo returns through (Internet -> NodeBalancer:25
+# -> infra-mail Postfix -> per-tenant Stalwart). infra-mail is SHARED across all
+# tenants, so deliberately do NOT dump its full log (that would surface other
+# tenants' envelope metadata into this log): capture pod health + a grep SCOPED
+# to the round-trip users only. The inbound echo is addressed to e2e-mailrcv, so
+# the user-scoped grep is both tighter and sufficient — no match => the echo
+# never re-entered the cluster MX (outbound-reject or reflector-side); present
+# here but absent from Stalwart => the loss is the Postfix->Stalwart hop.
+echo ""
+echo "------------------------------------------------------------------"
+echo "  POSTFIX (inbound MX)   (ns=infra-mail, selector=app=postfix)"
+echo "------------------------------------------------------------------"
+dump_pod_diagnostics "infra-mail" "app=postfix"
+echo ""
+echo ">>> POSTFIX round-trip lines (e2e-mailrt/e2e-mailrcv only, over --since=${LOG_SINCE}):"
+kubectl logs -n "infra-mail" -l app=postfix --since="$LOG_SINCE" --all-containers=true --timestamps 2>/dev/null \
+  | grep -iE 'e2e-mailr(t|cv)' \
+  | tail -n 80 | sed 's/^/    /' || echo "    (no postfix round-trip lines found in window)"
 
 # Keycloak — token issuance / redirect_uri / invalid_client errors. Helm-managed,
 # so match pods by name rather than a fixed label.
@@ -288,5 +350,12 @@ echo "     (shard-5 Echo Group, pipeline #1580). Read the oauth-flow errors + th
 echo "     keycloak code->token highlights for that user to name WHY."
 echo "   • browser-side [roundcube-stuck:*] lines in the e2e log show WHERE"
 echo "     the browser stopped (Keycloak vs webmail-no-inbox)."
+echo "   • email-roundtrip (shard-5) — read STALWART mail round-trip + POSTFIX:"
+echo "     OUTBOUND from=e2e-mailrt to=<echo group> then dsn-perm-fail/bounce/"
+echo "     reject -> outbound leg broke; queued+completed but NO inbound echo to"
+echo "     e2e-mailrcv (no rcpt-to / message-ingest, nothing in Postfix) -> the"
+echo "     external reflector didn't return in time (120s budget vs #419 cold"
+echo "     edge); echo present in POSTFIX but not Stalwart -> Postfix->Stalwart"
+echo "     hop. No outbound at all in-window -> send never left Roundcube."
 echo "=================================================================="
 exit 0

--- a/e2e/helpers/roundcube.ts
+++ b/e2e/helpers/roundcube.ts
@@ -1,0 +1,82 @@
+import type { Page } from '@playwright/test';
+import { urls } from './urls';
+import { keycloakLogin } from './auth';
+import { captureRoundcubeStuckState } from './roundcube-failure';
+
+/**
+ * Selectors that prove the Roundcube inbox has rendered (any one is enough).
+ * Shared so every caller waits on the same "logged-in" signal.
+ */
+export const ROUNDCUBE_INBOX =
+  '#messagelist, #mailboxlist, .mailbox-list, button:has-text("Compose")';
+
+/**
+ * Log into Roundcube via the OIDC flow and wait until the inbox has rendered.
+ *
+ * Deliberately does NOT use `page.waitForLoadState('networkidle')`. Roundcube
+ * keeps background network activity going (keep-alive ping / inbox refresh), so
+ * the network never goes idle for the 500ms `networkidle` requires — it times
+ * out intermittently EVEN WHEN the OIDC login already succeeded server-side.
+ * Observed on shard-5 pipeline #1597: roundcube logged `Successful login for
+ * e2e-mailrcv` (the receiver), zero `Failed login` anywhere, yet the test still
+ * failed on `networkidle`. Instead we race the inbox selector against the
+ * Keycloak login form and resolve as soon as either is present — the same
+ * robust pattern that keeps `roundcube-basic` green.
+ *
+ * `label` distinguishes call sites in the on-failure `[roundcube-stuck:*]` log
+ * (e.g. `roundtrip-sender` vs `roundtrip-receiver`).
+ *
+ * Best-effort failure capture: on timeout it records WHERE the browser got
+ * stuck (Keycloak vs. webmail-no-inbox) before re-throwing, so it never masks
+ * the real assertion.
+ */
+export async function roundcubeOidcLogin(
+  page: Page,
+  username: string,
+  password: string,
+  label = 'roundcube',
+): Promise<void> {
+  try {
+    // One retry for a transient mid-redirect hiccup.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await page.goto(`${urls.webmail}/?_task=login&_action=oauth`);
+
+      // Race: inbox (SSO already valid) vs. Keycloak login form (creds needed).
+      const kc = '#username:visible, #mt-password, #passkey-login-btn';
+      const result = await Promise.race([
+        page
+          .locator(ROUNDCUBE_INBOX)
+          .first()
+          .waitFor({ timeout: 45_000 })
+          .then(() => 'inbox' as const),
+        page
+          .locator(kc)
+          .first()
+          .waitFor({ timeout: 45_000, state: 'attached' })
+          .then(() => 'keycloak' as const),
+      ]).catch(() => 'timeout' as const);
+
+      if (result === 'inbox') {
+        return; // SSO completed — inbox is up.
+      }
+
+      if (result === 'keycloak') {
+        await keycloakLogin(page, username, password);
+        await page.waitForSelector(ROUNDCUBE_INBOX, { timeout: 30_000 });
+        return;
+      }
+
+      // Timeout: page may be stuck mid-redirect on Keycloak. Retry once.
+      if (attempt === 0) {
+        console.log('  [roundcube] OIDC redirect timed out, retrying...');
+        continue;
+      }
+
+      // Second attempt also timed out — final wait for the inbox to surface.
+      await page.waitForSelector(ROUNDCUBE_INBOX, { timeout: 15_000 });
+    }
+  } catch (err) {
+    await captureRoundcubeStuckState(page, label);
+    throw err;
+  }
+}

--- a/e2e/tests/email/dkim-signature-validation.spec.ts
+++ b/e2e/tests/email/dkim-signature-validation.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '../../fixtures/authenticated';
-import { urls } from '../../helpers/urls';
 import { TEST_USERS } from '../../helpers/test-users';
-import { keycloakLogin } from '../../helpers/auth';
+import { roundcubeOidcLogin } from '../../helpers/roundcube';
 import { isImapConfigured, waitForEmailBody, deleteEmailsBySubject } from '../../helpers/imap';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -23,19 +22,6 @@ const echoGroupAddress = process.env.E2E_ECHO_GROUP_ADDRESS || config.echoGroupA
  */
 const expectDkimSigned =
   process.env.E2E_EXPECT_DKIM_SIGNED === 'true' || config.expectDkimSigned === true;
-
-async function roundcubeLogin(page: import('@playwright/test').Page, username: string, password: string) {
-  await page.goto(`${urls.webmail}/?_task=login&_action=oauth`);
-  await page.waitForLoadState('networkidle');
-
-  const onKeycloak = new URL(page.url()).hostname.startsWith('auth.');
-  if (onKeycloak) {
-    await keycloakLogin(page, username, password);
-    await page.waitForLoadState('networkidle');
-  }
-
-  await page.waitForSelector('#messagelist, #mailboxlist, .mailbox-list', { timeout: 30_000 });
-}
 
 /**
  * Parse every DKIM-Signature header block in a raw MIME message.
@@ -106,7 +92,7 @@ test.describe('Email — DKIM Signature on Outbound Mail', () => {
     expect(senderDomain, 'sender email must include a domain').toBeTruthy();
 
     try {
-      await roundcubeLogin(senderPage, sender.username, sender.password);
+      await roundcubeOidcLogin(senderPage, sender.username, sender.password, 'dkim-sender');
 
       await senderPage.waitForFunction(
         () => window.rcmail && window.rcmail.task === 'mail' && !window.rcmail.busy,

--- a/e2e/tests/email/email-roundtrip.spec.ts
+++ b/e2e/tests/email/email-roundtrip.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '../../fixtures/authenticated';
-import { urls } from '../../helpers/urls';
 import { TEST_USERS } from '../../helpers/test-users';
-import { keycloakLogin } from '../../helpers/auth';
+import { roundcubeOidcLogin } from '../../helpers/roundcube';
 import { isImapConfigured, waitForEmailBody, deleteEmailsBySubject } from '../../helpers/imap';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -13,25 +12,6 @@ const config = fs.existsSync(configPath)
   : {};
 
 const echoGroupAddress = process.env.E2E_ECHO_GROUP_ADDRESS || config.echoGroupAddress;
-
-/**
- * Helper: log into Roundcube via OIDC for the given page/user.
- * Triggers the OIDC flow directly, handles Keycloak login if no SSO session.
- */
-async function roundcubeLogin(page: import('@playwright/test').Page, username: string, password: string) {
-  await page.goto(`${urls.webmail}/?_task=login&_action=oauth`);
-  await page.waitForLoadState('networkidle');
-
-  // Check hostname (not full URL) — the OIDC callback URL contains 'auth.' in
-  // query params (iss=https://auth.../realms/...) which would false-positive.
-  const onKeycloak = new URL(page.url()).hostname.startsWith('auth.');
-  if (onKeycloak) {
-    await keycloakLogin(page, username, password);
-    await page.waitForLoadState('networkidle');
-  }
-
-  await page.waitForSelector('#messagelist, #mailboxlist, .mailbox-list', { timeout: 30_000 });
-}
 
 test.describe('Email — Round-Trip via Echo Group', () => {
   // This test verifies the full email path: outbound (Roundcube → Stalwart → Postfix → internet)
@@ -55,7 +35,7 @@ test.describe('Email — Round-Trip via Echo Group', () => {
 
     try {
       // ── Step 1: Sender logs into Roundcube and sends email to the echo group ──
-      await roundcubeLogin(senderPage, sender.username, sender.password);
+      await roundcubeOidcLogin(senderPage, sender.username, sender.password, 'roundtrip-sender');
 
       // Wait for Roundcube JS app to finish initializing (rcmail.busy clears
       // after IMAP inbox load completes — large inboxes delay this)
@@ -86,7 +66,7 @@ test.describe('Email — Round-Trip via Echo Group', () => {
       await senderPage.waitForSelector('#messagelist, #mailboxlist, .mailbox-list', { timeout: 60_000 });
 
       // ── Step 2: Receiver logs into Roundcube and polls for the forwarded email ──
-      await roundcubeLogin(receiverPage, receiver.username, receiver.password);
+      await roundcubeOidcLogin(receiverPage, receiver.username, receiver.password, 'roundtrip-receiver');
 
       const maxWait = 120_000;
       const pollInterval = 5_000;

--- a/e2e/tests/email/roundcube-basic.spec.ts
+++ b/e2e/tests/email/roundcube-basic.spec.ts
@@ -1,79 +1,13 @@
 import { test, expect } from '../../fixtures/authenticated';
-import { urls } from '../../helpers/urls';
 import { TEST_USERS } from '../../helpers/test-users';
-import { keycloakLogin } from '../../helpers/auth';
-import { captureRoundcubeStuckState } from '../../helpers/roundcube-failure';
-
-const ROUNDCUBE_INBOX = '#messagelist, #mailboxlist, .mailbox-list, button:has-text("Compose")';
-
-/**
- * Navigate to Roundcube and wait for the inbox to load.
- *
- * Handles the OIDC redirect flow gracefully:
- * - If SSO session exists, Keycloak auto-redirects → inbox appears
- * - If credentials needed, completes Keycloak login first
- * - If page ends up mid-redirect on Keycloak, retries the OAuth URL
- */
-async function navigateToRoundcube(
-  page: import('@playwright/test').Page,
-  username: string,
-  password: string,
-) {
-  try {
-    await navigateToRoundcubeInner(page, username, password);
-  } catch (err) {
-    // On failure, record WHERE the OIDC login got stuck (browser-side); the
-    // server-side pod logs are dumped by ci/scripts/ci-e2e-diagnostics.sh.
-    await captureRoundcubeStuckState(page, 'roundcube-basic');
-    throw err;
-  }
-}
-
-async function navigateToRoundcubeInner(
-  page: import('@playwright/test').Page,
-  username: string,
-  password: string,
-) {
-  // Attempt the OIDC flow (with one retry for transient redirect issues)
-  for (let attempt = 0; attempt < 2; attempt++) {
-    await page.goto(`${urls.webmail}/?_task=login&_action=oauth`);
-
-    // Race: wait for either Roundcube inbox (SSO completed) or Keycloak
-    // login form (credentials needed).
-    const kc = '#username:visible, #mt-password, #passkey-login-btn';
-    const result = await Promise.race([
-      page.locator(ROUNDCUBE_INBOX).first().waitFor({ timeout: 45_000 }).then(() => 'inbox' as const),
-      page.locator(kc).first().waitFor({ timeout: 45_000, state: 'attached' }).then(() => 'keycloak' as const),
-    ]).catch(() => 'timeout' as const);
-
-    if (result === 'inbox') {
-      return; // SSO completed successfully
-    }
-
-    if (result === 'keycloak') {
-      await keycloakLogin(page, username, password);
-      await page.waitForSelector(ROUNDCUBE_INBOX, { timeout: 30_000 });
-      return;
-    }
-
-    // Timeout — page may be stuck mid-redirect on Keycloak or showing an error.
-    // On first attempt, retry the OAuth URL to give the redirect another chance.
-    if (attempt === 0) {
-      console.log('  [roundcube] OIDC redirect timed out, retrying...');
-      continue;
-    }
-
-    // Second attempt also timed out — try one final wait for inbox
-    await page.waitForSelector(ROUNDCUBE_INBOX, { timeout: 15_000 });
-  }
-}
+import { roundcubeOidcLogin, ROUNDCUBE_INBOX } from '../../helpers/roundcube';
 
 // Uses emailTestPage (fixed user with persistent Stalwart mail principal)
 // because pipeline-scoped users may not have Stalwart principals yet,
 // causing OAUTHBEARER auth to fail during the Roundcube OIDC flow.
 test.describe('Email — Roundcube Basic', () => {
   test('SSO login to Roundcube loads inbox', async ({ emailTestPage: page }) => {
-    await navigateToRoundcube(page, TEST_USERS.emailTest.username, TEST_USERS.emailTest.password);
+    await roundcubeOidcLogin(page, TEST_USERS.emailTest.username, TEST_USERS.emailTest.password, 'roundcube-basic');
 
     await expect(
       page.locator(ROUNDCUBE_INBOX).first(),
@@ -81,7 +15,7 @@ test.describe('Email — Roundcube Basic', () => {
   });
 
   test('keyboard shortcuts plugin is active', async ({ emailTestPage: page }) => {
-    await navigateToRoundcube(page, TEST_USERS.emailTest.username, TEST_USERS.emailTest.password);
+    await roundcubeOidcLogin(page, TEST_USERS.emailTest.username, TEST_USERS.emailTest.password, 'roundcube-basic');
 
     // The keyboard_shortcuts plugin injects a link with id "keyboard_shortcuts_link"
     await expect(page.locator('#keyboard_shortcuts_link')).toBeAttached({ timeout: 10_000 });
@@ -100,7 +34,7 @@ test.describe('Email — Roundcube Basic', () => {
   });
 
   test('calendar button links to Nextcloud Calendar', async ({ emailTestPage: page }) => {
-    await navigateToRoundcube(page, TEST_USERS.emailTest.username, TEST_USERS.emailTest.password);
+    await roundcubeOidcLogin(page, TEST_USERS.emailTest.username, TEST_USERS.emailTest.password, 'roundcube-basic');
 
     // The nextcloud_calendar plugin adds a calendar button to the sidebar
     const calendarBtn = page.locator('#taskmenu a.button-calendar');
@@ -116,7 +50,7 @@ test.describe('Email — Roundcube Basic', () => {
   });
 
   test('can open compose form', async ({ emailTestPage: page }) => {
-    await navigateToRoundcube(page, TEST_USERS.emailTest.username, TEST_USERS.emailTest.password);
+    await roundcubeOidcLogin(page, TEST_USERS.emailTest.username, TEST_USERS.emailTest.password, 'roundcube-basic');
 
     // Wait for Roundcube JS app to finish initializing before clicking.
     // The Compose button element appears in the DOM before rcmail.init() binds


### PR DESCRIPTION
## Why

Diagnosis of the chronic shard-5 `email-roundtrip` failure (pipeline #1597) showed the previously-"confirmed" root causes (Roundcube DB missing / missing principals) **do not apply** — the DB was healthy (18 tables + schema version), both `e2e-mailrt`/`e2e-mailrcv` principals authenticated, both logged into Roundcube with zero OIDC errors. The failure had **two independent modes**:

1. **Login flake** — the test's local `roundcubeLogin` used `page.waitForLoadState('networkidle')`, which times out on the receiver login **even when the OIDC login already succeeded server-side** (#1597: roundcube logged `Successful login for e2e-mailrcv`, zero `Failed login`, yet the test failed on networkidle). networkidle never settles against Roundcube's background polling.
2. **Delivery** — the echo round-trip never reached the receiver's inbox in 120s — but the diagnostics could not show **which leg** broke.

## What

**Fix 1 — robust Roundcube login (drop `networkidle`)**
- New `e2e/helpers/roundcube.ts` → `roundcubeOidcLogin()` races the inbox selector against the Keycloak form (the pattern that already keeps `roundcube-basic` green), with per-call-site `[roundcube-stuck:*]` labels.
- Migrated `email-roundtrip`, `dkim-signature-validation` (same latent flake), and `roundcube-basic` (the source — now deduplicated). `cross-app-sso` already used the robust approach.

**Fix 2 — diagnostics that can see a delivery failure** (`ci/scripts/ci-e2e-diagnostics.sh`)
- Stalwart capture switched from `--tail=300` (≈28s window under IMAP-auth churn, #1597) to time-windowed `--since`.
- Added a Stalwart **mail round-trip / delivery** grep (outbound send + remote-delivery result + inbound echo).
- Added a **Postfix inbound-MX** capture (`infra-mail`) — the leg the echo returns through — scoped to the round-trip users.
- "HOW TO READ" footer updated to name the broken leg (outbound reject vs reflector latency vs inbound loss).

This PR does **not** touch the 120s budget or the external echo — Fix 2 first makes that leg observable.

## Validation
- `shellcheck -S error -x ci/scripts/ci-e2e-diagnostics.sh` clean; `bash -n` clean; both shard YAMLs parse.
- `tsc --noEmit` on `e2e/`: identical 238 pre-existing env errors as `main` (missing `@types/node`/`rcmail` globals — not gated in CI); **zero** new module/export/arity errors from the refactor.
- No portal code changed → no version bump (confirmed by version-bump agent).

## OSS Compliance Review
**CRITICAL 0 · HIGH 0 · MEDIUM 0 · LOW 0 — clean.**
Verified the echo-group address is **not** hardcoded anywhere (committed `e2e/e2e.config.json` keeps `echoGroupAddress: ""`; real value injected via Woodpecker secret). Test usernames `e2e-mailrt`/`e2e-mailrcv` are non-secret CI accounts already in the tree. No real domains, personal info, credentials, private-registry refs, or `config/` submodule files.

## Security Review
**CRITICAL 0 · HIGH 0 · MEDIUM 1 · LOW 1 — both ADDRESSED in this PR.**

- **MEDIUM (addressed):** echo-group address (a Woodpecker secret) would print **unmasked** in the diagnostics step, because that step didn't declare the secret (Woodpecker masks only secrets a step references). → Declared `E2E_POOL{1,2}_ECHO_GROUP_ADDRESS` (`from_secret`) in the shard-5 and shard-10 `roundcube-diagnostics` steps so Woodpecker masks it in the delivery grep output.
- **LOW (addressed):** the Postfix capture targeted the **shared** `infra-mail` namespace; a full `--since` dump + generic `relay=|status=|to=<` grep would surface other tenants' envelope metadata. → Dropped the full shared-namespace log dump (kept pod health) and scoped the grep to `e2e-mailr(t|cv)` only.

Cleared as non-issues: command injection (only quoted `kubectl` args; `E2E_TENANT` still allowlist-gated before any SQL interpolation), no new credential handling, Postfix logs `sasl_username` but never passwords, DKIM keys live in SES (not in-cluster).