### PR TITLE
fix(ci): stop full vault rebuild from re-adding the dev kubeconfig

### DIFF
--- a/DEV_VAULT_ACCESS.md
+++ b/DEV_VAULT_ACCESS.md
@@ -102,7 +102,7 @@ Update the LastPass note, repeat steps 2–5. Re-share with the contributor.
 
 You need: the **dev vault password** (from the operator) and **write access to
 the `config/tenants` and `config/platform` submodules**. You do **not** need
-LastPass, the dev kubeconfig, terraform outputs, or tf-state credentials.
+LastPass, terraform outputs, or tf-state credentials.
 
 > **Note:** config/platform access is not narrow — that submodule holds
 > operator-level CI secrets. Granting a contributor config/platform access
@@ -164,8 +164,9 @@ You deploy via CI only — never directly.
    needed (GitHub issue #463).
 
 ### What the dev password actually grants
-The dev password decrypts the **entire** dev vault — the dev kubeconfig,
-terraform outputs, tf-state credentials, and **every** tenant's dev secrets —
-not just the tenant you edit. Patch mode also exposes all of that transiently
+The dev password decrypts the **entire** dev vault — terraform outputs,
+tf-state credentials, and **every** tenant's dev secrets — not just the tenant
+you edit. (The dev vault no longer ships a kubeconfig; CI fetches it live from
+the Linode LKE API.) Patch mode also exposes all of that transiently
 in a temp staging dir on your machine while it runs. It does **not** grant any
 access to prod or prod-eu.

--- a/scripts/build-deploy-vaults.sh
+++ b/scripts/build-deploy-vaults.sh
@@ -34,7 +34,8 @@ set -euo pipefail
 #
 # Prerequisites:
 #   - ansible-vault, tar installed
-#   - Full build: kubeconfig.<env>.yaml at repo root,
+#   - Full build: kubeconfig.<env>.yaml at repo root (prod / prod-eu only;
+#                 dev fetches its kubeconfig live from the Linode LKE API),
 #                 config/platform/infra/terraform-outputs.<env>.env,
 #                 config/tenants/<tenant>/<env>.secrets.yaml,
 #                 and a password source (LastPass login or MT_VAULT_PASSWORD*)
@@ -310,13 +311,22 @@ for env in "${ENVS[@]}"; do
 
   ERRORS=()
 
-  # 1. Kubeconfig
-  KUBECONFIG_SRC="$REPO_ROOT/kubeconfig.${env}.yaml"
-  if [[ -f "$KUBECONFIG_SRC" ]]; then
-    cp "$KUBECONFIG_SRC" "$STAGING/kubeconfig.yaml"
-    print_status "  Added kubeconfig.yaml"
+  # 1. Kubeconfig (prod / prod-eu only)
+  # Dev does NOT ship a kubeconfig in the vault: CI refetches it live from the
+  # Linode LKE API on every dev step (ci_fetch_dev_kubeconfig in ci-lib.sh), and
+  # the ephemeral on-demand dev cluster makes any baked-in copy stale within a
+  # reaper cycle. Staging one here would silently re-add it on the next full
+  # rebuild. Prod / prod-eu have stable clusters and still rely on the vault copy.
+  if [[ "$env" == "dev" ]]; then
+    print_status "  Skipping kubeconfig (dev fetches it live from the Linode LKE API)"
   else
-    ERRORS+=("Kubeconfig not found: $KUBECONFIG_SRC")
+    KUBECONFIG_SRC="$REPO_ROOT/kubeconfig.${env}.yaml"
+    if [[ -f "$KUBECONFIG_SRC" ]]; then
+      cp "$KUBECONFIG_SRC" "$STAGING/kubeconfig.yaml"
+      print_status "  Added kubeconfig.yaml"
+    else
+      ERRORS+=("Kubeconfig not found: $KUBECONFIG_SRC")
+    fi
   fi
 
   # 2. Terraform outputs


### PR DESCRIPTION
## Summary

Stops `scripts/build-deploy-vaults.sh` from re-adding the dev kubeconfig on a full vault rebuild — the durability half of the dev-kubeconfig removal.

The dev kubeconfig was removed from the committed dev deploy vault because CI refetches it **live from the Linode LKE API** on every dev step (`ci_fetch_dev_kubeconfig` in `ci/scripts/ci-lib.sh`). The ephemeral on-demand dev cluster makes any baked-in copy stale within a reaper cycle, so the vault copy was an unused, always-stale fallback. But `build-deploy-vaults.sh` still staged `kubeconfig.dev.yaml` on every full build, so the next operator full rebuild would have silently re-added it and undone the removal.

### Change
- **`scripts/build-deploy-vaults.sh`**: gate kubeconfig staging on `env != dev`. Prod / prod-eu have stable clusters and still ship (and require) their vault kubeconfig — their fail-fast behavior is unchanged.
- **`DEV_VAULT_ACCESS.md`**: correct two statements that described the dev vault as containing a kubeconfig.

### Safety
The dev consumer (`ci-deploy.sh` / `ci-deploy-app.sh`) fetches live and then **fails closed** (`ERROR: kubeconfig.yaml not found; exit 1`) if no kubeconfig is present — so a fetch failure aborts loudly rather than silently using a stale cluster config. `LINODE_CLI_TOKEN` is wired into every dev deploy step, so the live fetch is the steady-state path. This PR also exercises that path end-to-end: it branches off `main`, whose committed dev vault already has no kubeconfig.

Note: `build-deploy-vaults.sh` is operator-only and is **not** run in CI, so this script edit can't affect the pipeline directly — the dev deploy here validates the already-merged vault change.

## OSS Compliance Review

✅ **Clean** — CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 0

No hardcoded credentials, real tenant domains, PII, or private registry references. The change *strengthens* the config boundary: `kubeconfig.dev.yaml` (a gitignored secret artifact) is no longer staged into the vault.

## Security Review

✅ **Clean** — CRITICAL: 0 | HIGH: 0 | MEDIUM: 0 | LOW: 1

Net security improvement: dropping the dev kubeconfig reduces the blast radius of the shareable dev vault password by one cluster-admin credential. Removing the fallback is fail-closed (verified `exit 1` guard in `ci-deploy.sh`); prod/prod-eu untouched.

- **LOW (informational, pre-existing, outside this diff)**: `ci/scripts/ci-deploy.sh:127` still logs `"falling back to vault copy"` on a dev fetch failure, but dev no longer has a vault copy to fall back to. Behavior is correct (fails closed); wording tidy is optional and deferred.

## Version Bump

No-op — no portal code changed (admin-portal `0.9.25` / account-portal `0.11.36` unchanged and in sync with `image-versions.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)